### PR TITLE
Revised semantics of comparisons between a pointer and 0.

### DIFF
--- a/backend/Selectionproof.v
+++ b/backend/Selectionproof.v
@@ -135,7 +135,7 @@ Proof.
   inv H. econstructor; eauto.
 (* default *)
   econstructor. constructor. eauto. constructor. 
-  simpl. inv H0. auto. auto. 
+  simpl. inv H0. auto. 
 Qed.
 
 Lemma eval_load:

--- a/backend/ValueDomain.v
+++ b/backend/ValueDomain.v
@@ -2121,12 +2121,14 @@ Proof.
   assert (IP: forall i b ofs,
     cmatch (Val.cmpu_bool valid c (Vint i) (Vptr b ofs)) (cmp_different_blocks c)).
   {
-    intros. simpl. destruct (Int.eq i Int.zero). apply cmp_different_blocks_sound. apply cmp_different_blocks_none.
+    intros. simpl. destruct (Int.eq i Int.zero && (valid b (Int.unsigned ofs) || valid b (Int.unsigned ofs - 1))).
+    apply cmp_different_blocks_sound. apply cmp_different_blocks_none.
   }
   assert (PI: forall i b ofs,
     cmatch (Val.cmpu_bool valid c (Vptr b ofs) (Vint i)) (cmp_different_blocks c)).
   {
-    intros. simpl. destruct (Int.eq i Int.zero). apply cmp_different_blocks_sound. apply cmp_different_blocks_none.
+    intros. simpl. destruct (Int.eq i Int.zero && (valid b (Int.unsigned ofs) || valid b (Int.unsigned ofs - 1))).
+    apply cmp_different_blocks_sound. apply cmp_different_blocks_none.
   }
   unfold cmpu_bool; inversion H; subst; inversion H0; subst;
   auto using cmatch_top, cmp_different_blocks_none, pcmp_none,

--- a/cfrontend/Clight.v
+++ b/cfrontend/Clight.v
@@ -403,7 +403,7 @@ Inductive eval_expr: expr -> val -> Prop :=
       eval_expr (Eaddrof a ty) (Vptr loc ofs)
   | eval_Eunop:  forall op a ty v1 v,
       eval_expr a v1 ->
-      sem_unary_operation op v1 (typeof a) = Some v ->
+      sem_unary_operation op v1 (typeof a) m = Some v ->
       eval_expr (Eunop op a ty) v
   | eval_Ebinop: forall op a1 a2 ty v1 v2 v,
       eval_expr a1 v1 ->
@@ -620,7 +620,7 @@ Inductive step: state -> trace -> state -> Prop :=
 
   | step_ifthenelse:  forall f a s1 s2 k e le m v1 b,
       eval_expr e le m a v1 ->
-      bool_val v1 (typeof a) = Some b ->
+      bool_val v1 (typeof a) m = Some b ->
       step (State f (Sifthenelse a s1 s2) k e le m)
         E0 (State f (if b then s1 else s2) k e le m)
 

--- a/cfrontend/ClightBigstep.v
+++ b/cfrontend/ClightBigstep.v
@@ -115,7 +115,7 @@ Inductive exec_stmt: env -> temp_env -> mem -> statement -> trace -> temp_env ->
                 t1 le1 m1 out
   | exec_Sifthenelse: forall e le m a s1 s2 v1 b t le' m' out,
       eval_expr ge e le m a v1 ->
-      bool_val v1 (typeof a) = Some b ->
+      bool_val v1 (typeof a) m = Some b ->
       exec_stmt e le m (if b then s1 else s2) t le' m' out ->
       exec_stmt e le m (Sifthenelse a s1 s2)
                 t le' m' out
@@ -204,7 +204,7 @@ CoInductive execinf_stmt: env -> temp_env -> mem -> statement -> traceinf -> Pro
       execinf_stmt e le m (Ssequence s1 s2) (t1 *** t2)
   | execinf_Sifthenelse: forall e le m a s1 s2 v1 b t,
       eval_expr ge e le m a v1 ->
-      bool_val v1 (typeof a) = Some b ->
+      bool_val v1 (typeof a) m = Some b ->
       execinf_stmt e le m (if b then s1 else s2) t ->
       execinf_stmt e le m (Sifthenelse a s1 s2) t
   | execinf_Sloop_body1: forall e le m s1 s2 t,

--- a/cfrontend/Cop.v
+++ b/cfrontend/Cop.v
@@ -370,7 +370,7 @@ Definition classify_bool (ty: type) : classify_bool_cases :=
   considered as true.  The integer zero (which also represents
   the null pointer) and the float 0.0 are false. *)
 
-Definition bool_val (v: val) (t: type) : option bool :=
+Definition bool_val (v: val) (t: type) (m: mem) : option bool :=
   match classify_bool t with
   | bool_case_i =>
       match v with
@@ -390,6 +390,7 @@ Definition bool_val (v: val) (t: type) : option bool :=
   | bool_case_p =>
       match v with
       | Vint n => Some (negb (Int.eq n Int.zero))
+      | Vptr b ofs => if Mem.weak_valid_pointer m b (Int.unsigned ofs) then Some true else None
       | _ => None
       end
   | bool_case_l =>
@@ -404,7 +405,7 @@ Definition bool_val (v: val) (t: type) : option bool :=
 
 (** *** Boolean negation *)
 
-Definition sem_notbool (v: val) (ty: type) : option val :=
+Definition sem_notbool (v: val) (ty: type) (m: mem): option val :=
   match classify_bool ty with
   | bool_case_i =>
       match v with
@@ -424,6 +425,7 @@ Definition sem_notbool (v: val) (ty: type) : option val :=
   | bool_case_p =>
       match v with
       | Vint n => Some (Val.of_bool (Int.eq n Int.zero))
+      | Vptr b ofs => if Mem.weak_valid_pointer m b (Int.unsigned ofs) then Some Vfalse else None
       | _ => None
       end
   | bool_case_l =>
@@ -970,9 +972,9 @@ Definition sem_switch_arg (v: val) (ty: type): option Z :=
 (** * Combined semantics of unary and binary operators *)
 
 Definition sem_unary_operation
-            (op: unary_operation) (v: val) (ty: type): option val :=
+            (op: unary_operation) (v: val) (ty: type) (m: mem): option val :=
   match op with
-  | Onotbool => sem_notbool v ty
+  | Onotbool => sem_notbool v ty m
   | Onotint => sem_notint v ty
   | Oneg => sem_neg v ty
   | Oabsfloat => sem_absfloat v ty
@@ -1088,15 +1090,17 @@ Proof.
 - econstructor; eauto.
 Qed.
 
-Lemma sem_unary_operation_inject:
+Lemma sem_unary_operation_inj:
   forall op v1 ty v tv1,
-  sem_unary_operation op v1 ty = Some v ->
+  sem_unary_operation op v1 ty m = Some v ->
   val_inject f v1 tv1 ->
-  exists tv, sem_unary_operation op tv1 ty = Some tv /\ val_inject f v tv.
+  exists tv, sem_unary_operation op tv1 ty m' = Some tv /\ val_inject f v tv.
 Proof.
   unfold sem_unary_operation; intros. destruct op.
   (* notbool *)
   unfold sem_notbool in *; destruct (classify_bool ty); inv H0; inv H; TrivialInject.
+  destruct (Mem.weak_valid_pointer m b1 (Int.unsigned ofs1)) eqn:VP; inv H2.
+  erewrite weak_valid_pointer_inj by eauto. TrivialInject.  
   (* notint *)
   unfold sem_notint in *; destruct (classify_notint ty); inv H0; inv H; TrivialInject.
   (* neg *)
@@ -1262,17 +1266,30 @@ Proof.
 - eapply sem_cmp_inj; eauto.
 Qed.
 
-Lemma bool_val_inject:
+Lemma bool_val_inj:
   forall v ty b tv,
-  bool_val v ty = Some b ->
+  bool_val v ty m = Some b ->
   val_inject f v tv ->
-  bool_val tv ty = Some b.
+  bool_val tv ty m' = Some b.
 Proof.
   unfold bool_val; intros. 
-  destruct (classify_bool ty); inv H0; congruence.
+  destruct (classify_bool ty); inv H0; try congruence.
+  destruct (Mem.weak_valid_pointer m b1 (Int.unsigned ofs1)) eqn:VP; inv H.
+  erewrite weak_valid_pointer_inj by eauto. auto.
 Qed.
 
 End GENERIC_INJECTION.
+
+Lemma sem_unary_operation_inject:
+  forall f m m' op v1 ty1 v tv1,
+  sem_unary_operation op v1 ty1 m = Some v ->
+  val_inject f v1 tv1 ->
+  Mem.inject f m m' ->
+  exists tv, sem_unary_operation op tv1 ty1 m' = Some tv /\ val_inject f v tv.
+Proof.
+  intros. eapply sem_unary_operation_inj; eauto. 
+  intros; eapply Mem.weak_valid_pointer_inject_val; eauto.
+Qed.
 
 Lemma sem_binary_operation_inject:
   forall f m m' cenv op v1 ty1 v2 ty2 v tv1 tv2,
@@ -1288,6 +1305,17 @@ Proof.
   intros; eapply Mem.different_pointers_inject; eauto.
 Qed.
 
+Lemma bool_val_inject:
+  forall f m m' v ty b tv,
+  bool_val v ty m = Some b ->
+  val_inject f v tv ->
+  Mem.inject f m m' ->
+  bool_val tv ty m' = Some b.
+Proof.
+  intros. eapply bool_val_inj; eauto.
+  intros; eapply Mem.weak_valid_pointer_inject_val; eauto.
+Qed.
+
 (** * Some properties of operator semantics *)
 
 (** This section collects some common-sense properties about the type
@@ -1298,9 +1326,12 @@ Qed.
 (** Relation between Boolean value and casting to [_Bool] type. *)
 
 Lemma cast_bool_bool_val:
-  forall v t,
-  sem_cast v t (Tint IBool Signed noattr) =
-  match bool_val v t with None => None | Some b => Some(Val.of_bool b) end.
+  forall v t m,
+  match sem_cast v t (Tint IBool Signed noattr), bool_val v t m with
+  | Some v', Some b => v' = Val.of_bool b
+  | Some v', None => False
+  | None, _ => True
+  end.
 Proof.
   intros.
   assert (A: classify_bool t =
@@ -1334,12 +1365,13 @@ Qed.
 (** Relation between Boolean value and Boolean negation. *)
 
 Lemma notbool_bool_val:
-  forall v t,
-  sem_notbool v t =
-  match bool_val v t with None => None | Some b => Some(Val.of_bool (negb b)) end.
+  forall v t m,
+  sem_notbool v t m =
+  match bool_val v t m with None => None | Some b => Some(Val.of_bool (negb b)) end.
 Proof.
   intros. unfold sem_notbool, bool_val. 
-  destruct (classify_bool t); auto; destruct v; auto; rewrite negb_involutive; auto.
+  destruct (classify_bool t); auto; destruct v; auto; rewrite ? negb_involutive; auto.
+  destruct (Mem.weak_valid_pointer m b (Int.unsigned i)); auto. 
 Qed.
 
 (** Relation with the arithmetic conversions of ISO C99, section 6.3.1 *)

--- a/cfrontend/Cop.v
+++ b/cfrontend/Cop.v
@@ -273,7 +273,6 @@ Definition sem_cast (v: val) (t1 t2: type) : option val :=
   | cast_case_p2bool =>
       match v with
       | Vint i => Some (Vint (cast_int_int IBool Signed i))
-      | Vptr _ _ => Some (Vint Int.one)
       | _ => None
       end
   | cast_case_l2l =>
@@ -391,7 +390,6 @@ Definition bool_val (v: val) (t: type) : option bool :=
   | bool_case_p =>
       match v with
       | Vint n => Some (negb (Int.eq n Int.zero))
-      | Vptr b ofs => Some true
       | _ => None
       end
   | bool_case_l =>
@@ -426,7 +424,6 @@ Definition sem_notbool (v: val) (ty: type) : option val :=
   | bool_case_p =>
       match v with
       | Vint n => Some (Val.of_bool (Int.eq n Int.zero))
-      | Vptr _ _ => Some Vfalse
       | _ => None
       end
   | bool_case_l =>

--- a/cfrontend/Csem.v
+++ b/cfrontend/Csem.v
@@ -241,7 +241,7 @@ Inductive rred: expr -> mem -> trace -> expr -> mem -> Prop :=
       rred (Eaddrof (Eloc b ofs ty1) ty) m
         E0 (Eval (Vptr b ofs) ty) m
   | red_unop: forall op v1 ty1 ty m v,
-      sem_unary_operation op v1 ty1 = Some v ->
+      sem_unary_operation op v1 ty1 m = Some v ->
       rred (Eunop op (Eval v1 ty1) ty) m
         E0 (Eval v ty) m
   | red_binop: forall op v1 ty1 v2 ty2 ty m v,
@@ -253,23 +253,23 @@ Inductive rred: expr -> mem -> trace -> expr -> mem -> Prop :=
       rred (Ecast (Eval v1 ty1) ty) m
         E0 (Eval v ty) m
   | red_seqand_true: forall v1 ty1 r2 ty m,
-      bool_val v1 ty1 = Some true ->
+      bool_val v1 ty1 m = Some true ->
       rred (Eseqand (Eval v1 ty1) r2 ty) m
         E0 (Eparen r2 type_bool ty) m
   | red_seqand_false: forall v1 ty1 r2 ty m,
-      bool_val v1 ty1 = Some false ->
+      bool_val v1 ty1 m = Some false ->
       rred (Eseqand (Eval v1 ty1) r2 ty) m
         E0 (Eval (Vint Int.zero) ty) m
   | red_seqor_true: forall v1 ty1 r2 ty m,
-      bool_val v1 ty1 = Some true ->
+      bool_val v1 ty1 m = Some true ->
       rred (Eseqor (Eval v1 ty1) r2 ty) m
         E0 (Eval (Vint Int.one) ty) m
   | red_seqor_false: forall v1 ty1 r2 ty m,
-      bool_val v1 ty1 = Some false ->
+      bool_val v1 ty1 m = Some false ->
       rred (Eseqor (Eval v1 ty1) r2 ty) m
         E0 (Eparen r2 type_bool ty) m
   | red_condition: forall v1 ty1 r1 r2 ty b m,
-      bool_val v1 ty1 = Some b ->
+      bool_val v1 ty1 m = Some b ->
       rred (Econdition (Eval v1 ty1) r1 r2 ty) m
         E0 (Eparen (if b then r1 else r2) ty ty) m
   | red_sizeof: forall ty1 ty m,
@@ -633,7 +633,7 @@ Inductive sstep: state -> trace -> state -> Prop :=
       sstep (State f (Sifthenelse a s1 s2) k e m)
          E0 (ExprState f a (Kifthenelse s1 s2 k) e m)
   | step_ifthenelse_2:  forall f v ty s1 s2 k e m b,
-      bool_val v ty = Some b ->
+      bool_val v ty m = Some b ->
       sstep (ExprState f (Eval v ty) (Kifthenelse s1 s2 k) e m)
          E0 (State f (if b then s1 else s2) k e m)
 
@@ -641,11 +641,11 @@ Inductive sstep: state -> trace -> state -> Prop :=
       sstep (State f (Swhile x s) k e m)
         E0 (ExprState f x (Kwhile1 x s k) e m)
   | step_while_false: forall f v ty x s k e m,
-      bool_val v ty = Some false ->
+      bool_val v ty m = Some false ->
       sstep (ExprState f (Eval v ty) (Kwhile1 x s k) e m)
         E0 (State f Sskip k e m)
   | step_while_true: forall f v ty x s k e m ,
-      bool_val v ty = Some true ->
+      bool_val v ty m = Some true ->
       sstep (ExprState f (Eval v ty) (Kwhile1 x s k) e m)
         E0 (State f s (Kwhile2 x s k) e m)
   | step_skip_or_continue_while: forall f s0 x s k e m,
@@ -664,11 +664,11 @@ Inductive sstep: state -> trace -> state -> Prop :=
       sstep (State f s0 (Kdowhile1 x s k) e m)
          E0 (ExprState f x (Kdowhile2 x s k) e m)
   | step_dowhile_false: forall f v ty x s k e m,
-      bool_val v ty = Some false ->
+      bool_val v ty m = Some false ->
       sstep (ExprState f (Eval v ty) (Kdowhile2 x s k) e m)
          E0 (State f Sskip k e m)
   | step_dowhile_true: forall f v ty x s k e m,
-      bool_val v ty = Some true ->
+      bool_val v ty m = Some true ->
       sstep (ExprState f (Eval v ty) (Kdowhile2 x s k) e m)
          E0 (State f (Sdowhile x s) k e m)
   | step_break_dowhile: forall f a s k e m,
@@ -683,11 +683,11 @@ Inductive sstep: state -> trace -> state -> Prop :=
       sstep (State f (Sfor Sskip a2 a3 s) k e m)
          E0 (ExprState f a2 (Kfor2 a2 a3 s k) e m)
   | step_for_false: forall f v ty a2 a3 s k e m,
-      bool_val v ty = Some false ->
+      bool_val v ty m = Some false ->
       sstep (ExprState f (Eval v ty) (Kfor2 a2 a3 s k) e m)
          E0 (State f Sskip k e m)
   | step_for_true: forall f v ty a2 a3 s k e m,
-      bool_val v ty = Some true ->
+      bool_val v ty m = Some true ->
       sstep (ExprState f (Eval v ty) (Kfor2 a2 a3 s k) e m)
          E0 (State f s (Kfor3 a2 a3 s k) e m)
   | step_skip_or_continue_for3: forall f x a2 a3 s k e m,

--- a/cfrontend/Cshmgenproof.v
+++ b/cfrontend/Cshmgenproof.v
@@ -333,7 +333,6 @@ Proof.
   econstructor; split. econstructor; eauto with cshm. simpl. eauto. 
   unfold Val.cmpu, Val.cmpu_bool. simpl.
   destruct (Int.eq i Int.zero); simpl; constructor.
-  exists Vtrue; split. econstructor; eauto with cshm. constructor.
 (* long *)
   econstructor; split. econstructor; eauto with cshm. simpl. unfold Val.cmpl. simpl. eauto. 
   destruct (Int64.eq i Int64.zero); simpl; constructor. 

--- a/cfrontend/Cshmgenproof.v
+++ b/cfrontend/Cshmgenproof.v
@@ -311,7 +311,7 @@ Qed.
 Lemma make_boolean_correct:
  forall e le m a v ty b,
   eval_expr ge e le m a v ->
-  bool_val v ty = Some b ->
+  bool_val v ty m = Some b ->
   exists vb,
     eval_expr ge e le m (make_boolean a ty) vb
     /\ Val.bool_of_val vb b.
@@ -333,6 +333,10 @@ Proof.
   econstructor; split. econstructor; eauto with cshm. simpl. eauto. 
   unfold Val.cmpu, Val.cmpu_bool. simpl.
   destruct (Int.eq i Int.zero); simpl; constructor.
+  econstructor; split. econstructor; eauto with cshm. simpl. eauto.
+  destruct (Mem.weak_valid_pointer m b0 (Int.unsigned i)) eqn:V; inv H2.
+  unfold Val.cmpu, Val.cmpu_bool. simpl.
+  unfold Mem.weak_valid_pointer in V; rewrite V. constructor. 
 (* long *)
   econstructor; split. econstructor; eauto with cshm. simpl. unfold Val.cmpl. simpl. eauto. 
   destruct (Int64.eq i Int64.zero); simpl; constructor. 
@@ -365,13 +369,16 @@ Qed.
 
 Lemma make_notbool_correct:
   forall a tya c va v e le m,
-  sem_notbool va tya = Some v ->
+  sem_notbool va tya m = Some v ->
   make_notbool a tya = OK c ->  
   eval_expr ge e le m a va ->
   eval_expr ge e le m c v.
 Proof.
   unfold sem_notbool, make_notbool; intros until m; intros SEM MAKE EV1;
   destruct (classify_bool tya); inv MAKE; destruct va; inv SEM; eauto with cshm.
+  destruct (Mem.weak_valid_pointer m b (Int.unsigned i)) eqn:V; inv H0.
+  econstructor; eauto with cshm. simpl. unfold Val.cmpu, Val.cmpu_bool.
+  unfold Mem.weak_valid_pointer in V; rewrite V. auto. 
 Qed.
 
 Lemma make_notint_correct:
@@ -632,7 +639,7 @@ Qed.
 Lemma transl_unop_correct:
   forall op a tya c va v e le m, 
   transl_unop op a tya = OK c ->
-  sem_unary_operation op va tya = Some v ->
+  sem_unary_operation op va tya m = Some v ->
   eval_expr ge e le m a va ->
   eval_expr ge e le m c v.
 Proof.

--- a/cfrontend/Ctyping.v
+++ b/cfrontend/Ctyping.v
@@ -1390,7 +1390,6 @@ Proof.
   destruct (Float.cmp Ceq f Float.zero); constructor; auto with ty.
   destruct (Float32.cmp Ceq f Float32.zero); constructor; auto with ty.
   destruct (Int.eq i Int.zero); constructor; auto with ty.
-  constructor; auto with ty.
   destruct (Int64.eq i Int64.zero); constructor; auto with ty.
 - (* notint *)
   unfold sem_notint in SEM; DestructCases; auto with ty.

--- a/cfrontend/Ctyping.v
+++ b/cfrontend/Ctyping.v
@@ -1376,9 +1376,9 @@ Proof.
 Qed.
 
 Lemma pres_sem_unop:
-  forall op ty1 ty v1 v,
+  forall op ty1 ty v1 m v,
   type_unop op ty1 = OK ty ->
-  sem_unary_operation op v1 ty1 = Some v ->
+  sem_unary_operation op v1 ty1 m = Some v ->
   wt_val v1 ty1 ->
   wt_val v ty.
 Proof.
@@ -1390,6 +1390,7 @@ Proof.
   destruct (Float.cmp Ceq f Float.zero); constructor; auto with ty.
   destruct (Float32.cmp Ceq f Float32.zero); constructor; auto with ty.
   destruct (Int.eq i Int.zero); constructor; auto with ty.
+  constructor. constructor.
   destruct (Int64.eq i Int64.zero); constructor; auto with ty.
 - (* notint *)
   unfold sem_notint in SEM; DestructCases; auto with ty.

--- a/cfrontend/Initializers.v
+++ b/cfrontend/Initializers.v
@@ -74,7 +74,7 @@ Fixpoint constval (ce: composite_env) (a: expr) : res val :=
       constval ce l
   | Eunop op r1 ty =>
       do v1 <- constval ce r1;
-      match sem_unary_operation op v1 (typeof r1) with
+      match sem_unary_operation op v1 (typeof r1) Mem.empty with
       | Some v => OK v
       | None => Error(msg "undefined unary operation")
       end
@@ -94,7 +94,7 @@ Fixpoint constval (ce: composite_env) (a: expr) : res val :=
   | Eseqand r1 r2 ty =>
       do v1 <- constval ce r1;
       do v2 <- constval ce r2;
-      match bool_val v1 (typeof r1) with
+      match bool_val v1 (typeof r1) Mem.empty with
       | Some true => do_cast v2 (typeof r2) type_bool
       | Some false => OK (Vint Int.zero)
       | None => Error(msg "undefined && operation")
@@ -102,7 +102,7 @@ Fixpoint constval (ce: composite_env) (a: expr) : res val :=
   | Eseqor r1 r2 ty =>
       do v1 <- constval ce r1;
       do v2 <- constval ce r2;
-      match bool_val v1 (typeof r1) with
+      match bool_val v1 (typeof r1) Mem.empty with
       | Some false => do_cast v2 (typeof r2) type_bool
       | Some true => OK (Vint Int.one)
       | None => Error(msg "undefined || operation")
@@ -111,7 +111,7 @@ Fixpoint constval (ce: composite_env) (a: expr) : res val :=
       do v1 <- constval ce r1;
       do v2 <- constval ce r2;
       do v3 <- constval ce r3;
-      match bool_val v1 (typeof r1) with
+      match bool_val v1 (typeof r1) Mem.empty with
       | Some true => do_cast v2 (typeof r2) ty
       | Some false => do_cast v3 (typeof r3) ty
       | None => Error(msg "condition is undefined")

--- a/cfrontend/SimplExpr.v
+++ b/cfrontend/SimplExpr.v
@@ -18,6 +18,7 @@ Require Import Errors.
 Require Import Integers.
 Require Import Floats.
 Require Import Values.
+Require Import Memory.
 Require Import AST.
 Require Import Ctypes.
 Require Import Cop.
@@ -129,7 +130,7 @@ Function eval_simpl_expr (a: expr) : option val :=
 Function makeif (a: expr) (s1 s2: statement) : statement :=
   match eval_simpl_expr a with
   | Some v =>
-      match bool_val v (typeof a) with
+      match bool_val v (typeof a) Mem.empty with
       | Some b => if b then s1 else s2
       | None   => Sifthenelse a s1 s2
       end

--- a/cfrontend/SimplLocalsproof.v
+++ b/cfrontend/SimplLocalsproof.v
@@ -267,11 +267,8 @@ Proof.
   constructor. simpl. destruct (Float32.cmp Ceq f Float32.zero); auto.
   constructor. simpl. destruct (Float.cmp Ceq f Float.zero); auto.
   constructor. simpl. destruct (Int.eq i Int.zero); auto.
-  constructor; auto.
   constructor. simpl. destruct (Int.eq i Int.zero); auto.
-  constructor; auto.
   constructor. simpl. destruct (Int.eq i Int.zero); auto.
-  constructor; auto.
 (* long *)
   destruct ty; try (destruct f); try discriminate.
   destruct v; inv H. constructor.

--- a/common/Values.v
+++ b/common/Values.v
@@ -111,15 +111,13 @@ Proof.
   simpl in *. InvBooleans. destruct H0. split; auto. eapply has_subtype; eauto.
 Qed.
 
-(** Truth values.  Pointers and non-zero integers are treated as [True].
+(** Truth values.  Non-zero integers are treated as [True].
   The integer 0 (also used to represent the null pointer) is [False].
-  [Vundef] and floats are neither true nor false. *)
+  Other values are neither true nor false. *)
 
 Inductive bool_of_val: val -> bool -> Prop :=
   | bool_of_val_int:
-      forall n, bool_of_val (Vint n) (negb (Int.eq n Int.zero))
-  | bool_of_val_ptr:
-      forall b ofs, bool_of_val (Vptr b ofs) true.
+      forall n, bool_of_val (Vint n) (negb (Int.eq n Int.zero)).
 
 (** Arithmetic operations *)
 
@@ -695,7 +693,9 @@ Definition cmpu_bool (c: comparison) (v1 v2: val): option bool :=
   | Vint n1, Vint n2 =>
       Some (Int.cmpu c n1 n2)
   | Vint n1, Vptr b2 ofs2 =>
-      if Int.eq n1 Int.zero then cmp_different_blocks c else None
+      if Int.eq n1 Int.zero && weak_valid_ptr b2 (Int.unsigned ofs2)
+      then cmp_different_blocks c
+      else None
   | Vptr b1 ofs1, Vptr b2 ofs2 =>
       if eq_block b1 b2 then
         if weak_valid_ptr b1 (Int.unsigned ofs1)
@@ -708,7 +708,9 @@ Definition cmpu_bool (c: comparison) (v1 v2: val): option bool :=
         then cmp_different_blocks c
         else None
   | Vptr b1 ofs1, Vint n2 =>
-      if Int.eq n2 Int.zero then cmp_different_blocks c else None
+      if Int.eq n2 Int.zero && weak_valid_ptr b1 (Int.unsigned ofs1)
+      then cmp_different_blocks c
+      else None
   | _, _ => None
   end.
 
@@ -1175,8 +1177,8 @@ Proof.
   destruct c; auto. 
   destruct x; destruct y; simpl; auto.
   rewrite Int.negate_cmpu. auto.
-  destruct (Int.eq i Int.zero); auto. 
-  destruct (Int.eq i0 Int.zero); auto.
+  destruct (Int.eq i Int.zero && (valid_ptr b (Int.unsigned i0) || valid_ptr b (Int.unsigned i0 - 1))); auto. 
+  destruct (Int.eq i0 Int.zero && (valid_ptr b (Int.unsigned i) || valid_ptr b (Int.unsigned i - 1))); auto.
   destruct (eq_block b b0).
   destruct ((valid_ptr b (Int.unsigned i) || valid_ptr b (Int.unsigned i - 1)) &&
             (valid_ptr b0 (Int.unsigned i0) || valid_ptr b0 (Int.unsigned i0 - 1))).
@@ -1222,8 +1224,8 @@ Proof.
     destruct c; auto.
   destruct x; destruct y; simpl; auto.
   rewrite Int.swap_cmpu. auto.
-  case (Int.eq i Int.zero); auto.
-  case (Int.eq i0 Int.zero); auto.
+  destruct (Int.eq i Int.zero && (valid_ptr b (Int.unsigned i0) || valid_ptr b (Int.unsigned i0 - 1))); auto.
+  destruct (Int.eq i0 Int.zero && (valid_ptr b (Int.unsigned i) || valid_ptr b (Int.unsigned i - 1))); auto.
   destruct (eq_block b b0); subst.
   rewrite dec_eq_true.
   destruct (valid_ptr b0 (Int.unsigned i) || valid_ptr b0 (Int.unsigned i - 1));
@@ -1423,19 +1425,23 @@ Lemma cmpu_bool_lessdef:
   cmpu_bool valid_ptr' c v1' v2' = Some b.
 Proof.
   intros. 
+  assert (A: forall b ofs, valid_ptr b ofs || valid_ptr b (ofs - 1) = true ->
+                           valid_ptr' b ofs || valid_ptr' b (ofs - 1) = true).
+  { intros until ofs. rewrite ! orb_true_iff. intuition. }
   destruct v1; simpl in H2; try discriminate;
   destruct v2; simpl in H2; try discriminate;
   inv H0; inv H1; simpl; auto.
+  destruct (Int.eq i Int.zero && (valid_ptr b0 (Int.unsigned i0) || valid_ptr b0 (Int.unsigned i0 - 1))) eqn:E; try discriminate.
+  InvBooleans. rewrite H0, A by auto. auto. 
+  destruct (Int.eq i0 Int.zero && (valid_ptr b0 (Int.unsigned i) || valid_ptr b0 (Int.unsigned i - 1))) eqn:E; try discriminate.
+  InvBooleans. rewrite H0, A by auto. auto. 
   destruct (eq_block b0 b1).
-  assert (forall b ofs, valid_ptr b ofs || valid_ptr b (ofs - 1) = true ->
-                        valid_ptr' b ofs || valid_ptr' b (ofs - 1) = true).
-    intros until ofs. rewrite ! orb_true_iff. intuition. 
   destruct (valid_ptr b0 (Int.unsigned i) || valid_ptr b0 (Int.unsigned i - 1)) eqn:?; try discriminate.
   destruct (valid_ptr b1 (Int.unsigned i0) || valid_ptr b1 (Int.unsigned i0 - 1)) eqn:?; try discriminate.
-  erewrite !H0 by eauto. auto.
+  erewrite ! A by eauto. auto.
   destruct (valid_ptr b0 (Int.unsigned i)) eqn:?; try discriminate.
   destruct (valid_ptr b1 (Int.unsigned i0)) eqn:?; try discriminate.
-  erewrite !H by eauto. auto.
+  erewrite ! H by eauto. auto.
 Qed.
 
 Lemma of_optbool_lessdef:
@@ -1599,7 +1605,17 @@ Lemma val_cmpu_bool_inject:
 Proof.
   Local Opaque Int.add.
   intros. inv H; simpl in H1; try discriminate; inv H0; simpl in H1; try discriminate; simpl; auto.
-  fold (weak_valid_ptr1 b1 (Int.unsigned ofs1)) in H1.
+- fold (weak_valid_ptr1 b1 (Int.unsigned ofs1)) in H1.
+  fold (weak_valid_ptr2 b2 (Int.unsigned (Int.add ofs1 (Int.repr delta)))).
+  destruct (Int.eq i Int.zero); auto.
+  destruct (weak_valid_ptr1 b1 (Int.unsigned ofs1)) eqn:E; try discriminate.
+  erewrite weak_valid_ptr_inj by eauto. auto. 
+- fold (weak_valid_ptr1 b1 (Int.unsigned ofs1)) in H1.
+  fold (weak_valid_ptr2 b2 (Int.unsigned (Int.add ofs1 (Int.repr delta)))).
+  destruct (Int.eq i Int.zero); auto.
+  destruct (weak_valid_ptr1 b1 (Int.unsigned ofs1)) eqn:E; try discriminate.
+  erewrite weak_valid_ptr_inj by eauto. auto. 
+- fold (weak_valid_ptr1 b1 (Int.unsigned ofs1)) in H1.
   fold (weak_valid_ptr1 b0 (Int.unsigned ofs0)) in H1.
   fold (weak_valid_ptr2 b2 (Int.unsigned (Int.add ofs1 (Int.repr delta)))).
   fold (weak_valid_ptr2 b3 (Int.unsigned (Int.add ofs0 (Int.repr delta0)))). 

--- a/ia32/Asmgenproof1.v
+++ b/ia32/Asmgenproof1.v
@@ -462,12 +462,14 @@ Proof.
   rewrite (int_ltu_not i i0). destruct (Int.ltu i i0); destruct (Int.eq i i0); reflexivity.
   destruct (Int.ltu i i0); reflexivity.
 (* int ptr *)
-  destruct (Int.eq i Int.zero) eqn:?; try discriminate.
+  destruct (Int.eq i Int.zero &&
+    (Mem.valid_pointer m b0 (Int.unsigned i0) || Mem.valid_pointer m b0 (Int.unsigned i0 - 1))) eqn:?; try discriminate.
   destruct c; simpl in *; inv H1.
   rewrite Heqb1; reflexivity. 
   rewrite Heqb1; reflexivity.
 (* ptr int *)
-  destruct (Int.eq i0 Int.zero) eqn:?; try discriminate.
+  destruct (Int.eq i0 Int.zero &&
+    (Mem.valid_pointer m b0 (Int.unsigned i) || Mem.valid_pointer m b0 (Int.unsigned i - 1))) eqn:?; try discriminate.
   destruct c; simpl in *; inv H1.
   rewrite Heqb1; reflexivity. 
   rewrite Heqb1; reflexivity.

--- a/ia32/Op.v
+++ b/ia32/Op.v
@@ -647,6 +647,7 @@ Definition is_trivial_op (op: operation) : bool :=
 Definition op_depends_on_memory (op: operation) : bool :=
   match op with
   | Ocmp (Ccompu _) => true
+  | Ocmp (Ccompuimm _ _) => true
   | _ => false
   end.
 
@@ -656,7 +657,7 @@ Lemma op_depends_on_memory_correct:
   eval_operation ge sp op args m1 = eval_operation ge sp op args m2.
 Proof.
   intros until m2. destruct op; simpl; try congruence.
-  destruct c; simpl; try congruence. reflexivity. 
+  destruct c; simpl; auto; congruence.
 Qed.
 
 (** Global variables mentioned in an operation or addressing mode *)


### PR DESCRIPTION
It used to be that a pointer value (Vptr) always compare unequal to the
null pointer (Vint Int.zero).  However, this may not be true in the
final machine code when pointer addition overflows and wraps around
to the bit pattern 0.  This patch checks the validity of the pointer
being compared with 0, and makes the comparison undefined if the
pointer is out of bounds.

Note: only the IA32 back-end was updated, ARM and PowerPC need updating.