### PR TITLE
Extended annotations

### DIFF
--- a/arm/Asmgen.v
+++ b/arm/Asmgen.v
@@ -695,14 +695,6 @@ Definition transl_store (chunk: memory_chunk) (addr: addressing)
       Error (msg "Asmgen.transl_store")
   end.
 
-(** Translation of arguments to annotations *)
-
-Definition transl_annot_param (p: Mach.annot_param) : Asm.annot_param :=
-  match p with
-  | Mach.APreg r => APreg (preg_of r)
-  | Mach.APstack chunk ofs => APstack chunk ofs
-  end.
-
 (** Translation of a Mach instruction. *)
 
 Definition transl_instr (f: Mach.function) (i: Mach.instruction)
@@ -737,7 +729,7 @@ Definition transl_instr (f: Mach.function) (i: Mach.instruction)
   | Mbuiltin ef args res =>
       OK (Pbuiltin ef (map preg_of args) (map preg_of res) :: k)
   | Mannot ef args =>
-      OK (Pannot ef (map transl_annot_param args) :: k)
+      OK (Pannot ef (List.map (map_annot_arg preg_of) args) :: k)
   | Mlabel lbl =>
       OK (Plabel lbl :: k)
   | Mgoto lbl =>

--- a/arm/Asmgenproof.v
+++ b/arm/Asmgenproof.v
@@ -771,13 +771,16 @@ Opaque loadind.
   inv AT. monadInv H4. 
   exploit functions_transl; eauto. intro FN.
   generalize (transf_function_no_overflow _ _ H3); intro NOOV.
-  exploit annot_arguments_match; eauto. intros [vargs' [P Q]]. 
-  exploit external_call_mem_extends'; eauto.
+  exploit annot_args_match; eauto. intros [vargs' [P Q]]. 
+  exploit external_call_mem_extends; eauto.
   intros [vres' [m2' [A [B [C D]]]]].
   left. econstructor; split. apply plus_one. 
   eapply exec_step_annot. eauto. eauto.
   eapply find_instr_tail; eauto. eauto.
-  eapply external_call_symbols_preserved'; eauto.
+  erewrite <- sp_val by eauto. 
+  eapply eval_annot_args_preserved with (ge1 := ge); eauto.
+  exact symbols_preserved.
+  eapply external_call_symbols_preserved; eauto.
   exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
   eapply match_states_intro with (ep := false); eauto with coqlib.
   unfold nextinstr. rewrite Pregmap.gss. 

--- a/arm/SelectOp.vp
+++ b/arm/SelectOp.vp
@@ -489,3 +489,16 @@ Nondetfunction addressing (chunk: memory_chunk) (e: expr) :=
   | _ => (Aindexed Int.zero, e:::Enil)
   end.
 
+(** ** Arguments of annotations *)
+
+Nondetfunction annot_arg (e: expr) :=
+  match e with
+  | Eop (Ointconst n) Enil => AA_int n
+  | Eop (Oaddrsymbol id ofs) Enil => AA_addrglobal id ofs
+  | Eop (Oaddrstack ofs) Enil => AA_addrstack ofs
+  | Eop Omakelong (Eop (Ointconst h) Enil ::: Eop (Ointconst l) Enil ::: Enil) =>
+        AA_long (Int64.ofwords h l)
+  | Eop Omakelong (h ::: l ::: Enil) => AA_longofwords (AA_base h) (AA_base l)
+  | Eload chunk (Ainstack ofs) Enil => AA_loadstack chunk ofs
+  | _ => AA_base e
+  end.

--- a/arm/SelectOpproof.v
+++ b/arm/SelectOpproof.v
@@ -864,4 +864,19 @@ Proof.
   exists (v :: nil); split. eauto with evalexpr. subst. simpl. rewrite Int.add_zero; auto.
 Qed.
 
+Theorem eval_annot_arg:
+  forall a v,
+  eval_expr ge sp e m nil a v ->
+  CminorSel.eval_annot_arg ge sp e m (annot_arg a) v.
+Proof.
+  intros until v. unfold annot_arg; case (annot_arg_match a); intros; InvEval.
+- constructor.
+- constructor.
+- constructor. 
+- simpl in H5. inv H5. constructor.
+- subst v. constructor; auto.
+- inv H. InvEval. simpl in H6; inv H6. constructor; auto.
+- constructor; auto.
+Qed.
+
 End CMCONSTR.

--- a/backend/Bounds.v
+++ b/backend/Bounds.v
@@ -69,7 +69,7 @@ Definition instr_within_bounds (i: instruction) :=
   | Lbuiltin ef args res =>
       forall r, In r res \/ In r (destroyed_by_builtin ef) -> mreg_within_bounds r
   | Lannot ef args =>
-      forall sl ofs ty, In (S sl ofs ty) args -> slot_within_bounds sl ofs ty
+      forall sl ofs ty, In (S sl ofs ty) (params_of_annot_args args) -> slot_within_bounds sl ofs ty
   | _ => True
   end.
 
@@ -121,7 +121,7 @@ Definition slots_of_instr (i: instruction) : list (slot * Z * typ) :=
   match i with
   | Lgetstack sl ofs ty r => (sl, ofs, ty) :: nil
   | Lsetstack r sl ofs ty => (sl, ofs, ty) :: nil
-  | Lannot ef args => slots_of_locs args
+  | Lannot ef args => slots_of_locs (params_of_annot_args args)
   | _ => nil
   end.
 

--- a/backend/CMparser.mly
+++ b/backend/CMparser.mly
@@ -55,8 +55,7 @@ let mkef sg toks =
   | [EFT_tok "memcpy"; EFT_tok "size"; EFT_int sz; EFT_tok "align"; EFT_int al] ->
       EF_memcpy(Z.of_sint32 sz, Z.of_sint32 al)
   | [EFT_tok "annot"; EFT_string txt] ->
-      EF_annot(intern_string txt,
-               List.map (fun t -> AA_arg t) sg.sig_args)
+      EF_annot(intern_string txt, sg.sig_args)
   | [EFT_tok "annot_val"; EFT_string txt] ->
       if sg.sig_args = [] then raise Parsing.Parse_error;
       EF_annot_val(intern_string txt, List.hd sg.sig_args)

--- a/backend/CSE.v
+++ b/backend/CSE.v
@@ -492,6 +492,8 @@ Definition transfer (f: function) (approx: PMap.t VA.t) (pc: node) (before: numb
           | EF_vload _ | EF_vload_global _ _ _ | EF_annot _ _ | EF_annot_val _ _ =>
               set_unknown before res
           end
+      | Iannot ef args s =>
+          before
       | Icond cond args ifso ifnot =>
           before
       | Ijumptable arg tbl =>

--- a/backend/CSEproof.v
+++ b/backend/CSEproof.v
@@ -1144,6 +1144,21 @@ Proof.
   + apply CASE1.
 * apply set_reg_lessdef; auto.
 
+- (* Iannot *)
+  exploit (@eval_annot_args_lessdef _ ge (fun r => rs#r) (fun r => rs'#r)); eauto. 
+  intros (vargs' & A & B).
+  exploit external_call_mem_extends; eauto.
+  intros (v' & m1' & P & Q & R & S).
+  econstructor; split.
+  eapply exec_Iannot; eauto.
+  eapply eval_annot_args_preserved with (ge1 := ge); eauto. exact symbols_preserved.
+  eapply external_call_symbols_preserved; eauto.
+  exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
+  econstructor; eauto.
+  eapply analysis_correct_1; eauto. simpl; auto.
+  unfold transfer; rewrite H. replace m' with m; auto. 
+  destruct ef; try contradiction. inv H2; auto.
+
 - (* Icond *)
   destruct (valnum_regs approx!!pc args) as [n1 vl] eqn:?.
   elim SAT; intros valu1 NH1.

--- a/backend/CleanupLabelsproof.v
+++ b/backend/CleanupLabelsproof.v
@@ -296,7 +296,9 @@ Proof.
   econstructor; eauto with coqlib.
 (* Lannot *)
   left; econstructor; split.
-  econstructor; eauto. eapply external_call_symbols_preserved'; eauto.
+  econstructor; eauto. 
+  eapply eval_annot_args_preserved with (ge1 := ge); eauto. exact symbols_preserved.
+  eapply external_call_symbols_preserved; eauto.
   exact symbols_preserved.  exact public_preserved. exact varinfo_preserved.
   econstructor; eauto with coqlib.
 (* Llabel *)

--- a/backend/CminorSel.v
+++ b/backend/CminorSel.v
@@ -79,6 +79,7 @@ Inductive stmt : Type :=
   | Scall : option ident -> signature -> expr + ident -> exprlist -> stmt
   | Stailcall: signature -> expr + ident -> exprlist -> stmt
   | Sbuiltin : option ident -> external_function -> exprlist -> stmt
+  | Sannot : external_function -> list (annot_arg expr) -> stmt
   | Sseq: stmt -> stmt -> stmt
   | Sifthenelse: condexpr -> stmt -> stmt -> stmt
   | Sloop: stmt -> stmt
@@ -248,6 +249,32 @@ Inductive eval_expr_or_symbol: letenv -> expr + ident -> val -> Prop :=
       Genv.find_symbol ge id = Some b ->
       eval_expr_or_symbol le (inr _ id) (Vptr b Int.zero).
 
+Inductive eval_annot_arg: annot_arg expr -> val -> Prop :=
+  | eval_AA_base: forall a v,
+      eval_expr nil a v ->
+      eval_annot_arg (AA_base a) v
+  | eval_AA_int: forall n,
+      eval_annot_arg (AA_int n) (Vint n)
+  | eval_AA_long: forall n,
+      eval_annot_arg (AA_long n) (Vlong n)
+  | eval_AA_float: forall n,
+      eval_annot_arg (AA_float n) (Vfloat n)
+  | eval_AA_single: forall n,
+      eval_annot_arg (AA_single n) (Vsingle n)
+  | eval_AA_loadstack: forall chunk ofs v,
+      Mem.loadv chunk m (Val.add sp (Vint ofs)) = Some v ->
+      eval_annot_arg (AA_loadstack chunk ofs) v
+  | eval_AA_addrstack: forall ofs,
+      eval_annot_arg (AA_addrstack ofs) (Val.add sp (Vint ofs))
+  | eval_AA_loadglobal: forall chunk id ofs v,
+      Mem.loadv chunk m (Genv.symbol_address ge id ofs) = Some v ->
+      eval_annot_arg (AA_loadglobal chunk id ofs) v
+  | eval_AA_addrglobal: forall id ofs,
+      eval_annot_arg (AA_addrglobal id ofs) (Genv.symbol_address ge id ofs)
+  | eval_AA_longofwords: forall a1 a2 v1 v2,
+      eval_expr nil a1 v1 -> eval_expr nil a2 v2 ->
+      eval_annot_arg (AA_longofwords (AA_base a1) (AA_base a2)) (Val.longofwords v1 v2).
+
 End EVAL_EXPR.
 
 (** Pop continuation until a call or stop *)
@@ -342,6 +369,13 @@ Inductive step: state -> trace -> state -> Prop :=
       external_call ef ge vl m t v m' ->
       step (State f (Sbuiltin optid ef al) k sp e m)
          t (State f Sskip k sp (set_optvar optid v e) m')
+
+  | step_annot: forall f ef al k sp e m vl t v m',
+      match ef with EF_annot _ _ => True | _ => False end ->
+      list_forall2 (eval_annot_arg sp e m) al vl ->
+      external_call ef ge vl m t v m' ->
+      step (State f (Sannot ef al) k sp e m)
+         t (State f Sskip k sp e m')
 
   | step_seq: forall f s1 s2 k sp e m,
       step (State f (Sseq s1 s2) k sp e m)

--- a/backend/Deadcodeproof.v
+++ b/backend/Deadcodeproof.v
@@ -547,39 +547,77 @@ Proof.
   eapply magree_monotone; eauto. intros; apply B; auto.  
 Qed.
 
-(** Properties of volatile memory accesses *)
+(** Annotation arguments *)
 
-(*
-Lemma transf_volatile_load:
-
-  forall s f sp pc e m te r tm nm chunk t v m',
-
-  volatile_load_sem chunk ge (addr :: nil) m t v m' ->
-  Val.lessdef addr taddr ->
+Lemma transfer_annot_arg_sound:
+  forall bc e e' sp m m' a v,
+  eval_annot_arg ge (fun r => e#r) (Vptr sp Int.zero) m a v ->
+  forall ne1 nm1 ne2 nm2,
+  transfer_annot_arg (ne1, nm1) a = (ne2, nm2) ->
+  eagree e e' ne2 ->
+  magree m m' (nlive ge sp nm2) ->
   genv_match bc ge ->
   bc sp = BCstack ->
-  pmatch 
-
-  sound_state prog (State s f (Vptr sp Int.zero) pc e m) ->
-  Val.lessdef e#r te#r ->
-  magree m tm
-        (nlive ge sp
-           (nmem_add nm (aaddr (vanalyze rm f) # pc r) (size_chunk chunk))) ->
-  m' = m /\
-  exists tv, volatile_load_sem chunk ge (te#r :: nil) tm t tv tm /\ Val.lessdef v tv.
+  exists v',
+     eval_annot_arg ge (fun r => e'#r) (Vptr sp Int.zero) m' a  v'
+  /\ Val.lessdef v v'
+  /\ eagree e e' ne1
+  /\ magree m m' (nlive ge sp nm1).
 Proof.
-  intros. inv H2. split; auto. rewrite <- H3 in H0; inv H0. inv H4.
-- (* volatile *)
-  exists (Val.load_result chunk v0); split; auto. 
-  constructor. constructor; auto. 
-- (* not volatile *)
+  induction 1; simpl; intros until nm2; intros TR EA MA GM SPM; inv TR.
+- exists e'#x; intuition auto. constructor. eauto 2 with na. eauto 2 with na.
+- exists (Vint n); intuition auto. constructor.
+- exists (Vlong n); intuition auto. constructor.
+- exists (Vfloat n); intuition auto. constructor.
+- exists (Vsingle n); intuition auto. constructor.
+- simpl in H. exploit magree_load; eauto. 
+  intros. eapply nlive_add; eauto with va. rewrite Int.add_zero_l in H0; auto.
+  intros (v' & A & B).
+  exists v'; intuition auto. constructor; auto.
+  eapply magree_monotone; eauto. intros; eapply incl_nmem_add; eauto. 
+- exists (Vptr sp (Int.add Int.zero ofs)); intuition auto with na. constructor. 
+- unfold Senv.symbol_address in H; simpl in H. 
+  destruct (Genv.find_symbol ge id) as [b|] eqn:FS; simpl in H; try discriminate.
   exploit magree_load; eauto.
-  exploit aaddr_sound; eauto. intros (bc & P & Q & R).
-  intros. eapply nlive_add; eauto.
-  intros (v' & P & Q).
-  exists v'; split. constructor. econstructor; eauto. auto.
+  intros. eapply nlive_add; eauto. constructor. apply GM; auto. 
+  intros (v' & A & B).
+  exists v'; intuition auto.
+  constructor. simpl. unfold Senv.symbol_address; simpl; rewrite FS; auto. 
+  eapply magree_monotone; eauto. intros; eapply incl_nmem_add; eauto.
+- exists (Senv.symbol_address ge id ofs); intuition auto with na. constructor.
+- destruct (transfer_annot_arg (ne1, nm1) hi) as [ne' nm'] eqn:TR.
+  exploit IHeval_annot_arg2; eauto. intros (vlo' & A & B & C & D).
+  exploit IHeval_annot_arg1; eauto. intros (vhi' & P & Q & R & S).
+  exists (Val.longofwords vhi' vlo'); intuition auto.
+  constructor; auto.
+  apply Val.longofwords_lessdef; auto.
 Qed.
-*)
+
+Lemma transfer_annot_args_sound:
+  forall e sp m e' m' bc al vl,
+  eval_annot_args ge (fun r => e#r) (Vptr sp Int.zero) m al vl ->
+  forall ne1 nm1 ne2 nm2,
+  List.fold_left transfer_annot_arg al (ne1, nm1) = (ne2, nm2) ->
+  eagree e e' ne2 ->
+  magree m m' (nlive ge sp nm2) ->
+  genv_match bc ge ->
+  bc sp = BCstack ->
+  exists vl',
+     eval_annot_args ge (fun r => e'#r) (Vptr sp Int.zero) m' al vl'
+  /\ Val.lessdef_list vl vl'
+  /\ eagree e e' ne1
+  /\ magree m m' (nlive ge sp nm1).
+Proof.
+Local Opaque transfer_annot_arg.
+  induction 1; simpl; intros.
+- inv H. exists (@nil val); intuition auto. constructor.
+- destruct (transfer_annot_arg (ne1, nm1) a1) as [ne' nm'] eqn:TR.
+  exploit IHlist_forall2; eauto. intros (vs' & A1 & B1 & C1 & D1).
+  exploit transfer_annot_arg_sound; eauto. intros (v1' & A2 & B2 & C2 & D2). 
+  exists (v1' :: vs'); intuition auto. constructor; auto. 
+Qed.
+
+(** Properties of volatile memory accesses *)
 
 Lemma transf_volatile_store:
   forall v1 v2 v1' v2' m tm chunk sp nm t v m',
@@ -929,6 +967,21 @@ Ltac UseTransfer :=
   eapply match_succ_states; eauto. simpl; auto.
   apply eagree_update; eauto 3 with na.
   eapply mextends_agree; eauto. 
+
+- (* annot *)
+  TransfInstr; UseTransfer. 
+  destruct (fold_left transfer_annot_arg args (ne, nm)) as [ne1 nm1] eqn:TR; simpl in *.
+  inv SS. exploit transfer_annot_args_sound; eauto. intros (vargs' & A & B & C & D).
+  assert (EC: m' = m /\ external_call ef ge vargs' tm t Vundef tm).
+  { destruct ef; try contradiction. inv H2. split; auto. simpl. constructor. 
+    eapply eventval_list_match_lessdef; eauto. }
+  destruct EC as [EC1 EC2]; subst m'.
+  econstructor; split.
+  eapply exec_Iannot. eauto. auto. 
+  eapply eval_annot_args_preserved with (ge1 := ge); eauto. exact symbols_preserved.
+  eapply external_call_symbols_preserved with (ge1 := ge); eauto.
+  exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
+  eapply match_succ_states; eauto. simpl; auto.
 
 - (* conditional *)
   TransfInstr; UseTransfer.

--- a/backend/Inliningspec.v
+++ b/backend/Inliningspec.v
@@ -316,6 +316,9 @@ Inductive tr_instr: context -> node -> instruction -> code -> Prop :=
       Ple res ctx.(mreg) ->
       c!(spc ctx pc) = Some (Ibuiltin ef (sregs ctx args) (sreg ctx res) (spc ctx s)) ->
       tr_instr ctx pc (Ibuiltin ef args res s) c
+  | tr_annot: forall ctx pc c ef args s,
+      c!(spc ctx pc) = Some (Iannot ef (map (sannotarg ctx) args) (spc ctx s)) ->
+      tr_instr ctx pc (Iannot ef args s) c
   | tr_cond: forall ctx pc cond args s1 s2 c,
       c!(spc ctx pc) = Some (Icond cond (sregs ctx args) (spc ctx s1) (spc ctx s2)) ->
       tr_instr ctx pc (Icond cond args s1 s2) c

--- a/backend/LTL.v
+++ b/backend/LTL.v
@@ -45,7 +45,7 @@ Inductive instruction: Type :=
   | Lcall (sg: signature) (ros: mreg + ident)
   | Ltailcall (sg: signature) (ros: mreg + ident)
   | Lbuiltin (ef: external_function) (args: list mreg) (res: list mreg)
-  | Lannot (ef: external_function) (args: list loc)
+  | Lannot (ef: external_function) (args: list (annot_arg loc))
   | Lbranch (s: node)
   | Lcond (cond: condition) (args: list mreg) (s1 s2: node)
   | Ljumptable (arg: mreg) (tbl: list node)
@@ -244,8 +244,9 @@ Inductive step: state -> trace -> state -> Prop :=
       rs' = Locmap.setlist (map R res) vl (undef_regs (destroyed_by_builtin ef) rs) ->
       step (Block s f sp (Lbuiltin ef args res :: bb) rs m)
          t (Block s f sp bb rs' m')
-  | exec_Lannot: forall s f sp ef args bb rs m t vl m',
-      external_call' ef ge (map rs args) m t vl m' ->
+  | exec_Lannot: forall s f sp ef args bb rs vl m t v' m',
+      eval_annot_args ge rs sp m args vl ->
+      external_call ef ge vl m t v' m' ->
       step (Block s f sp (Lannot ef args :: bb) rs m)
          t (Block s f sp bb rs m')
   | exec_Lbranch: forall s f sp pc bb rs m,

--- a/backend/Linear.v
+++ b/backend/Linear.v
@@ -42,7 +42,7 @@ Inductive instruction: Type :=
   | Lcall: signature -> mreg + ident -> instruction
   | Ltailcall: signature -> mreg + ident -> instruction
   | Lbuiltin: external_function -> list mreg -> list mreg -> instruction
-  | Lannot: external_function -> list loc -> instruction
+  | Lannot: external_function -> list (annot_arg loc) -> instruction
   | Llabel: label -> instruction
   | Lgoto: label -> instruction
   | Lcond: condition -> list mreg -> label -> instruction
@@ -204,8 +204,9 @@ Inductive step: state -> trace -> state -> Prop :=
       step (State s f sp (Lbuiltin ef args res :: b) rs m)
          t (State s f sp b rs' m')
   | exec_Lannot:
-      forall s f sp rs m ef args b t v m',
-      external_call' ef ge (map rs args) m t v m' ->
+      forall s f sp rs m ef args vl b t v m',
+      eval_annot_args ge rs sp m args vl ->
+      external_call ef ge vl m t v m' ->
       step (State s f sp (Lannot ef args :: b) rs m)
          t (State s f sp b rs m')
   | exec_Llabel:

--- a/backend/Linearizeproof.v
+++ b/backend/Linearizeproof.v
@@ -651,7 +651,8 @@ Proof.
   (* Lannot *)
   left; econstructor; split. simpl.
   apply plus_one. eapply exec_Lannot; eauto.
-  eapply external_call_symbols_preserved'; eauto.
+  eapply eval_annot_args_preserved with (ge1 := ge); eauto. exact symbols_preserved.
+  eapply external_call_symbols_preserved; eauto.
   exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
   econstructor; eauto.
 

--- a/backend/Lineartyping.v
+++ b/backend/Lineartyping.v
@@ -76,7 +76,7 @@ Definition wt_instr (i: instruction) : bool :=
   | Lbuiltin ef args res =>
       subtype_list (proj_sig_res' (ef_sig ef)) (map mreg_type res) 
   | Lannot ef args =>
-      forallb loc_valid args
+      forallb loc_valid (params_of_annot_args args)
   | _ =>
       true
   end.
@@ -365,7 +365,7 @@ Qed.
 Lemma wt_state_annot:
   forall s f sp ef args c rs m,
   wt_state (State s f sp (Lannot ef args :: c) rs m) ->
-  forallb (loc_valid f) args = true.
+  forallb (loc_valid f) (params_of_annot_args args) = true.
 Proof.
   intros. inv H. simpl in WTC; InvBooleans. auto. 
 Qed.

--- a/backend/Liveness.v
+++ b/backend/Liveness.v
@@ -93,6 +93,8 @@ Definition transfer
           reg_list_live args (reg_sum_live ros Regset.empty)
       | Ibuiltin ef args res s =>
           reg_list_live args (reg_dead res after)
+      | Iannot ef args s =>
+          reg_list_live (params_of_annot_args args) after
       | Icond cond args ifso ifnot =>
           reg_list_live args after
       | Ijumptable arg tbl =>

--- a/backend/PrintAnnot.ml
+++ b/backend/PrintAnnot.ml
@@ -90,11 +90,34 @@ let print_file_line_d1 oc pref file line =
 
 let re_annot_param = Str.regexp "%%\\|%[1-9][0-9]*"
 
-type arg_value =
-  | Reg of preg
-  | Stack of memory_chunk * Int.int
-  | Intconst of Int.int
-  | Floatconst of float
+let rec print_annot print_preg sp_reg_name oc = function
+  | AA_base x -> print_preg oc x
+  | AA_int n -> fprintf oc "%ld" (camlint_of_coqint n)
+  | AA_long n -> fprintf oc "%Ld" (camlint64_of_coqint n)
+  | AA_float n -> fprintf oc "%.18g" (camlfloat_of_coqfloat n)
+  | AA_single n -> fprintf oc "%.18g" (camlfloat_of_coqfloat32 n)
+  | AA_loadstack(chunk, ofs) ->
+      fprintf oc "mem(%s + %ld, %ld)"
+         sp_reg_name
+         (camlint_of_coqint ofs)
+         (camlint_of_coqint (size_chunk chunk))
+  | AA_addrstack ofs ->
+      fprintf oc "(%s + %ld)"
+         sp_reg_name
+         (camlint_of_coqint ofs)
+  | AA_loadglobal(chunk, id, ofs) ->
+      fprintf oc "mem(\"%s\" + %ld, %ld)"
+         (extern_atom id)
+         (camlint_of_coqint ofs)
+         (camlint_of_coqint (size_chunk chunk))
+  | AA_addrglobal(id, ofs) ->
+      fprintf oc "(\"%s\" + %ld)"
+         (extern_atom id)
+         (camlint_of_coqint ofs)
+  | AA_longofwords(hi, lo) ->
+      fprintf oc "(%a * 0x100000000 + %a)"
+        (print_annot print_preg sp_reg_name) hi
+        (print_annot print_preg sp_reg_name) lo
 
 let print_annot_text print_preg sp_reg_name oc txt args =
   let print_fragment = function
@@ -105,42 +128,18 @@ let print_annot_text print_preg sp_reg_name oc txt args =
   | Str.Delim s ->
       let n = int_of_string (String.sub s 1 (String.length s - 1)) in
       try
-        match List.nth args (n-1) with
-        | Reg r ->
-            print_preg oc r
-        | Stack(chunk, ofs) ->
-            fprintf oc "mem(%s + %ld, %ld)"
-               sp_reg_name
-               (camlint_of_coqint ofs)
-               (camlint_of_coqint (size_chunk chunk))
-        | Intconst n ->
-            fprintf oc "%ld" (camlint_of_coqint n)
-        | Floatconst n ->
-            fprintf oc "%.18g" (camlfloat_of_coqfloat n)
+        print_annot print_preg sp_reg_name oc (List.nth args (n-1))
       with Failure _ ->
         fprintf oc "<bad parameter %s>" s in
   List.iter print_fragment (Str.full_split re_annot_param txt);
   fprintf oc "\n"
 
-let rec annot_args tmpl args =
-  match tmpl, args with
-  | [], _ -> []
-  | AA_arg _ :: tmpl', APreg r :: args' ->
-      Reg r :: annot_args tmpl' args'
-  | AA_arg _ :: tmpl', APstack(chunk, ofs) :: args' ->
-      Stack(chunk, ofs) :: annot_args tmpl' args'
-  | AA_arg _ :: tmpl', [] -> []         (* should never happen *)
-  | AA_int n :: tmpl', _ ->
-      Intconst n :: annot_args tmpl' args
-  | AA_float n :: tmpl', _ ->
-      Floatconst n :: annot_args tmpl' args
-
-let print_annot_stmt print_preg sp_reg_name oc txt tmpl args =
-  print_annot_text print_preg sp_reg_name oc txt (annot_args tmpl args)
+let print_annot_stmt print_preg sp_reg_name oc txt tys args =
+  print_annot_text print_preg sp_reg_name oc txt args
 
 let print_annot_val print_preg oc txt args =
   print_annot_text print_preg "<internal error>" oc txt
-    (List.map (fun r -> Reg r) args)
+    (List.map (fun r -> AA_base r) args)
 
 (* Print CompCert version and command-line as asm comment *)
 

--- a/backend/PrintLTL.ml
+++ b/backend/PrintLTL.ml
@@ -81,8 +81,8 @@ let print_instruction pp succ = function
       fprintf pp "%a = %s(%a)"
         mregs res (name_of_external ef) mregs args
   | Lannot(ef, args) ->
-      fprintf pp "%s(%a)"
-        (name_of_external ef) locs args
+      fprintf pp "%s(%a)\n"
+        (name_of_external ef) (print_annot_args loc) args
   | Lbranch s ->
       print_succ pp s succ
   | Lcond(cond, args, s1, s2) ->

--- a/backend/PrintMach.ml
+++ b/backend/PrintMach.ml
@@ -34,15 +34,6 @@ let rec regs pp = function
   | [r] -> reg pp r
   | r1::rl -> fprintf pp "%a, %a" reg r1 regs rl
 
-let annot_param pp = function
-  | APreg r -> reg pp r
-  | APstack(chunk, ofs) -> fprintf pp "stack(%s,%ld)" (name_of_chunk chunk) (camlint_of_coqint ofs)
-
-let rec annot_params pp = function
-  | [] -> ()
-  | [r] -> annot_param pp r
-  | r1::rl -> fprintf pp "%a, %a" annot_param r1 annot_params rl
-
 let ros pp = function
   | Coq_inl r -> reg pp r
   | Coq_inr s -> fprintf pp "\"%s\"" (extern_atom s)
@@ -78,7 +69,8 @@ let print_instruction pp i =
       fprintf pp "\t%a = %s(%a)\n"
         regs res (name_of_external ef) regs args
   | Mannot(ef, args) ->
-      fprintf pp "\t%s(%a)\n" (name_of_external ef) annot_params args
+      fprintf pp "\t%s(%a)\n"
+        (name_of_external ef) (print_annot_args reg) args
   | Mlabel lbl ->
       fprintf pp "%5d:" (P.to_int lbl)
   | Mgoto lbl ->

--- a/backend/PrintRTL.ml
+++ b/backend/PrintRTL.ml
@@ -74,6 +74,10 @@ let print_instruction pp (pc, i) =
       fprintf pp "%a = %s(%a)\n"
         reg res (name_of_external ef) regs args;
       print_succ pp s (pc - 1)
+  | Iannot(ef, args, s) ->
+      fprintf pp "%s(%a)\n"
+        (name_of_external ef) (print_annot_args reg) args;
+      print_succ pp s (pc - 1)
   | Icond(cond, args, s1, s2) ->
       fprintf pp "if (%a) goto %d else goto %d\n"
         (PrintOp.print_condition reg) (cond, args)

--- a/backend/RTLgenspec.v
+++ b/backend/RTLgenspec.v
@@ -807,49 +807,6 @@ Inductive tr_exitexpr (c: code):
       tr_exitexpr c (add_letvar map r) b n1 nexits ->
       tr_exitexpr c map (XElet a b) ns nexits.
 
-(** Translation of arguments to annotations.
-    [tr_annot_args c map pr al ns nd al'] holds if the graph [c],
-    starting at node [ns], contains instructions that evaluate the
-    expressions contained in the built-in argument list [al],
-    then terminate on node [nd].  When [nd] is reached, the registers
-    contained in [al'] hold the values of the corresponding expressions
-    in [al].  Registers in [pr] are not modified. *)
-
-Inductive tr_annot_arg (c: code):
-      mapping -> list reg -> annot_arg expr -> node -> node -> annot_arg reg -> Prop :=
-  | tr_AA_base: forall map pr a ns nd r,
-      tr_expr c map pr a ns nd r None ->
-      tr_annot_arg c map pr (AA_base a) ns nd (AA_base r)
-  | tr_AA_int: forall map pr i n,
-      tr_annot_arg c map pr (AA_int i) n n (AA_int i)
-  | tr_AA_long: forall map pr i n,
-      tr_annot_arg c map pr (AA_long i) n n (AA_long i)
-  | tr_AA_float: forall map pr i n,
-      tr_annot_arg c map pr (AA_float i) n n (AA_float i)
-  | tr_AA_single: forall map pr i n,
-      tr_annot_arg c map pr (AA_single i) n n (AA_single i)
-  | tr_AA_loadstack: forall map pr chunk ofs n,
-      tr_annot_arg c map pr (AA_loadstack chunk ofs) n n (AA_loadstack chunk ofs)
-  | tr_AA_addrstack: forall map pr ofs n,
-      tr_annot_arg c map pr (AA_addrstack ofs) n n (AA_addrstack ofs)
-  | tr_AA_loadglobal: forall map pr chunk id ofs n,
-      tr_annot_arg c map pr (AA_loadglobal chunk id ofs) n n (AA_loadglobal chunk id ofs)
-  | tr_AA_addrglobal: forall map pr id ofs n,
-      tr_annot_arg c map pr (AA_addrglobal id ofs) n n (AA_addrglobal id ofs)
-  | tr_AA_longofwords: forall map pr hi lo ns nd n1 hi' lo',
-      tr_annot_arg c map pr hi ns n1 hi' ->
-      tr_annot_arg c map (params_of_annot_arg hi' ++ pr) lo n1 nd lo' ->
-      tr_annot_arg c map pr (AA_longofwords hi lo) ns nd (AA_longofwords hi' lo').
-
-Inductive tr_annot_args (c: code):
-      mapping -> list reg -> list (annot_arg expr) -> node -> node -> list (annot_arg reg) -> Prop :=
-  | tr_AA_nil: forall map pr n,
-      tr_annot_args c map pr nil n n nil
-  | tr_AA_cons: forall map pr a ns n1 a' al nd al',
-      tr_annot_arg c map pr a ns n1 a' ->
-      tr_annot_args c map (params_of_annot_arg a' ++ pr) al n1 nd al' ->
-      tr_annot_args c map pr (a :: al) ns nd (a' :: al').
-
 (** [tr_stmt c map stmt ns ncont nexits nret rret] holds if the graph [c],
   starting at node [ns], contains instructions that perform the Cminor
   statement [stmt].   These instructions branch to node [ncont] if
@@ -897,9 +854,9 @@ Inductive tr_stmt (c: code) (map: mapping):
      c!n1 = Some (Ibuiltin ef rargs rd nd) ->
      reg_map_ok map rd optid ->
      tr_stmt c map (Sbuiltin optid ef al) ns nd nexits ngoto nret rret
-  | tr_Sannot: forall ef al ns nd nexits ngoto nret rret n1 al',
-     tr_annot_args c map nil al ns n1 al' ->
-     c!n1 = Some (Iannot ef al' nd) ->
+  | tr_Sannot: forall ef al ns nd nexits ngoto nret rret n1 rargs,
+     tr_exprlist c map nil (exprlist_of_expr_list (params_of_annot_args al)) ns n1 rargs ->
+     c!n1 = Some (Iannot ef (convert_annot_args al rargs) nd) ->
      tr_stmt c map (Sannot ef al) ns nd nexits ngoto nret rret
   | tr_Sseq: forall s1 s2 ns nd nexits ngoto nret rret n,
      tr_stmt c map s2 n nd nexits ngoto nret rret ->
@@ -1190,28 +1147,6 @@ Proof.
   induction 1; econstructor; eauto with rtlg.
 Qed.
 
-Lemma tr_annot_arg_incr:
-  forall s1 s2, state_incr s1 s2 ->
-  forall map pr a ns nd a',
-  tr_annot_arg s1.(st_code) map pr a ns nd a' ->
-  tr_annot_arg s2.(st_code) map pr a ns nd a'.
-Proof.
-  intros s1 s2 EXT.
-  generalize tr_expr_incr; intros I1.
-  induction 1; econstructor; eauto with rtlg.
-Qed.
-
-Lemma tr_annot_args_incr:
-  forall s1 s2, state_incr s1 s2 ->
-  forall map pr al ns nd al',
-  tr_annot_args s1.(st_code) map pr al ns nd al' ->
-  tr_annot_args s2.(st_code) map pr al ns nd al'.
-Proof.
-  intros s1 s2 EXT.
-  generalize tr_annot_arg_incr; intros I1.
-  induction 1; econstructor; eauto with rtlg.
-Qed.
-
 Lemma tr_stmt_incr:
   forall s1 s2, state_incr s1 s2 ->
   forall map s ns nd nexits ngoto nret rret,
@@ -1219,7 +1154,7 @@ Lemma tr_stmt_incr:
   tr_stmt s2.(st_code) map s ns nd nexits ngoto nret rret.
 Proof.
   intros s1 s2 EXT.
-  generalize tr_expr_incr tr_condition_incr tr_exprlist_incr tr_exitexpr_incr tr_annot_args_incr; intros I1 I2 I3 I4 I5.
+  generalize tr_expr_incr tr_condition_incr tr_exprlist_incr tr_exitexpr_incr; intros I1 I2 I3 I4.
   pose (AT := fun pc i => instr_at_incr s1 s2 pc i EXT).
   induction 1; econstructor; eauto.
 Qed.
@@ -1271,142 +1206,6 @@ Proof.
   eapply transl_expr_charact; eauto with rtlg.
   apply tr_exitexpr_incr with s1; auto. eapply IHa; eauto with rtlg.
   apply add_letvar_valid; eauto with rtlg.
-Qed.
-
-Lemma convert_annot_arg_valid:
-  forall map a s1 a' s2 i,
-  convert_annot_arg map a s1 = OK a' s2 i ->
-  map_valid map s1 ->
-  regs_valid (params_of_annot_arg a') s2.
-Proof.
-  induction a; simpl; intros; monadInv H; simpl; auto using regs_valid_nil.
-- apply regs_valid_cons. eauto with rtlg. apply regs_valid_nil.
-- apply regs_valid_app. eauto with rtlg. eapply IHa2; eauto with rtlg. 
-Qed.
-
-Lemma convert_annot_args_valid:
-  forall map l s1 l' s2 i,
-  convert_annot_args map l s1 = OK l' s2 i ->
-  map_valid map s1 ->
-  regs_valid (params_of_annot_args l') s2.
-Proof.
-  induction l; simpl; intros.
-- monadInv H. apply regs_valid_nil. 
-- monadInv H. simpl. apply regs_valid_app.
-  + apply regs_valid_incr with s; auto. eapply convert_annot_arg_valid; eauto.
-  + eapply IHl; eauto with rtlg.
-Qed.
-
-Inductive target_annot_arg_ok (map: mapping): list reg -> annot_arg expr -> annot_arg reg -> Prop :=
-  | taa_AA_base: forall pr a r,
-      target_reg_ok map pr a r ->
-      target_annot_arg_ok map pr (AA_base a) (AA_base r)
-  | taa_AA_int: forall pr i,
-      target_annot_arg_ok map pr (AA_int i) (AA_int i)
-  | taa_AA_long: forall pr i,
-      target_annot_arg_ok map pr (AA_long i) (AA_long i)
-  | taa_AA_float: forall pr i,
-      target_annot_arg_ok map pr (AA_float i) (AA_float i)
-  | taa_AA_single: forall pr i,
-      target_annot_arg_ok map pr (AA_single i) (AA_single i)
-  | taa_AA_loadstack: forall pr chunk ofs,
-      target_annot_arg_ok map pr (AA_loadstack chunk ofs) (AA_loadstack chunk ofs)
-  | taa_AA_addrstack: forall pr ofs,
-      target_annot_arg_ok map pr (AA_addrstack ofs) (AA_addrstack ofs)
-  | taa_AA_loadglobal: forall pr chunk id ofs,
-      target_annot_arg_ok map pr (AA_loadglobal chunk id ofs) (AA_loadglobal chunk id ofs)
-  | taa_AA_addrglobal: forall pr id ofs,
-      target_annot_arg_ok map pr (AA_addrglobal id ofs) (AA_addrglobal id ofs)
-  | taa_AA_longofwords: forall pr hi lo hi' lo',
-      target_annot_arg_ok map pr hi hi' ->
-      target_annot_arg_ok map (params_of_annot_arg hi' ++ pr) lo lo' ->
-      target_annot_arg_ok map pr (AA_longofwords hi lo) (AA_longofwords hi' lo').
-
-Lemma convert_annot_arg_ok:
-  forall map a pr s1 a' s2 i,
-  map_valid map s1 ->
-  regs_valid pr s1 ->
-  convert_annot_arg map a s1 = OK a' s2 i ->
-  target_annot_arg_ok map pr a a'.
-Proof.
-  induction a; simpl; intros until i; intros MAP PR CVT; monadInv CVT; try (now constructor).
-- constructor. eauto with rtlg.
-- constructor. 
-  eapply IHa1 with (s1 := s1); eauto. 
-  eapply IHa2 with (s1 := s); eauto with rtlg. 
-  apply regs_valid_app; eauto using convert_annot_arg_valid with rtlg.
-Qed.
-
-Inductive target_annot_args_ok (map: mapping): list reg -> list (annot_arg expr) -> list (annot_arg reg) -> Prop :=
-  | taa_AA_nil: forall pr,
-      target_annot_args_ok map pr nil nil
-  | taa_AA_cons: forall pr a a' l l',
-      target_annot_arg_ok map pr a a' ->
-      target_annot_args_ok map (params_of_annot_arg a' ++ pr) l l' ->
-      target_annot_args_ok map pr (a :: l) (a' :: l').
-
-Lemma convert_annot_args_ok:
-  forall map l pr s1 l' s2 i,
-  map_valid map s1 ->
-  regs_valid pr s1 ->
-  convert_annot_args map l s1 = OK l' s2 i ->
-  target_annot_args_ok map pr l l'.
-Proof.
-  induction l; simpl; intros until i; intros MAP PR CVT; monadInv CVT.
-- constructor.
-- constructor.
-  eapply convert_annot_arg_ok with (s1 := s1); eauto. 
-  eapply IHl with (s1 := s); eauto with rtlg.
-  apply regs_valid_app; eauto using convert_annot_arg_valid with rtlg.
-Qed.
-
-Lemma transl_annot_arg_charact:
-  forall map a a' nd s ns s' i pr
-     (TR: transl_annot_arg map a a' nd s = OK ns s' i) 
-     (WF: map_valid map s)
-     (OK: target_annot_arg_ok map pr a a')
-     (VALID: regs_valid pr s)
-     (VALID2: regs_valid (params_of_annot_arg a') s),
-  tr_annot_arg s'.(st_code) map pr a ns nd a'.
-Proof.
-  induction a; intros; inv OK; simpl in TR; try (monadInv TR); simpl in VALID2.
-- assert (reg_valid r s) by auto with coqlib.
-  constructor. eapply transl_expr_charact; eauto with rtlg. 
-- constructor.
-- constructor.
-- constructor.
-- constructor.
-- constructor.
-- constructor.
-- constructor.
-- constructor.
-- econstructor. 
-  eapply IHa1; eauto with rtlg.
-  red; intros. apply reg_valid_incr with s; auto using in_or_app.
-  apply tr_annot_arg_incr with s0; auto. 
-  eapply IHa2; eauto with rtlg.
-  apply regs_valid_app; auto. red; intros; auto using in_or_app.
-  red; intros; auto using in_or_app.
-Qed.
-
-Lemma transl_annot_args_charact:
-  forall map al al' nd s ns s' i pr
-     (TR: transl_annot_args map al al' nd s = OK ns s' i) 
-     (WF: map_valid map s)
-     (OK: target_annot_args_ok map pr al al')
-     (VALID: regs_valid pr s)
-     (VALID2: regs_valid (params_of_annot_args al') s),
-  tr_annot_args s'.(st_code) map pr al ns nd al'.
-Proof.
-  induction al as [|a al]; intros; inv OK; monadInv TR; simpl in VALID2.
-- constructor.
-- econstructor. 
-  eapply transl_annot_arg_charact; eauto with rtlg.
-  red; intros. apply reg_valid_incr with s; auto using in_or_app.
-  apply tr_annot_args_incr with s0; auto. 
-  eapply IHal; eauto with rtlg.
-  apply regs_valid_app; auto. red; intros; auto using in_or_app.
-  red; intros; auto using in_or_app.
 Qed.
 
 Lemma transl_stmt_charact:
@@ -1463,10 +1262,8 @@ Proof.
   eapply transl_exprlist_charact; eauto 3 with rtlg.
   eapply alloc_optreg_map_ok with (s1 := s0); eauto with rtlg.
   (* Sannot *)
-  econstructor; eauto 4 with rtlg. 
-  eapply transl_annot_args_charact; eauto 3 with rtlg.
-  eapply convert_annot_args_ok; eauto 3 with rtlg.
-  apply regs_valid_incr with s0; auto. eapply convert_annot_args_valid; eauto. 
+  econstructor; eauto 4 with rtlg.
+  eapply transl_exprlist_charact; eauto 3 with rtlg.
   (* Sseq *)
   econstructor. 
   apply tr_stmt_incr with s0; auto. 

--- a/backend/Regalloc.ml
+++ b/backend/Regalloc.ml
@@ -114,6 +114,22 @@ let xparmove srcs dsts k =
   | [src], [dst] -> move src dst k
   | _, _ -> Xparmove(srcs, dsts, new_temp Tint, new_temp Tfloat) :: k
 
+let convert_annot_arg tyenv = function
+  | AA_base r ->
+      begin match tyenv r with
+      | Tlong -> AA_longofwords(V(r, Tint), V(twin_reg r, Tint))
+      | ty    -> AA_base(V(r, ty))
+      end
+  | AA_int n -> AA_int n
+  | AA_long n -> AA_long n
+  | AA_float n -> AA_float n
+  | AA_single n -> AA_single n
+  | AA_loadstack(chunk, ofs) -> AA_loadstack(chunk, ofs)
+  | AA_addrstack(ofs) -> AA_addrstack(ofs)
+  | AA_loadglobal(chunk, id, ofs) -> AA_loadglobal(chunk, id, ofs)
+  | AA_addrglobal(id, ofs) -> AA_addrglobal(id, ofs)
+  | AA_longofwords(hi, lo) -> AA_longofwords(vreg tyenv hi, vreg tyenv lo)
+ 
 (* Return the XTL basic block corresponding to the given RTL instruction.
    Move and parallel move instructions are introduced to honor calling
    conventions and register constraints on some operations.
@@ -192,6 +208,8 @@ let block_of_RTL_instr funsig tyenv = function
       let args2 = constrain_regs args1 cargs and res2 = constrain_regs res1 cres in
       movelist args1 args2
          (Xbuiltin(ef, args2, res2) :: movelist res2 res1 [Xbranch s])
+  | RTL.Iannot(ef, args, s) ->
+      [Xannot(ef, List.map (convert_annot_arg tyenv) args); Xbranch s]
   | RTL.Icond(cond, args, s1, s2) ->
       [Xcond(cond, vregs tyenv args, s1, s2)]
   | RTL.Ijumptable(arg, tbl) ->
@@ -231,6 +249,11 @@ let vset_removelist vl after = List.fold_right VSet.remove vl after
 let vset_addlist vl after = List.fold_right VSet.add vl after
 let vset_addros vos after =
   match vos with Coq_inl v -> VSet.add v after | Coq_inr id -> after
+let vset_addannot a after =
+  match a with
+  | AA_base v -> VSet.add v after
+  | AA_longofwords(hi, lo) -> VSet.add hi (VSet.add lo after)
+  | _ -> after
 
 let live_before instr after =
   match instr with
@@ -256,6 +279,8 @@ let live_before instr after =
       vset_addlist args (vset_addros ros VSet.empty)
   | Xbuiltin(ef, args, res) ->
       vset_addlist args (vset_removelist res after)
+  | Xannot(ef, args) ->
+      List.fold_right vset_addannot args after
   | Xbranch s ->
       after
   | Xcond(cond, args, s1, s2) ->
@@ -431,16 +456,14 @@ let spill_costs f =
         | EF_vstore _ | EF_vstore_global _ | EF_memcpy _ ->
             (* result is not used but should not be spilled *)
             charge_list 10 1 args; charge_list max_int 0 res
-        | EF_annot _ ->
-            (* arguments are not actually used, so don't charge;
-               result is never used but should not be spilled *)
-            charge_list max_int 0 res
         | EF_annot_val _ ->
             (* like a move *)
             charge_list 1 1 args; charge_list 1 1 res
         | _ ->
             charge_list 10 1 args; charge_list 10 1 res
         end
+    | Xannot(ef, args) ->
+        ()
     | Xbranch _ -> ()
     | Xcond(cond, args, _, _) ->
         charge_list 10 1 args
@@ -556,6 +579,8 @@ let add_interfs_instr g instr live =
       | EF_annot_val _, [arg], [res] -> IRC.add_pref g arg res (* like a move *)
       | _ -> ()
       end
+  | Xannot(ef, args) ->
+      ()
   | Xbranch s ->
       ()
   | Xcond(cond, args, s1, s2) ->
@@ -631,10 +656,9 @@ let tospill_instr alloc instr ts =
   | Xtailcall(sg, vos, args) ->
       addros_tospill alloc vos ts
   | Xbuiltin(ef, args, res) ->
-      begin match ef with
-      | EF_annot _ -> ts
-      |      _     -> addlist_tospill alloc args (addlist_tospill alloc res ts)
-      end
+      addlist_tospill alloc args (addlist_tospill alloc res ts)
+  | Xannot(ef, args) ->
+      ts
   | Xbranch s ->
       ts
   | Xcond(cond, args, s1, s2) ->
@@ -794,14 +818,11 @@ let spill_instr tospill eqs instr =
   | Xtailcall(sg, Coq_inr id, args) ->
       ([instr], [])
   | Xbuiltin(ef, args, res) ->
-      begin match ef with
-      | EF_annot _ ->
-          ([instr], eqs)
-      | _ ->
-          let (args', c1, eqs1) = reload_vars tospill eqs args in
-          let (res', c2, eqs2) = save_vars tospill eqs1 res in
-          (c1 @ Xbuiltin(ef, args', res') :: c2, eqs2)
-      end
+      let (args', c1, eqs1) = reload_vars tospill eqs args in
+      let (res', c2, eqs2) = save_vars tospill eqs1 res in
+      (c1 @ Xbuiltin(ef, args', res') :: c2, eqs2)
+  | Xannot(ef, args) ->
+      ([instr], eqs)
   | Xbranch s ->
       ([instr], eqs)
   | Xcond(cond, args, s1, s2) ->
@@ -911,6 +932,18 @@ let make_parmove srcs dsts itmp ftmp k =
   done;
   List.rev_append !code k
 
+let transl_annot_arg alloc = function
+  | AA_base v -> AA_base (alloc v)
+  | AA_int n -> AA_int n
+  | AA_long n -> AA_long n
+  | AA_float n -> AA_float n
+  | AA_single n -> AA_single n
+  | AA_loadstack(chunk, ofs) -> AA_loadstack(chunk, ofs)
+  | AA_addrstack(ofs) -> AA_addrstack(ofs)
+  | AA_loadglobal(chunk, id, ofs) -> AA_loadglobal(chunk, id, ofs)
+  | AA_addrglobal(id, ofs) -> AA_addrglobal(id, ofs)
+  | AA_longofwords(hi, lo) -> AA_longofwords(alloc hi, alloc lo)
+
 let transl_instr alloc instr k =
   match instr with
   | Xmove(src, dst) | Xreload(src, dst) | Xspill(src, dst) ->
@@ -940,12 +973,9 @@ let transl_instr alloc instr k =
   | Xtailcall(sg, vos, args) ->
       LTL.Ltailcall(sg, mros_of alloc vos) :: []
   | Xbuiltin(ef, args, res) ->
-      begin match ef with
-      | EF_annot _ ->
-          LTL.Lannot(ef, List.map alloc args) :: k
-      | _ ->
-          LTL.Lbuiltin(ef, mregs_of alloc args, mregs_of alloc res) :: k
-      end
+      LTL.Lbuiltin(ef, mregs_of alloc args, mregs_of alloc res) :: k
+  | Xannot(ef, args) ->
+      LTL.Lannot(ef, List.map (transl_annot_arg alloc) args) :: k
   | Xbranch s ->
       LTL.Lbranch s :: []
   | Xcond(cond, args, s1, s2) ->

--- a/backend/Renumber.v
+++ b/backend/Renumber.v
@@ -48,6 +48,7 @@ Definition renum_instr (i: instruction) : instruction :=
   | Icall sg ros args res s => Icall sg ros args res (renum_pc s)
   | Itailcall sg ros args => i
   | Ibuiltin ef args res s => Ibuiltin ef args res (renum_pc s)
+  | Iannot ef args s => Iannot ef args (renum_pc s)
   | Icond cond args s1 s2 => Icond cond args (renum_pc s1) (renum_pc s2)
   | Ijumptable arg tbl => Ijumptable arg (List.map renum_pc tbl)
   | Ireturn or => i

--- a/backend/Renumberproof.v
+++ b/backend/Renumberproof.v
@@ -201,6 +201,13 @@ Proof.
     eapply external_call_symbols_preserved; eauto.
     exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
   constructor; auto. eapply reach_succ; eauto. simpl; auto.
+(* annot *)
+  econstructor; split.
+  eapply exec_Iannot; eauto.
+    eapply eval_annot_args_preserved with (ge1 := ge); eauto. exact symbols_preserved.
+    eapply external_call_symbols_preserved; eauto.
+    exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
+  constructor; auto. eapply reach_succ; eauto. simpl; auto.
 (* cond *)
   econstructor; split.
   eapply exec_Icond; eauto. 

--- a/backend/Selection.v
+++ b/backend/Selection.v
@@ -203,10 +203,21 @@ Definition classify_call (ge: Cminor.genv) (e: Cminor.expr) : call_kind :=
       end
   end.
 
+(** Annotations *)
+
 Definition builtin_is_annot (ef: external_function) (optid: option ident) : bool :=
   match ef, optid with
   | EF_annot _ _, None => true
   | _, _ => false
+  end.
+
+Function sel_annot_arg (e: Cminor.expr) : AST.annot_arg expr :=
+  match e with
+  | Cminor.Econst (Cminor.Oaddrsymbol id ofs) => AA_addrglobal id ofs
+  | Cminor.Econst (Cminor.Oaddrstack ofs) => AA_addrstack ofs
+  | Cminor.Eload chunk (Cminor.Econst (Cminor.Oaddrsymbol id ofs)) => AA_loadglobal chunk id ofs
+  | Cminor.Eload chunk (Cminor.Econst (Cminor.Oaddrstack ofs)) => AA_loadstack chunk ofs
+  | _ => annot_arg (sel_expr e)
   end.
 
 (** Conversion of Cminor [switch] statements to decision trees. *)
@@ -270,7 +281,7 @@ Fixpoint sel_stmt (ge: Cminor.genv) (s: Cminor.stmt) : res stmt :=
       end)
   | Cminor.Sbuiltin optid ef args =>
       OK (if builtin_is_annot ef optid
-          then Sannot ef (List.map (fun e => annot_arg (sel_expr e)) args)
+          then Sannot ef (List.map sel_annot_arg args)
           else Sbuiltin optid ef (sel_exprlist args))
   | Cminor.Stailcall sg fn args => 
       OK (match classify_call ge fn with

--- a/backend/Splitting.ml
+++ b/backend/Splitting.ml
@@ -163,6 +163,8 @@ let ren_instr f maps pc i =
       Itailcall(sg, ren_ros before ros, ren_regs before args)
   | Ibuiltin(ef, args, res, s) ->
       Ibuiltin(ef, ren_regs before args, ren_reg after res, s)
+  | Iannot(ef, args, s) ->
+      Iannot(ef, List.map (AST.map_annot_arg (ren_reg before)) args, s)
   | Icond(cond, args, s1, s2) ->
       Icond(cond, ren_regs before args, s1, s2)
   | Ijumptable(arg, tbl) ->

--- a/backend/Tailcallproof.v
+++ b/backend/Tailcallproof.v
@@ -513,6 +513,19 @@ Proof.
   exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
   econstructor; eauto. apply regset_set; auto.
 
+(* annot *)
+  TransfInstr.
+  exploit (@eval_annot_args_lessdef _ ge (fun r => rs#r) (fun r => rs'#r)); eauto.
+  intros (vargs' & P & Q).
+  exploit external_call_mem_extends; eauto.
+  intros [v' [m'1 [A [B [C D]]]]].
+  left. exists (State s' (transf_function f) (Vptr sp0 Int.zero) pc' rs' m'1); split.
+  eapply exec_Iannot; eauto.
+  eapply eval_annot_args_preserved with (ge1 := ge); eauto. exact symbols_preserved.
+  eapply external_call_symbols_preserved; eauto.
+  exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
+  econstructor; eauto.
+
 (* cond *)
   TransfInstr. 
   left. exists (State s' (transf_function f) (Vptr sp0 Int.zero) (if b then ifso else ifnot) rs' m'); split.

--- a/backend/Tunnelingproof.v
+++ b/backend/Tunnelingproof.v
@@ -344,8 +344,9 @@ Proof.
   econstructor; eauto.
   (* Lannot *)
   left; simpl; econstructor; split.
-  eapply exec_Lannot; eauto. 
-  eapply external_call_symbols_preserved'; eauto.
+  eapply exec_Lannot; eauto.
+  eapply eval_annot_args_preserved with (ge1 := ge); eauto. exact symbols_preserved.
+  eapply external_call_symbols_preserved; eauto.
   exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
   econstructor; eauto.
 

--- a/backend/Unusedglob.v
+++ b/backend/Unusedglob.v
@@ -60,6 +60,7 @@ Definition ref_instruction (i: instruction) : list ident :=
   | Itailcall _ (inl r) _ => nil
   | Itailcall _ (inr id) _ => id :: nil
   | Ibuiltin ef _ _ _ => globals_external ef
+  | Iannot _ args _ => globals_of_annot_args args
   | Icond cond _ _ _ => nil
   | Ijumptable _ _ => nil
   | Ireturn _ => nil

--- a/backend/XTL.ml
+++ b/backend/XTL.ml
@@ -125,10 +125,10 @@ let rec set_vars_type vl tyl =
 let unify_var_type v1 v2 =
   if typeof v1 <> typeof v2 then raise Type_error
 
-let type_annot_arg a ty =
+let rec type_annot_arg a ty =
   match a with
   | AA_base v -> set_var_type v ty
-  | AA_longofwords(v1, v2) -> set_var_type v1 Tint; set_var_type v2 Tint
+  | AA_longofwords(a1, a2) -> type_annot_arg a1 Tint; type_annot_arg a2 Tint
   | _ -> ()
 
 let type_instr = function

--- a/backend/XTL.ml
+++ b/backend/XTL.ml
@@ -35,6 +35,7 @@ type instruction =
   | Xcall of signature * (var, ident) sum * var list * var list
   | Xtailcall of signature * (var, ident) sum * var list
   | Xbuiltin of external_function * var list * var list
+  | Xannot of external_function * var annot_arg list
   | Xbranch of node
   | Xcond of condition * var list * node * node
   | Xjumptable of var * node list
@@ -124,6 +125,12 @@ let rec set_vars_type vl tyl =
 let unify_var_type v1 v2 =
   if typeof v1 <> typeof v2 then raise Type_error
 
+let type_annot_arg a ty =
+  match a with
+  | AA_base v -> set_var_type v ty
+  | AA_longofwords(v1, v2) -> set_var_type v1 Tint; set_var_type v2 Tint
+  | _ -> ()
+
 let type_instr = function
   | Xmove(src, dst) | Xspill(src, dst) | Xreload(src, dst) ->
       unify_var_type src dst
@@ -153,6 +160,11 @@ let type_instr = function
       let sg = ef_sig ef in
       set_vars_type args sg.sig_args;
       set_vars_type res (Events.proj_sig_res' sg)
+  | Xannot(ef, args) ->
+      let sg = ef_sig ef in
+      if List.length args = List.length sg.sig_args
+      then List.iter2 type_annot_arg args sg.sig_args
+      else raise Type_error
   | Xbranch s ->
       ()
   | Xcond(cond, args, s1, s2) ->

--- a/backend/XTL.mli
+++ b/backend/XTL.mli
@@ -36,6 +36,7 @@ type instruction =
   | Xcall of signature * (var, ident) sum * var list * var list
   | Xtailcall of signature * (var, ident) sum * var list
   | Xbuiltin of external_function * var list * var list
+  | Xannot of external_function * var annot_arg list
   | Xbranch of node
   | Xcond of condition * var list * node * node
   | Xjumptable of var * node list

--- a/cfrontend/C2C.ml
+++ b/cfrontend/C2C.ml
@@ -713,8 +713,7 @@ let rec convertExpr env e =
       | {edesc = C.EConst(CStr txt)} :: args1 ->
           let targs1 = convertTypArgs env [] args1 in
           Ebuiltin(
-            EF_annot(intern_string txt,
-                     List.map (fun t -> AA_arg t) (typlist_of_typelist targs1)),
+            EF_annot(intern_string txt, typlist_of_typelist targs1),
             targs1, convertExprList env args1, convertTyp env e.etyp)
       | _ ->
           error "ill-formed __builtin_annot (first argument must be string literal)";

--- a/cfrontend/Cexec.v
+++ b/cfrontend/Cexec.v
@@ -513,10 +513,10 @@ Definition do_ef_memcpy (sz al: Z)
   | _ => None
   end.
 
-Definition do_ef_annot (text: ident) (targs: list annot_arg)
+Definition do_ef_annot (text: ident) (targs: list typ)
        (w: world) (vargs: list val) (m: mem) : option (world * trace * val * mem) :=
-  do args <- list_eventval_of_val vargs (annot_args_typ targs);
-  Some(w, Event_annot text (annot_eventvals targs args) :: E0, Vundef, m).
+  do args <- list_eventval_of_val vargs targs;
+  Some(w, Event_annot text args :: E0, Vundef, m).
 
 Definition do_ef_annot_val (text: ident) (targ: typ)
        (w: world) (vargs: list val) (m: mem) : option (world * trace * val * mem) :=

--- a/common/Events.v
+++ b/common/Events.v
@@ -1915,37 +1915,3 @@ Qed.
 
 End EVAL_ANNOT_ARG_LESSDEF.
 
-(** Extensionality *)
-
-Section EVAL_ANNOT_ARG_EXTEN.
-
-Variable A: Type.
-Variable ge: Senv.t.
-Variables e1 e2: A -> val.
-Variable sp: val.
-Variable m: mem.
-
-Lemma eval_annot_arg_exten:
-  forall a v, eval_annot_arg ge e1 sp m a v ->
-  (forall x, In x (params_of_annot_arg a) -> e2 x = e1 x) ->
-  eval_annot_arg ge e2 sp m a v.
-Proof.
-  induction 1; simpl; intros EXT; try (now constructor).
-- rewrite <- EXT by auto. constructor.
-- constructor; eauto using in_or_app. 
-Qed.
-
-Lemma eval_annot_args_exten:
-  forall a v, eval_annot_args ge e1 sp m a v ->
-  (forall x, In x (params_of_annot_args a) -> e2 x = e1 x) ->
-  eval_annot_args ge e2 sp m a v.
-Proof.
-  induction 1; simpl; intros EXT; constructor.
-  eapply eval_annot_arg_exten; eauto using in_or_app.
-  eapply IHlist_forall2; eauto using in_or_app.
-Qed.
-
-End EVAL_ANNOT_ARG_EXTEN.
-
-
-

--- a/common/Events.v
+++ b/common/Events.v
@@ -1344,25 +1344,16 @@ Qed.
 
 (** ** Semantics of annotations. *)
 
-Fixpoint annot_eventvals (targs: list annot_arg) (vargs: list eventval) : list eventval :=
-  match targs, vargs with
-  | AA_arg ty :: targs', varg :: vargs' => varg :: annot_eventvals targs' vargs'
-  | AA_int n :: targs', _ => EVint n :: annot_eventvals targs' vargs
-  | AA_float n :: targs', _ => EVfloat n :: annot_eventvals targs' vargs
-  | _, _ => vargs
-  end.
-
-Inductive extcall_annot_sem (text: ident) (targs: list annot_arg) (ge: Senv.t):
+Inductive extcall_annot_sem (text: ident) (targs: list typ) (ge: Senv.t):
               list val -> mem -> trace -> val -> mem -> Prop :=
   | extcall_annot_sem_intro: forall vargs m args,
-      eventval_list_match ge args (annot_args_typ targs) vargs ->
-      extcall_annot_sem text targs ge vargs m
-           (Event_annot text (annot_eventvals targs args) :: E0) Vundef m.
+      eventval_list_match ge args targs vargs ->
+      extcall_annot_sem text targs ge vargs m (Event_annot text args :: E0) Vundef m.
 
 Lemma extcall_annot_ok:
   forall text targs,
   extcall_properties (extcall_annot_sem text targs)
-                     (mksignature (annot_args_typ targs) None cc_default)
+                     (mksignature targs None cc_default)
                      nil.
 Proof.
   intros; constructor; intros.
@@ -1794,9 +1785,167 @@ Proof.
   split; congruence.
 Qed.
 
+(** * Evaluation of annotation arguments *)
 
+Section EVAL_ANNOT_ARG.
 
+Variable A: Type.
+Variable ge: Senv.t.
+Variable e: A -> val.
+Variable sp: val.
+Variable m: mem.
 
+Inductive eval_annot_arg: annot_arg A -> val -> Prop :=
+  | eval_AA_base: forall x,
+      eval_annot_arg (AA_base x) (e x)
+  | eval_AA_int: forall n,
+      eval_annot_arg (AA_int n) (Vint n)
+  | eval_AA_long: forall n,
+      eval_annot_arg (AA_long n) (Vlong n)
+  | eval_AA_float: forall n,
+      eval_annot_arg (AA_float n) (Vfloat n)
+  | eval_AA_single: forall n,
+      eval_annot_arg (AA_single n) (Vsingle n)
+  | eval_AA_loadstack: forall chunk ofs v,
+      Mem.loadv chunk m (Val.add sp (Vint ofs)) = Some v ->
+      eval_annot_arg (AA_loadstack chunk ofs) v
+  | eval_AA_addrstack: forall ofs,
+      eval_annot_arg (AA_addrstack ofs) (Val.add sp (Vint ofs))
+  | eval_AA_loadglobal: forall chunk id ofs v,
+      Mem.loadv chunk m (Senv.symbol_address ge id ofs) = Some v ->
+      eval_annot_arg (AA_loadglobal chunk id ofs) v
+  | eval_AA_addrglobal: forall id ofs,
+      eval_annot_arg (AA_addrglobal id ofs) (Senv.symbol_address ge id ofs)
+  | eval_AA_longofwords: forall hi lo vhi vlo,
+      eval_annot_arg hi vhi -> eval_annot_arg lo vlo ->
+      eval_annot_arg (AA_longofwords hi lo) (Val.longofwords vhi vlo).
+
+Definition eval_annot_args (al: list (annot_arg A)) (vl: list val) : Prop :=
+  list_forall2 eval_annot_arg al vl.
+
+Lemma eval_annot_arg_determ:
+  forall a v, eval_annot_arg a v -> forall v', eval_annot_arg a v' -> v' = v.
+Proof.
+  induction 1; intros v' EV; inv EV; try congruence.
+  f_equal; eauto.
+Qed.
+
+Lemma eval_annot_args_determ:
+  forall al vl, eval_annot_args al vl -> forall vl', eval_annot_args al vl' -> vl' = vl.
+Proof.
+  induction 1; intros v' EV; inv EV; f_equal; eauto using eval_annot_arg_determ.
+Qed.
+
+End EVAL_ANNOT_ARG.
+
+Hint Constructors eval_annot_arg: aarg.
+
+(** Invariance by change of global environment. *)
+
+Section EVAL_ANNOT_ARG_PRESERVED.
+
+Variables A F1 V1 F2 V2: Type.
+Variable ge1: Genv.t F1 V1.
+Variable ge2: Genv.t F2 V2.
+Variable e: A -> val.
+Variable sp: val.
+Variable m: mem.
+
+Hypothesis symbols_preserved:
+  forall id, Genv.find_symbol ge2 id = Genv.find_symbol ge1 id.
+
+Lemma eval_annot_arg_preserved:
+  forall a v, eval_annot_arg ge1 e sp m a v -> eval_annot_arg ge2 e sp m a v.
+Proof.
+  assert (EQ: forall id ofs, Senv.symbol_address ge2 id ofs = Senv.symbol_address ge1 id ofs).
+  { unfold Senv.symbol_address; simpl; intros. rewrite symbols_preserved; auto. }
+  induction 1; eauto with aarg. rewrite <- EQ in H; eauto with aarg. rewrite <- EQ; eauto with aarg. 
+Qed. 
+
+Lemma eval_annot_args_preserved:
+  forall al vl, eval_annot_args ge1 e sp m al vl -> eval_annot_args ge2 e sp m al vl.
+Proof.
+  induction 1; constructor; auto; eapply eval_annot_arg_preserved; eauto. 
+Qed.
+
+End EVAL_ANNOT_ARG_PRESERVED.
+
+(** Compatibility with the "is less defined than" relation. *)
+
+Section EVAL_ANNOT_ARG_LESSDEF.
+
+Variable A: Type.
+Variable ge: Senv.t.
+Variables e1 e2: A -> val.
+Variable sp: val.
+Variables m1 m2: mem.
+
+Hypothesis env_lessdef: forall x, Val.lessdef (e1 x) (e2 x).
+Hypothesis mem_extends: Mem.extends m1 m2.
+
+Lemma eval_annot_arg_lessdef:
+  forall a v1, eval_annot_arg ge e1 sp m1 a v1 ->
+  exists v2, eval_annot_arg ge e2 sp m2 a v2 /\ Val.lessdef v1 v2.
+Proof.
+  induction 1.
+- exists (e2 x); auto with aarg.
+- econstructor; eauto with aarg.
+- econstructor; eauto with aarg.
+- econstructor; eauto with aarg.
+- econstructor; eauto with aarg.
+- exploit Mem.loadv_extends; eauto. intros (v' & P & Q). exists v'; eauto with aarg. 
+- econstructor; eauto with aarg.
+- exploit Mem.loadv_extends; eauto. intros (v' & P & Q). exists v'; eauto with aarg.
+- econstructor; eauto with aarg.
+- destruct IHeval_annot_arg1 as (vhi' & P & Q).
+  destruct IHeval_annot_arg2 as (vlo' & R & S).
+  econstructor; split; eauto with aarg. apply Val.longofwords_lessdef; auto. 
+Qed.
+
+Lemma eval_annot_args_lessdef:
+  forall al vl1, eval_annot_args ge e1 sp m1 al vl1 ->
+  exists vl2, eval_annot_args ge e2 sp m2 al vl2 /\ Val.lessdef_list vl1 vl2.
+Proof.
+  induction 1.
+- econstructor; split. constructor. auto.
+- exploit eval_annot_arg_lessdef; eauto. intros (v1' & P & Q). 
+  destruct IHlist_forall2 as (vl' & U & V).
+  exists (v1'::vl'); split; constructor; auto.
+Qed.
+
+End EVAL_ANNOT_ARG_LESSDEF.
+
+(** Extensionality *)
+
+Section EVAL_ANNOT_ARG_EXTEN.
+
+Variable A: Type.
+Variable ge: Senv.t.
+Variables e1 e2: A -> val.
+Variable sp: val.
+Variable m: mem.
+
+Lemma eval_annot_arg_exten:
+  forall a v, eval_annot_arg ge e1 sp m a v ->
+  (forall x, In x (params_of_annot_arg a) -> e2 x = e1 x) ->
+  eval_annot_arg ge e2 sp m a v.
+Proof.
+  induction 1; simpl; intros EXT; try (now constructor).
+- rewrite <- EXT by auto. constructor.
+- constructor; eauto using in_or_app. 
+Qed.
+
+Lemma eval_annot_args_exten:
+  forall a v, eval_annot_args ge e1 sp m a v ->
+  (forall x, In x (params_of_annot_args a) -> e2 x = e1 x) ->
+  eval_annot_args ge e2 sp m a v.
+Proof.
+  induction 1; simpl; intros EXT; constructor.
+  eapply eval_annot_arg_exten; eauto using in_or_app.
+  eapply IHlist_forall2; eauto using in_or_app.
+Qed.
+
+End EVAL_ANNOT_ARG_EXTEN.
 
 
 

--- a/common/PrintAST.ml
+++ b/common/PrintAST.ml
@@ -55,7 +55,7 @@ let name_of_external = function
   | EF_annot_val(text, targ) ->  sprintf "annot_val %S" (extern_atom text)
   | EF_inline_asm text -> sprintf "inline_asm %S" (extern_atom text)
 
-let print_annot_arg px oc = function
+let rec print_annot_arg px oc = function
   | AA_base x -> px oc x
   | AA_int n -> fprintf oc "int %ld" (camlint_of_coqint n)
   | AA_long n -> fprintf oc "long %Ld" (camlint64_of_coqint n)
@@ -70,7 +70,9 @@ let print_annot_arg px oc = function
               (name_of_chunk chunk) (extern_atom id) (camlint_of_coqint ofs)
   | AA_addrglobal(id, ofs) ->
       fprintf oc "&%s + %ld" (extern_atom id) (camlint_of_coqint ofs)
-  | AA_longofwords(hi, lo) -> fprintf oc "longofwords %a %a" px hi px lo
+  | AA_longofwords(hi, lo) ->
+      fprintf oc "longofwords(%a, %a)" 
+                 (print_annot_arg px) hi (print_annot_arg px) lo
 
 let rec print_annot_args px oc = function
   | [] -> ()

--- a/common/PrintAST.ml
+++ b/common/PrintAST.ml
@@ -54,3 +54,26 @@ let name_of_external = function
   | EF_annot(text, targs) -> sprintf "annot %S" (extern_atom text)
   | EF_annot_val(text, targ) ->  sprintf "annot_val %S" (extern_atom text)
   | EF_inline_asm text -> sprintf "inline_asm %S" (extern_atom text)
+
+let print_annot_arg px oc = function
+  | AA_base x -> px oc x
+  | AA_int n -> fprintf oc "int %ld" (camlint_of_coqint n)
+  | AA_long n -> fprintf oc "long %Ld" (camlint64_of_coqint n)
+  | AA_float n -> fprintf oc "float %F" (camlfloat_of_coqfloat n)
+  | AA_single n -> fprintf oc "single %F" (camlfloat_of_coqfloat32 n)
+  | AA_loadstack(chunk, ofs) -> 
+      fprintf oc "%s[sp + %ld]" (name_of_chunk chunk) (camlint_of_coqint ofs)
+  | AA_addrstack(ofs) ->
+      fprintf oc "sp + %ld" (camlint_of_coqint ofs)
+  | AA_loadglobal(chunk, id, ofs) -> 
+      fprintf oc "%s[&%s + %ld]"
+              (name_of_chunk chunk) (extern_atom id) (camlint_of_coqint ofs)
+  | AA_addrglobal(id, ofs) ->
+      fprintf oc "&%s + %ld" (extern_atom id) (camlint_of_coqint ofs)
+  | AA_longofwords(hi, lo) -> fprintf oc "longofwords %a %a" px hi px lo
+
+let rec print_annot_args px oc = function
+  | [] -> ()
+  | [a] -> print_annot_arg px oc a
+  | a1 :: al ->
+      fprintf oc "%a, %a" (print_annot_arg px) a1 (print_annot_args px) al

--- a/common/Values.v
+++ b/common/Values.v
@@ -1381,6 +1381,12 @@ Proof.
   left; congruence. tauto. tauto.
 Qed.
 
+Lemma lessdef_list_trans:
+  forall vl1 vl2, lessdef_list vl1 vl2 -> forall vl3, lessdef_list vl2 vl3 -> lessdef_list vl1 vl3.
+Proof.
+  induction 1; intros vl3 LD; inv LD; constructor; eauto using lessdef_trans.
+Qed.
+
 (** Compatibility of operations with the [lessdef] relation. *)
 
 Lemma load_result_lessdef:

--- a/ia32/Asmgen.v
+++ b/ia32/Asmgen.v
@@ -492,14 +492,6 @@ Definition transl_store (chunk: memory_chunk)
       Error (msg "Asmgen.transl_store")
   end.
 
-(** Translation of arguments to annotations *)
-
-Definition transl_annot_param (p: Mach.annot_param) : Asm.annot_param :=
-  match p with
-  | Mach.APreg r => APreg (preg_of r)
-  | Mach.APstack chunk ofs => APstack chunk ofs
-  end.
-
 (** Translation of a Mach instruction. *)
 
 Definition transl_instr (f: Mach.function) (i: Mach.instruction)
@@ -546,7 +538,7 @@ Definition transl_instr (f: Mach.function) (i: Mach.instruction)
   | Mbuiltin ef args res =>
       OK (Pbuiltin ef (List.map preg_of args) (List.map preg_of res) :: k)
   | Mannot ef args =>
-      OK (Pannot ef (map transl_annot_param args) :: k)
+      OK (Pannot ef (List.map (map_annot_arg preg_of) args) :: k)
   end.
 
 (** Translation of a code sequence *)

--- a/ia32/Asmgenproof.v
+++ b/ia32/Asmgenproof.v
@@ -700,13 +700,16 @@ Opaque loadind.
   inv AT. monadInv H4. 
   exploit functions_transl; eauto. intro FN.
   generalize (transf_function_no_overflow _ _ H3); intro NOOV.
-  exploit annot_arguments_match; eauto. intros [vargs' [P Q]]. 
-  exploit external_call_mem_extends'; eauto.
+  exploit annot_args_match; eauto. intros [vargs' [P Q]]. 
+  exploit external_call_mem_extends; eauto.
   intros [vres' [m2' [A [B [C D]]]]].
   left. econstructor; split. apply plus_one. 
   eapply exec_step_annot. eauto. eauto.
   eapply find_instr_tail; eauto. eauto.
-  eapply external_call_symbols_preserved'; eauto.
+  erewrite <- sp_val by eauto. 
+  eapply eval_annot_args_preserved with (ge1 := ge); eauto.
+  exact symbols_preserved.
+  eapply external_call_symbols_preserved; eauto.
   exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
   eapply match_states_intro with (ep := false); eauto with coqlib.
   unfold nextinstr. rewrite Pregmap.gss. 

--- a/ia32/SelectOp.vp
+++ b/ia32/SelectOp.vp
@@ -507,3 +507,17 @@ Nondetfunction addressing (chunk: memory_chunk) (e: expr) :=
   | _ => (Aindexed Int.zero, e:::Enil)
   end.
 
+(** ** Arguments of annotations *)
+
+Nondetfunction annot_arg (e: expr) :=
+  match e with
+  | Eop (Ointconst n) Enil => AA_int n
+  | Eop (Olea (Aglobal id ofs)) Enil => AA_addrglobal id ofs
+  | Eop (Olea (Ainstack ofs)) Enil => AA_addrstack ofs
+  | Eop Omakelong (Eop (Ointconst h) Enil ::: Eop (Ointconst l) Enil ::: Enil) =>
+        AA_long (Int64.ofwords h l)
+  | Eop Omakelong (h ::: l ::: Enil) => AA_longofwords (AA_base h) (AA_base l)
+  | Eload chunk (Aglobal id ofs) Enil => AA_loadglobal chunk id ofs
+  | Eload chunk (Ainstack ofs) Enil => AA_loadstack chunk ofs
+  | _ => AA_base e
+  end.

--- a/ia32/SelectOpproof.v
+++ b/ia32/SelectOpproof.v
@@ -898,4 +898,20 @@ Proof.
   exists (v :: nil); split. constructor; auto. constructor. subst; simpl. rewrite Int.add_zero; auto. 
 Qed.
 
+Theorem eval_annot_arg:
+  forall a v,
+  eval_expr ge sp e m nil a v ->
+  CminorSel.eval_annot_arg ge sp e m (annot_arg a) v.
+Proof.
+  intros until v. unfold annot_arg; case (annot_arg_match a); intros; InvEval.
+- constructor.
+- constructor.
+- constructor. 
+- simpl in H5. inv H5. constructor.
+- subst v. constructor; auto.
+- inv H. InvEval. simpl in H6; inv H6. constructor; auto.
+- inv H. InvEval. simpl in H6. inv H6. constructor; auto.
+- constructor; auto.
+Qed.
+
 End CMCONSTR.

--- a/ia32/TargetPrinter.ml
+++ b/ia32/TargetPrinter.ml
@@ -339,7 +339,7 @@ module Target(System: SYSTEM):TARGET =
           (int_of_string (Str.matched_group 2 txt))
       end else begin
         fprintf oc "%s annotation: " comment;
-        PrintAnnot.print_annot_stmt preg "ESP" oc txt targs args
+        PrintAnnot.print_annot_stmt preg "%esp" oc txt targs args
       end
 
     let print_annot_val oc txt args res =

--- a/powerpc/Asm.v
+++ b/powerpc/Asm.v
@@ -276,13 +276,9 @@ Inductive instruction : Type :=
   | Pxoris: ireg -> ireg -> constant -> instruction           (**r bitwise xor with immediate high *)
   | Plabel: label -> instruction                              (**r define a code label *)
   | Pbuiltin: external_function -> list preg -> list preg -> instruction (**r built-in function (pseudo) *)
-  | Pannot: external_function -> list annot_param -> instruction (**r annotation statement (pseudo) *)
+  | Pannot: external_function -> list (annot_arg preg) -> instruction (**r annotation statement (pseudo) *)
   | Pcfi_adjust: int -> instruction                           (**r .cfi_adjust debug directive *)
-  | Pcfi_rel_offset: int -> instruction                       (**r .cfi_rel_offset lr debug directive *)
-
-with annot_param : Type :=
-  | APreg: preg -> annot_param
-  | APstack: memory_chunk -> Z -> annot_param.
+  | Pcfi_rel_offset: int -> instruction.                      (**r .cfi_rel_offset lr debug directive *)
 
 (** The pseudo-instructions are the following:
 
@@ -936,20 +932,6 @@ Definition extcall_arguments
 Definition loc_external_result (sg: signature) : list preg :=
   map preg_of (loc_result sg).
 
-(** Extract the values of the arguments of an annotation. *)
-
-Inductive annot_arg (rs: regset) (m: mem): annot_param -> val -> Prop :=
-  | annot_arg_reg: forall r,
-      annot_arg rs m (APreg r) (rs r)
-  | annot_arg_stack: forall chunk ofs stk base v,
-      rs (IR GPR1) = Vptr stk base ->
-      Mem.load chunk m stk (Int.unsigned base + ofs) = Some v ->
-      annot_arg rs m (APstack chunk ofs) v.
-
-Definition annot_arguments
-    (rs: regset) (m: mem) (params: list annot_param) (args: list val) : Prop :=
-  list_forall2 (annot_arg rs m) params args.
-
 (** Execution of the instruction at [rs#PC]. *)
 
 Inductive state: Type :=
@@ -978,8 +960,8 @@ Inductive step: state -> trace -> state -> Prop :=
       rs PC = Vptr b ofs ->
       Genv.find_funct_ptr ge b = Some (Internal f) ->
       find_instr (Int.unsigned ofs) f.(fn_code) = Some (Pannot ef args) ->
-      annot_arguments rs m args vargs ->
-      external_call' ef ge vargs m t v m' ->
+      eval_annot_args ge rs (rs GPR1) m args vargs ->
+      external_call ef ge vargs m t v m' ->
       step (State rs m) t
            (State (nextinstr rs) m')
   | exec_step_external:
@@ -1031,16 +1013,6 @@ Proof.
   intros. red in H0; red in H1. eauto. 
 Qed.
 
-Remark annot_arguments_determ:
-  forall rs m params args1 args2,
-  annot_arguments rs m params args1 -> annot_arguments rs m params args2 -> args1 = args2.
-Proof.
-  unfold annot_arguments. intros. revert params args1 H args2 H0. 
-  induction 1; intros. 
-  inv H0; auto.
-  inv H1. decEq; eauto. inv H; inv H4. auto. congruence. 
-Qed.
-
 Lemma semantics_determinate: forall p, determinate (semantics p).
 Proof.
 Ltac Equalities :=
@@ -1059,8 +1031,8 @@ Ltac Equalities :=
   exploit external_call_determ'. eexact H4. eexact H9. intros [A B].
   split. auto. intros. destruct B; auto. subst. auto.
   inv H12.
-  assert (vargs0 = vargs) by (eapply annot_arguments_determ; eauto). subst vargs0.
-  exploit external_call_determ'. eexact H5. eexact H13. intros [A B].
+  assert (vargs0 = vargs) by (eapply eval_annot_args_determ; eauto). subst vargs0.
+  exploit external_call_determ. eexact H5. eexact H13. intros [A B].
   split. auto. intros. destruct B; auto. subst. auto.
   assert (args0 = args) by (eapply extcall_arguments_determ; eauto). subst args0.
   exploit external_call_determ'. eexact H3. eexact H8. intros [A B].
@@ -1069,7 +1041,7 @@ Ltac Equalities :=
   red; intros. inv H; simpl.
   omega.
   inv H3; eapply external_call_trace_length; eauto.
-  inv H4; eapply external_call_trace_length; eauto.
+  eapply external_call_trace_length; eauto.
   inv H2; eapply external_call_trace_length; eauto.
 (* initial states *)
   inv H; inv H0. f_equal. congruence.

--- a/powerpc/Asmexpand.ml
+++ b/powerpc/Asmexpand.ml
@@ -74,7 +74,7 @@ let _m8 = coqint_of_camlint (-8l)
 (* Handling of annotations *)
 
 let expand_annot_val txt targ args res =
-  emit (Pannot(EF_annot(txt, [AA_arg targ]), List.map (fun r -> APreg r) args));
+  emit (Pannot(EF_annot(txt, [targ]), List.map (fun r -> AA_base r) args));
   begin match args, res with
   | [IR src], [IR dst] ->
       if dst <> src then emit (Pmr(dst, src))

--- a/powerpc/Asmgen.v
+++ b/powerpc/Asmgen.v
@@ -610,14 +610,6 @@ Definition transl_store (chunk: memory_chunk) (addr: addressing)
       Error (msg "Asmgen.transl_store")
   end.
 
-(** Translation of arguments to annotations *)
-
-Definition transl_annot_param (p: Mach.annot_param) : Asm.annot_param :=
-  match p with
-  | Mach.APreg r => APreg (preg_of r)
-  | Mach.APstack chunk ofs => APstack chunk ofs
-  end.
-
 (** Translation of a Mach instruction. *)
 
 Definition transl_instr (f: Mach.function) (i: Mach.instruction)
@@ -658,7 +650,7 @@ Definition transl_instr (f: Mach.function) (i: Mach.instruction)
   | Mbuiltin ef args res =>
       OK (Pbuiltin ef (map preg_of args) (map preg_of res) :: k)
   | Mannot ef args =>
-      OK (Pannot ef (map transl_annot_param args) :: k)
+      OK (Pannot ef (List.map (map_annot_arg preg_of) args) :: k)
   | Mlabel lbl =>
       OK (Plabel lbl :: k)
   | Mgoto lbl =>

--- a/powerpc/Asmgenproof.v
+++ b/powerpc/Asmgenproof.v
@@ -778,13 +778,16 @@ Hint Resolve agree_nextinstr agree_set_other: asmgen.
   inv AT. monadInv H4. 
   exploit functions_transl; eauto. intro FN.
   generalize (transf_function_no_overflow _ _ H3); intro NOOV.
-  exploit annot_arguments_match; eauto. intros [vargs' [P Q]]. 
-  exploit external_call_mem_extends'; eauto.
+  exploit annot_args_match; eauto. intros [vargs' [P Q]]. 
+  exploit external_call_mem_extends; eauto.
   intros [vres' [m2' [A [B [C D]]]]].
   left. econstructor; split. apply plus_one. 
   eapply exec_step_annot. eauto. eauto.
   eapply find_instr_tail; eauto. eauto.
-  eapply external_call_symbols_preserved'; eauto.
+  erewrite <- sp_val by eauto. 
+  eapply eval_annot_args_preserved with (ge1 := ge); eauto.
+  exact symbols_preserved.
+  eapply external_call_symbols_preserved; eauto.
   exact symbols_preserved. exact public_preserved. exact varinfo_preserved.
   eapply match_states_intro with (ep := false); eauto with coqlib.
   unfold nextinstr. rewrite Pregmap.gss. 

--- a/powerpc/SelectOp.vp
+++ b/powerpc/SelectOp.vp
@@ -523,3 +523,18 @@ Nondetfunction addressing (chunk: memory_chunk) (e: expr) :=
      else (Aindexed Int.zero, Eop Oadd (e1:::e2:::Enil) ::: Enil)
   | _ => (Aindexed Int.zero, e:::Enil)
   end.
+
+(** ** Arguments of annotations *)
+
+Nondetfunction annot_arg (e: expr) :=
+  match e with
+  | Eop (Ointconst n) Enil => AA_int n
+  | Eop (Oaddrsymbol id ofs) Enil => AA_addrglobal id ofs
+  | Eop (Oaddrstack ofs) Enil => AA_addrstack ofs
+  | Eop Omakelong (Eop (Ointconst h) Enil ::: Eop (Ointconst l) Enil ::: Enil) =>
+        AA_long (Int64.ofwords h l)
+  | Eop Omakelong (h ::: l ::: Enil) => AA_longofwords (AA_base h) (AA_base l)
+  | Eload chunk (Aglobal id ofs) Enil => AA_loadglobal chunk id ofs
+  | Eload chunk (Ainstack ofs) Enil => AA_loadstack chunk ofs
+  | _ => AA_base e
+  end.

--- a/powerpc/SelectOpproof.v
+++ b/powerpc/SelectOpproof.v
@@ -999,5 +999,21 @@ Proof.
   rewrite Int.add_zero. auto.
 Qed.
 
+Theorem eval_annot_arg:
+  forall a v,
+  eval_expr ge sp e m nil a v ->
+  CminorSel.eval_annot_arg ge sp e m (annot_arg a) v.
+Proof.
+  intros until v. unfold annot_arg; case (annot_arg_match a); intros; InvEval.
+- constructor.
+- constructor.
+- constructor. 
+- simpl in H5. inv H5. constructor.
+- subst v. constructor; auto.
+- inv H. InvEval. simpl in H6; inv H6. constructor; auto.
+- inv H. InvEval. simpl in H6. inv H6. constructor; auto.
+- constructor; auto.
+Qed.
+
 End CMCONSTR.
 

--- a/powerpc/TargetPrinter.ml
+++ b/powerpc/TargetPrinter.ml
@@ -234,9 +234,12 @@ module Target (System : SYSTEM):TARGET =
     let ireg_or_zero oc r =
       if r = GPR0 then output_string oc "0" else ireg oc r
 
+    (* [preg] is only used for printing annotations.
+       Use the full register names [rN] and [fN] to avoid
+       ambiguity with constants. *)
     let preg oc = function
-      | IR r -> ireg oc r
-      | FR r -> freg oc r
+      | IR r -> fprintf oc "r%s" (int_reg_name r)
+      | FR r -> fprintf oc "f%s" (float_reg_name r)
       | _    -> assert false
 
     let section oc sec =

--- a/test/regression/annot1.c
+++ b/test/regression/annot1.c
@@ -58,6 +58,42 @@ void k(int arg)
                   C1 + 1, arg, C2 * 2);
 }
 
+int j(int a)
+{
+  /* Local variables that are stack-allocated early */
+  short b = 0, c = 0;
+  char d[4];
+  *(a ? &b : &c) = 42;
+  __builtin_annot("j %1 %2 %3 %4", b, c, d[0], d[3]);
+  return b;
+}
+
+long long ll(long long a)
+{
+  /* Force spilling */
+  long long b = a+1;
+  long long c = b+1;
+  long long d = c+1;
+  long long e = d+1;
+  long long f = e+1;
+  long long g = f+1;
+  long long h = g+1;
+  long long i = h+1;
+  long long j = i+1;
+  long long k = j+1;
+  long long l = k+1;
+  long long m = l+1;
+  long long n = m+1;
+  long long o = n+1;
+  long long p = o+1;
+  long long q = p+1;
+  long long r = q+1;
+  long long s = r+1;
+  long long t = s+1;
+  __builtin_annot("ll %1 %2 %3 %4 %5 %6 %7 %8 %9 %10 %11 %12 %13 %14 %15 %16 %17 %18 %19 %20", a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t);
+  return t;
+}
+
 int main()
 {
   __builtin_annot("calling f");


### PR DESCRIPTION
The purpose of this branch is to improve the compilation of __builtin_annot statements.  More specifically, if the arguments to __builtin_annot are either variables or compile-time constant expressions, we make sure that
1- the locations of the variables are correctly tracked all the way to assembly;
2- no code is generated to evaluate the arguments.
These properties do not hold in the current master branch in several cases: 1- local scalar variables whose addresses are taken; 2- local variables of array or composite types; 3- global variables.

The new implementation adds a special case for annotation statements in the CminorSel and RTL intermediate languages; extends the special case already present in LTL, Linear, Mach and Asm; and adapts the back-end compilation passes and their proofs accordingly.  

This extension to the annotation mechanism is also a first step towards generating debugging information for local variables: a variant of EF_annot that produces no observable events could be used to keep track of the locations of these variables.
