### PR TITLE
Tail-recursive array initialization (for very large files)

### DIFF
--- a/cparser/Rename.ml
+++ b/cparser/Rename.ml
@@ -142,7 +142,7 @@ and exp_desc env = function
 
 and init env = function
   | Init_single e -> Init_single(exp env e)
-  | Init_array il -> Init_array (List.map (init env) il)
+  | Init_array il -> Init_array (List.rev (List.rev_map (init env) il))
   | Init_struct(id, il) ->
       Init_struct(ident env id,
                   List.map (fun (f, i) -> (field env f, init env i)) il)

--- a/cparser/StructReturn.ml
+++ b/cparser/StructReturn.ml
@@ -412,7 +412,7 @@ and transf_init env = function
   | Init_single e ->
       Init_single (transf_expr env Val e)
   | Init_array il ->
-      Init_array (List.map (transf_init env) il)
+      Init_array (List.rev (List.rev_map (transf_init env) il))
   | Init_struct(id, fil) ->
       Init_struct (id, List.map (fun (fld, i) -> (fld, transf_init env i)) fil)
   | Init_union(id, fld, i) ->

--- a/cparser/Unblock.ml
+++ b/cparser/Unblock.ml
@@ -154,6 +154,7 @@ let rec expand_expr islocal env e =
 (* Elimination of compound literals within an initializer. *)
 
 and expand_init islocal env i =
+
   let rec expand i =
     match i with
     (* The following "flattening" is not C99.  GCC documents it; whether
@@ -169,7 +170,7 @@ and expand_init islocal env i =
     | Init_single e ->
         Init_single (expand_expr islocal env e)
     | Init_array il ->
-        Init_array (List.map expand il)
+        Init_array (List.rev (List.rev_map expand il))
     | Init_struct(id, flds) ->
         Init_struct(id, List.map (fun (f, i) -> (f, expand i)) flds)
     | Init_union(id, fld, i) ->

--- a/extraction/extraction.v
+++ b/extraction/extraction.v
@@ -154,7 +154,7 @@ Separate Extraction
    Compiler.transf_c_program Compiler.transf_cminor_program
    Cexec.do_initial_state Cexec.do_step Cexec.at_final_state
    Ctypes.merge_attributes Ctypes.remove_attributes Ctypes.build_composite_env
-   Initializers.transl_init Initializers.constval
+   Initializers.transl_init_tr Initializers.constval
    Csyntax.Eindex Csyntax.Epreincr
    Ctyping.typecheck_program
    Ctyping.epostincr Ctyping.epostdecr Ctyping.epreincr Ctyping.epredecr


### PR DESCRIPTION
Small optimizations to enable CompCert to handle files with unreasonable amounts (200k+) of array initializers.

This pull request is mostly to inform of the changes I did when trying to compile large files consisting mainly in huge arrays initialized byte per byte. I do not believe this request has production-quality level (there is duplicated code, the proof could be simplified, etc.), but it might nevertheless be useful for patching (if someone else also needs to compile such unreasonably large files).

The good news is that after only these few modifications, I was able to compile source files larger than 10MB, with almost a million initializers. The compilation time is surely larger than GCC's, but the OCaml code is more time- and memory-efficient than I expected for extracted Coq code.