### PR TITLE
Fix overflows in printers for clight and csyntax.

### DIFF
--- a/cfrontend/PrintClight.ml
+++ b/cfrontend/PrintClight.ml
@@ -206,7 +206,7 @@ and print_cases p cases =
 
 and print_case_label p = function
   | None -> fprintf p "default"
-  | Some lbl -> fprintf p "case %ld" (camlint_of_coqint lbl)
+  | Some lbl -> fprintf p "case %s" (Z.to_string lbl)
 
 and print_stmt_for p s =
   match s with

--- a/cfrontend/PrintCsyntax.ml
+++ b/cfrontend/PrintCsyntax.ml
@@ -346,7 +346,7 @@ and print_cases p cases =
 
 and print_case_label p = function
   | None -> fprintf p "default"
-  | Some lbl -> fprintf p "case %ld" (camlint_of_coqint lbl)
+  | Some lbl -> fprintf p "case %s" (Z.to_string lbl)
 
 and print_stmt_for p s =
   match s with


### PR DESCRIPTION
In printers for Clight and Csyntax, there are overflows for switch case labels, because of the new internal syntax of switch cases (witch are now Z instead of Int).