### PR TITLE
Correction of a few bugs in the pre-parser, added comments.

### DIFF
--- a/cparser/Elab.ml
+++ b/cparser/Elab.ml
@@ -2250,20 +2250,3 @@ let elab_file prog =
   reset();
   ignore (elab_definitions false (Builtins.environment()) prog);
   elaborated_program()
-(*
-  let rec inf = Datatypes.S inf in
-  let ast:Cabs.definition list =
-    Obj.magic
-      (match Parser.translation_unit_file inf (Lexer.tokens_stream lb) with
-         | Parser.Parser.Inter.Fail_pr ->
-             (* Theoretically impossible : implies inconsistencies
-                between grammars. *)
-             Cerrors.fatal_error "Internal error while parsing"
-         | Parser.Parser.Inter.Timeout_pr -> assert false
-         | Parser.Parser.Inter.Parsed_pr (ast, _ ) -> ast)
-  in
-  reset();
-  ignore (elab_definitions false (Builtins.environment()) ast);
-  elaborated_program()
-*)
-

--- a/cparser/Parse.ml
+++ b/cparser/Parse.ml
@@ -49,12 +49,16 @@ let preprocessed_file transfs name sourcefile =
   let p,d =
     try
       let t = parse_transformations transfs in
-      let lb = Lexer.init name ic in
       let rec inf = Datatypes.S inf in
       let ast : Cabs.definition list =
         Obj.magic
-          (match Timing.time2 "Parsing"
-                 Parser.translation_unit_file inf (Lexer.tokens_stream lb) with
+          (match Timing.time "Parsing"
+              (* The call to Lexer.tokens_stream results in the pre
+                 parsing of the entire file. This is non-negligeabe,
+                 so we cannot use Timing.time2 *)
+              (fun () ->
+                Parser.translation_unit_file inf (Lexer.tokens_stream name ic)) ()
+           with
              | Parser.Parser.Inter.Fail_pr ->
                  (* Theoretically impossible : implies inconsistencies
                     between grammars. *)

--- a/cparser/pre_parser_aux.ml
+++ b/cparser/pre_parser_aux.ml
@@ -18,8 +18,20 @@ type identifier_type =
   | TypedefId
   | OtherId
 
-let push_context:(unit -> unit) ref= ref (fun () -> assert false)
-let pop_context:(unit -> unit) ref = ref (fun () -> assert false)
+(* These functions push and pop a context on the contexts stack. *)
+let open_context:(unit -> unit) ref = ref (fun () -> assert false)
+let close_context:(unit -> unit) ref = ref (fun () -> assert false)
 
+(* Applying once this functions saves the whole contexts stack, and
+   applying it the second time restores it.
+
+   This is mainly used to rollback the context stack to a previous
+   state. This is usefull for example when we pop too much contexts at
+   the end of the first branch of an if statement. See
+   pre_parser.mly. *)
+let save_contexts_stk:(unit -> (unit -> unit)) ref = ref (fun _ -> assert false)
+
+(* Change the context at the top of the top stack of context, by
+   changing an identifier to be a varname or a typename*)
 let declare_varname:(string -> unit) ref = ref (fun _ -> assert false)
 let declare_typename:(string -> unit) ref = ref (fun _ -> assert false)

--- a/test/regression/Makefile
+++ b/test/regression/Makefile
@@ -17,7 +17,8 @@ TESTS=int32 int64 floats floats-basics \
   volatile1 volatile2 volatile3 \
   funct3 expr5 struct7 struct8 struct11 struct12 casts1 casts2 char1 \
   sizeof1 sizeof2 binops bool for1 switch switch2 compound \
-  decl1 interop1 bitfields9 ptrs3
+  decl1 interop1 bitfields9 ptrs3 \
+  parsing
 
 # Can run, but only in compiled mode, and have reference output in Results
 

--- a/test/regression/parsing.c
+++ b/test/regression/parsing.c
@@ -1,0 +1,104 @@
+#include<stdio.h>
+
+typedef signed int T;
+
+T f(T(T));
+T f(T a(T)) {
+  T b;
+  return 1;
+}
+int g(int x) {
+ T:;
+  T y;
+  T T;
+  T=1;
+
+  return 1;
+}
+
+void h() {
+  for(int T; ;)
+    if(1)
+      ;
+  T *x;
+  x = 0;
+}
+
+void h2() {
+  for(int T; ;)
+    if(1)
+      ;
+    else T;
+}
+
+struct S {
+  const T:3;
+  unsigned T:3;
+  const T:3;
+};
+
+void i() {
+  struct S s;
+  s.T = -1;
+  if(s.T < 0) printf("ERROR i\n");
+}
+
+/* These ones are parsed correctly, but rejected by the elaborator. */
+/* void j() { */
+/*   typedef int I; */
+/*   {sizeof(enum{I=2}); return I;} */
+/*   {do sizeof(enum{I=2}); while((I)1);} */
+/*   {if(1) return sizeof(enum{I=2}); */
+/*    else  return (I)1;} */
+/*   {if(sizeof(enum{I=2})) return I; */
+/*    else return I;} */
+/*   {sizeof(enum{I=2})+I;} */
+/*   {for(int i = sizeof(enum{I=2}); I; I) I; (I)1;} */
+/* } */
+/* int f2(enum{I=2} x) { */
+/*   return I; */
+/* } */
+/* void k(A, B) */
+/*      int B; */
+/*      int A[B]; */
+/* { } */
+/* int l(A) */
+/*      enum {T=1} A; */
+/* { return T * A; } */
+
+void m() {
+  if(0)
+    if(1);
+    else printf("ERROR m\n");
+  if(0)
+    for(int i; ; )
+      if(1);
+      else printf("ERROR m\n");
+  if(0)
+    for(1; ; )
+      if(1);
+      else printf("ERROR m\n");
+  if(0)
+    while(1)
+      if(1);
+      else printf("ERROR m\n");
+  if(0)
+  L: if(1);
+     else printf("ERROR m\n");
+
+  if(0)
+  LL:for(1;;)
+      for(int i;;)
+        while(1)
+          switch(1)
+          case 1:
+            if(1);
+            else printf("ERROR m\n");
+}
+
+int main () {
+  f(g);
+  i();
+  m();
+  return 0;
+}


### PR DESCRIPTION
Fixed a few bugs in the pre parser. In particular, the following code was not parsed correctly:

typedef int a;

int f() {
  for(int a; ;)
    if(1);
  a * x;
}

Additionally, I tried to add some comments in the pre-parser code,
especially for the different hacks used to solve various conflicts.