### PR TITLE
Pass --no-stdlib and -v to menhir when compiling pre_parser.mly.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ cparser/Parser.v
 cparser/Lexer.ml
 cparser/pre_parser.ml
 cparser/pre_parser.mli
+cparser/pre_parser.automaton
 lib/Readconfig.ml
 lib/Tokenize.ml
 driver/Version.ml

--- a/Makefile.extr
+++ b/Makefile.extr
@@ -70,7 +70,7 @@ OCAMLC_P4=ocamlfind ocamlc $(COMPFLAGS) $(BITSTRING)
 OCAMLOPT_P4=ocamlfind ocamlopt $(COMPFLAGS) $(BITSTRING)
 OCAMLDEP_P4=ocamlfind ocamldep $(INCLUDES) $(BITSTRING)
 
-MENHIR=menhir -v --no-stdlib
+MENHIR=menhir -v --no-stdlib -la 1
 OCAMLLEX=ocamllex -q
 MODORDER=tools/modorder .depend.extr
 

--- a/Makefile.extr
+++ b/Makefile.extr
@@ -17,6 +17,10 @@
 
 include Makefile.config
 
+# Menhir configuration and rules.
+
+include Makefile.menhir
+
 # Directories containing plain Caml code (no preprocessing)
 
 DIRS=extraction \
@@ -33,7 +37,7 @@ endif
 
 ALLDIRS=$(DIRS) $(DIRS_P4)
 
-INCLUDES=$(patsubst %,-I %, $(ALLDIRS))
+INCLUDES=$(patsubst %,-I %, $(ALLDIRS)) $(MENHIR_INCLUDES)
 
 # Control of warnings:
 # warning 3 = deprecated feature.  Turned off for OCaml 4.02 (bytes vs strings)
@@ -70,7 +74,6 @@ OCAMLC_P4=ocamlfind ocamlc $(COMPFLAGS) $(BITSTRING)
 OCAMLOPT_P4=ocamlfind ocamlopt $(COMPFLAGS) $(BITSTRING)
 OCAMLDEP_P4=ocamlfind ocamldep $(INCLUDES) $(BITSTRING)
 
-MENHIR=menhir -v --no-stdlib -la 1
 OCAMLLEX=ocamllex -q
 MODORDER=tools/modorder .depend.extr
 
@@ -78,7 +81,9 @@ PARSERS=backend/CMparser.mly cparser/pre_parser.mly
 LEXERS=backend/CMlexer.mll cparser/Lexer.mll \
        lib/Tokenize.mll lib/Readconfig.mll
 
-LIBS=str.cmxa unix.cmxa
+LIBS=str.cmxa unix.cmxa $(MENHIR_LIBS)
+LIBS_BYTE=$(patsubst %.cmxa,%.cma,$(patsubst %.cmx,%.cmo,$(LIBS)))
+
 CHECKLINK_LIBS=str.cmxa
 
 EXECUTABLES=ccomp ccomp.byte cchecklink cchecklink.byte clightgen clightgen.byte
@@ -96,7 +101,7 @@ ccomp: $(CCOMP_OBJS)
 
 ccomp.byte: $(CCOMP_OBJS:.cmx=.cmo)
 	@echo "Linking $@"
-	@$(OCAMLC) -o $@ $(LIBS:.cmxa=.cma) $+
+	@$(OCAMLC) -o $@ $(LIBS_BYTE) $+
 
 ifeq ($(CCHECKLINK),true)
 
@@ -120,7 +125,7 @@ clightgen: $(CLIGHTGEN_OBJS)
 
 clightgen.byte: $(CLIGHTGEN_OBJS:.cmx=.cmo)
 	@echo "Linking $@"
-	@$(OCAMLC) -o $@ $(LIBS:.cmxa=.cma) $+
+	@$(OCAMLC) -o $@ $(LIBS_BYTE) $+
 
 include .depend.extr
 
@@ -148,8 +153,6 @@ checklink/%.cmx: checklink/%.ml
 	@echo "OCAMLOPT $<"
 	@$(OCAMLOPT) -c $<
 
-%.ml %.mli: %.mly
-	$(MENHIR) $<
 %.ml: %.mll
 	$(OCAMLLEX) $<
 

--- a/Makefile.extr
+++ b/Makefile.extr
@@ -70,7 +70,7 @@ OCAMLC_P4=ocamlfind ocamlc $(COMPFLAGS) $(BITSTRING)
 OCAMLOPT_P4=ocamlfind ocamlopt $(COMPFLAGS) $(BITSTRING)
 OCAMLDEP_P4=ocamlfind ocamldep $(INCLUDES) $(BITSTRING)
 
-MENHIR=menhir --explain
+MENHIR=menhir -v --no-stdlib
 OCAMLLEX=ocamllex -q
 MODORDER=tools/modorder .depend.extr
 

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -52,7 +52,7 @@ ifeq ($(MENHIR_TABLE),true)
 
   MENHIR_SUGGESTION = $(MENHIR) --suggest-comp-flags
 
-  MENHIR_INCLUDES = $(shell \
+  MENHIR_INCLUDES := $(shell \
     if $(MENHIR_SUGGESTION) | grep -e "-package" >/dev/null ; then \
       echo "-I `ocamlfind query menhirLib`" ; \
     else \

--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -1,0 +1,67 @@
+# This is a Makefile fragment for Menhir-specific aspects.
+
+# This flag can be set to true or false. It controls whether we use
+# Menhir's table back-end or code back-end. The table back-end is a
+# bit slower, but supports more features, including advanced error
+# reporting.
+
+MENHIR_TABLE = false
+
+# Executable.
+
+ifeq ($(MENHIR_TABLE),true)
+  MENHIR = menhir --table
+else
+  MENHIR = menhir
+endif
+
+# Options.
+
+MENHIR_FLAGS = -v --no-stdlib -la 1
+
+# Using Menhir in --table mode requires MenhirLib.
+
+ifeq ($(MENHIR_TABLE),true)
+  MENHIR_LIBS = menhirLib.cmx
+else
+  MENHIR_LIBS =
+endif
+
+# The compilation rule.
+
+%.ml %.mli: %.mly
+	$(MENHIR) $(MENHIR_FLAGS) $<
+
+# Note 1: finding where MenhirLib has been installed would be easier if we
+# could depend on ocamlfind, but as far as I understand and as of today,
+# CompCert can be compiled and linked even in the absence of ocamlfind.
+# So, we should not require ocamlfind.
+
+# Note 2: Menhir has options --suggest-comp-flags and --suggest-link-flags
+# which we are supposed to help solve this difficulty. However, they don't
+# work for us out of the box, because if Menhir has been installed using
+# ocamlfind, then Menhir will suggest using ocamlfind (i.e. it will suggest
+# -package and -linkpkg options), which we don't want to do.
+
+# Solution: Ask Menhir first. If Menhir answers "-package menhirLib", then
+# Menhir was installed with ocamlfind, so we should not ask Menhir, but we
+# can instead ask ocamlfind where Menhir's library was installed. Otherwise,
+# Menhir answers directly with a "-I ..." directive, which we use.
+
+ifeq ($(MENHIR_TABLE),true)
+
+  MENHIR_SUGGESTION = $(MENHIR) --suggest-comp-flags
+
+  MENHIR_INCLUDES = $(shell \
+    if $(MENHIR_SUGGESTION) | grep -e "-package" >/dev/null ; then \
+      echo "-I `ocamlfind query menhirLib`" ; \
+    else \
+      $(MENHIR_SUGGESTION) ; \
+    fi)
+
+else
+
+  MENHIR_INCLUDES =
+
+endif
+

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -210,37 +210,44 @@ cast_expression:
 | LPAREN type_name RPAREN cast_expression
     {}
 
+multiplicative_operator:
+  STAR | SLASH | PERCENT {}
+
 multiplicative_expression:
 | cast_expression
-| multiplicative_expression STAR cast_expression
-| multiplicative_expression SLASH cast_expression
-| multiplicative_expression PERCENT cast_expression
+| multiplicative_expression multiplicative_operator cast_expression
     {}
+
+additive_operator:
+  PLUS | MINUS {}
 
 additive_expression:
 | multiplicative_expression
-| additive_expression PLUS multiplicative_expression
-| additive_expression MINUS multiplicative_expression
+| additive_expression additive_operator multiplicative_expression
     {}
+
+shift_operator:
+  LEFT | RIGHT {}
 
 shift_expression:
 | additive_expression
-| shift_expression LEFT additive_expression
-| shift_expression RIGHT additive_expression
+| shift_expression shift_operator additive_expression
     {}
+
+relational_operator:
+  LT | GT | LEQ | GEQ {}
 
 relational_expression:
 | shift_expression
-| relational_expression LT shift_expression
-| relational_expression GT shift_expression
-| relational_expression LEQ shift_expression
-| relational_expression GEQ shift_expression
+| relational_expression relational_operator shift_expression
     {}
+
+equality_operator:
+  EQEQ | NEQ {}
 
 equality_expression:
 | relational_expression
-| equality_expression EQEQ relational_expression
-| equality_expression NEQ relational_expression
+| equality_expression equality_operator relational_expression
     {}
 
 and_expression:

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -581,7 +581,7 @@ abstract_declarator:
 
 direct_abstract_declarator:
 | LPAREN abstract_declarator RPAREN
-| ioption(direct_abstract_declarator) LBRACK type_qualifier_list? assignment_expression? RBRACK
+| option(direct_abstract_declarator) LBRACK type_qualifier_list? assignment_expression? RBRACK
 | ioption(direct_abstract_declarator) LPAREN in_context(parameter_type_list?) RPAREN
     {}
 

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -772,8 +772,12 @@ iteration_statement(openc,last_statement):
 | WHILE openc LPAREN expression RPAREN last_statement
 | DO open_context statement_finish_close WHILE
     openc LPAREN expression RPAREN close_context SEMICOLON
-| FOR openc LPAREN optional(expression, SEMICOLON) optional(expression, SEMICOLON) optional(expression, RPAREN) last_statement
-| FOR openc LPAREN declaration                     optional(expression, SEMICOLON) optional(expression, RPAREN) last_statement
+| FOR openc LPAREN for_statement_header optional(expression, SEMICOLON) optional(expression, RPAREN) last_statement
+    {}
+
+for_statement_header:
+| optional(expression, SEMICOLON)
+| declaration
     {}
 
 asm_attributes:

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -97,6 +97,14 @@ option(X):
 | x = X
     { Some x }
 
+(* [optional(X, Y)] is equivalent to [X? Y]. However, by inlining
+   the two possibilies -- either [X Y] or just [Y] -- we are able
+   to give more meaningful syntax error messages. [optional(X, Y)]
+   itself is usually NOT inlined, as that would cause a useless
+   explosion of cases. *)
+optional(X, Y):
+  ioption(X) Y {}
+
 %inline fst(X):
 | x = X
     { fst x }
@@ -537,7 +545,7 @@ direct_declarator:
 | i = general_identifier
     { set_id_type i VarId; (i, None) }
 | LPAREN x = declarator RPAREN
-| x = direct_declarator LBRACK type_qualifier_list? assignment_expression? RBRACK
+| x = direct_declarator LBRACK type_qualifier_list? optional(assignment_expression, RBRACK)
     { x }
 | x = direct_declarator LPAREN
     open_context parameter_type_list? restore_fun = save_contexts_stk
@@ -583,7 +591,7 @@ abstract_declarator:
 
 direct_abstract_declarator:
 | LPAREN abstract_declarator RPAREN
-| option(direct_abstract_declarator) LBRACK type_qualifier_list? assignment_expression? RBRACK
+| option(direct_abstract_declarator) LBRACK type_qualifier_list? optional(assignment_expression, RBRACK)
 | ioption(direct_abstract_declarator) LPAREN in_context(parameter_type_list?) RPAREN
     {}
 
@@ -764,8 +772,8 @@ iteration_statement(openc,last_statement):
 | WHILE openc LPAREN expression RPAREN last_statement
 | DO open_context statement_finish_close WHILE
     openc LPAREN expression RPAREN close_context SEMICOLON
-| FOR openc LPAREN expression? SEMICOLON expression? SEMICOLON expression? RPAREN last_statement
-| FOR openc LPAREN declaration expression? SEMICOLON expression? RPAREN last_statement
+| FOR openc LPAREN optional(expression, SEMICOLON) optional(expression, SEMICOLON) optional(expression, RPAREN) last_statement
+| FOR openc LPAREN declaration                     optional(expression, SEMICOLON) optional(expression, RPAREN) last_statement
     {}
 
 asm_attributes:

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -451,13 +451,10 @@ struct_declarator:
     {}
 
 enum_specifier:
-| ENUM attribute_specifier_list LBRACE enumerator_list COMMA? RBRACE
-| ENUM attribute_specifier_list other_identifier LBRACE enumerator_list COMMA? RBRACE
+| ENUM attribute_specifier_list other_identifier? LBRACE enumerator_list COMMA? RBRACE
 | ENUM attribute_specifier_list other_identifier
     {}
-| ENUM attribute_specifier_list LBRACE enumerator_list COMMA? error
-    { unclosed "{" "}" $startpos($3) $endpos }
-| ENUM attribute_specifier_list general_identifier LBRACE enumerator_list COMMA? error
+| ENUM attribute_specifier_list other_identifier? LBRACE enumerator_list COMMA? error
     { unclosed "{" "}" $startpos($4) $endpos }
 
 enumerator_list:

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -408,13 +408,10 @@ type_specifier_no_typedef_name:
     {}
 
 struct_or_union_specifier:
-| struct_or_union attribute_specifier_list LBRACE struct_declaration_list RBRACE
-| struct_or_union attribute_specifier_list other_identifier LBRACE struct_declaration_list RBRACE
+| struct_or_union attribute_specifier_list other_identifier? LBRACE struct_declaration_list RBRACE
 | struct_or_union attribute_specifier_list other_identifier
     {}
-| struct_or_union attribute_specifier_list LBRACE struct_declaration_list error
-    { unclosed "{" "}" $startpos($3) $endpos }
-| struct_or_union attribute_specifier_list general_identifier LBRACE struct_declaration_list error
+| struct_or_union attribute_specifier_list other_identifier? LBRACE struct_declaration_list error
     { unclosed "{" "}" $startpos($4) $endpos }
 
 struct_or_union:

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -150,8 +150,7 @@ declare_typename(nt):
 (* Actual grammar *)
 
 primary_expression:
-| i = VAR_NAME
-    { set_id_type i VarId }
+| VAR_NAME
 | CONSTANT
 | string_literals_list
 | LPAREN expression RPAREN
@@ -378,8 +377,7 @@ declaration_specifiers_no_typedef_name:
    The first field is a named t, while the second is unnamed of type t.
 *)
 declaration_specifiers:
-| ioption(declaration_specifiers_no_type) i = TYPEDEF_NAME               declaration_specifiers_no_type?
-    { set_id_type i TypedefId }
+| ioption(declaration_specifiers_no_type) TYPEDEF_NAME                   declaration_specifiers_no_type?
 | ioption(declaration_specifiers_no_type) type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
     {}
 
@@ -387,9 +385,8 @@ declaration_specifiers:
    "typedef" keyword. To avoid conflicts, we also encode the
    constraint described in the comment for [declaration_specifiers]. *)
 declaration_specifiers_typedef:
-| ioption(declaration_specifiers_no_type) TYPEDEF                        declaration_specifiers_no_type?         i = TYPEDEF_NAME               declaration_specifiers_no_type?
-| ioption(declaration_specifiers_no_type) i = TYPEDEF_NAME               declaration_specifiers_no_type?         TYPEDEF                        declaration_specifiers_no_type?
-    { set_id_type i TypedefId }
+| ioption(declaration_specifiers_no_type) TYPEDEF                        declaration_specifiers_no_type?         TYPEDEF_NAME                   declaration_specifiers_no_type?
+| ioption(declaration_specifiers_no_type) TYPEDEF_NAME                   declaration_specifiers_no_type?         TYPEDEF                        declaration_specifiers_no_type?
 | ioption(declaration_specifiers_no_type) TYPEDEF                        declaration_specifiers_no_type?         type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
 | ioption(declaration_specifiers_no_type) type_specifier_no_typedef_name declaration_specifiers_no_typedef_name? TYPEDEF                        declaration_specifiers_no_typedef_name?
     {}
@@ -437,8 +434,7 @@ struct_declaration:
 (* As in the standard, except it also encodes the constraint described
    in the comment above [declaration_specifiers]. *)
 specifier_qualifier_list:
-| type_qualifier_list? i = TYPEDEF_NAME               type_qualifier_list?
-    { set_id_type i TypedefId }
+| type_qualifier_list? TYPEDEF_NAME                   type_qualifier_list?
 | type_qualifier_list? type_specifier_no_typedef_name specifier_qualifier_list_no_typedef_name?
     {}
 

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -591,7 +591,7 @@ abstract_declarator:
 
 direct_abstract_declarator:
 | LPAREN abstract_declarator RPAREN
-| option(direct_abstract_declarator) LBRACK type_qualifier_list? optional(assignment_expression, RBRACK)
+| direct_abstract_declarator? LBRACK type_qualifier_list? optional(assignment_expression, RBRACK)
 | ioption(direct_abstract_declarator) LPAREN in_context(parameter_type_list?) RPAREN
     {}
 

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -286,7 +286,7 @@ constant_expression:
    typedef). *)
 
 declaration:
-| declaration_specifiers init_declarator_list? SEMICOLON
+| declaration_specifiers         init_declarator_list?    SEMICOLON
     {}
 | declaration_specifiers_typedef typedef_declarator_list? SEMICOLON
     {}
@@ -321,8 +321,8 @@ storage_class_specifier_no_typedef:
    that do not contain either "typedef" nor type specifiers. *)
 declaration_specifiers_no_type:
 | storage_class_specifier_no_typedef declaration_specifiers_no_type?
-| type_qualifier declaration_specifiers_no_type?
-| function_specifier declaration_specifiers_no_type?
+| type_qualifier                     declaration_specifiers_no_type?
+| function_specifier                 declaration_specifiers_no_type?
     {}
 
 (* [declaration_specifiers_no_typedef_name] matches declaration
@@ -331,9 +331,9 @@ declaration_specifiers_no_type:
    keyword"). *)
 declaration_specifiers_no_typedef_name:
 | storage_class_specifier_no_typedef declaration_specifiers_no_typedef_name?
-| type_qualifier declaration_specifiers_no_typedef_name?
-| function_specifier declaration_specifiers_no_typedef_name?
-| type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
+| type_qualifier                     declaration_specifiers_no_typedef_name?
+| function_specifier                 declaration_specifiers_no_typedef_name?
+| type_specifier_no_typedef_name     declaration_specifiers_no_typedef_name?
     {}
 
 (* [declaration_specifiers_no_type] matches declaration_specifiers
@@ -353,7 +353,7 @@ declaration_specifiers_no_typedef_name:
    The first field is a named t, while the second is unnamed of type t.
 *)
 declaration_specifiers:
-| declaration_specifiers_no_type? i = TYPEDEF_NAME declaration_specifiers_no_type?
+| declaration_specifiers_no_type? i = TYPEDEF_NAME               declaration_specifiers_no_type?
     { set_id_type i TypedefId }
 | declaration_specifiers_no_type? type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
     {}
@@ -362,19 +362,11 @@ declaration_specifiers:
    "typedef" keyword. To avoid conflicts, we also encode the
    constraint described in the comment for [declaration_specifiers]. *)
 declaration_specifiers_typedef:
-| declaration_specifiers_no_type?
-  TYPEDEF declaration_specifiers_no_type?
-  i = TYPEDEF_NAME declaration_specifiers_no_type?
-| declaration_specifiers_no_type?
-  i = TYPEDEF_NAME declaration_specifiers_no_type?
-  TYPEDEF declaration_specifiers_no_type?
+| declaration_specifiers_no_type? TYPEDEF                        declaration_specifiers_no_type?         i = TYPEDEF_NAME               declaration_specifiers_no_type?
+| declaration_specifiers_no_type? i = TYPEDEF_NAME               declaration_specifiers_no_type?         TYPEDEF                        declaration_specifiers_no_type?
     { set_id_type i TypedefId }
-| declaration_specifiers_no_type?
-  TYPEDEF declaration_specifiers_no_type?
-  type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
-| declaration_specifiers_no_type?
-  type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
-  TYPEDEF declaration_specifiers_no_typedef_name?
+| declaration_specifiers_no_type? TYPEDEF                        declaration_specifiers_no_type?         type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
+| declaration_specifiers_no_type? type_specifier_no_typedef_name declaration_specifiers_no_typedef_name? TYPEDEF                        declaration_specifiers_no_typedef_name?
     {}
 
 (* A type specifier which is not a typedef name. *)
@@ -421,14 +413,14 @@ struct_declaration:
 (* As in the standard, except it also encodes the constraint described
    in the comment above [declaration_specifiers]. *)
 specifier_qualifier_list:
-| type_qualifier_list? i = TYPEDEF_NAME type_qualifier_list?
+| type_qualifier_list? i = TYPEDEF_NAME               type_qualifier_list?
     { set_id_type i TypedefId }
 | type_qualifier_list? type_specifier_no_typedef_name specifier_qualifier_list_no_typedef_name?
     {}
 
 specifier_qualifier_list_no_typedef_name:
 | type_specifier_no_typedef_name specifier_qualifier_list_no_typedef_name?
-| type_qualifier specifier_qualifier_list_no_typedef_name?
+| type_qualifier                 specifier_qualifier_list_no_typedef_name?
     {}
 
 struct_declarator_list:

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -138,7 +138,7 @@ string_literals_list:
    follow set of the non-terminal in question. The follow sets are
    given by menhir with option -lg 3. *)
 
-%inline nop: (* empty *) { }
+%inline nop: (* empty *) {}
 
 open_context:
   (* empty *)%prec highPrec { !open_context () }
@@ -326,7 +326,6 @@ constant_expression:
 
 declaration:
 | declaration_specifiers         init_declarator_list?    SEMICOLON
-    {}
 | declaration_specifiers_typedef typedef_declarator_list? SEMICOLON
     {}
 
@@ -338,7 +337,7 @@ init_declarator_list:
 init_declarator:
 | declare_varname(fst(declarator))
 | declare_varname(fst(declarator)) EQ c_initializer
-    { }
+    {}
 
 typedef_declarator_list:
 | typedef_declarator
@@ -347,7 +346,7 @@ typedef_declarator_list:
 
 typedef_declarator:
 | declare_typename(fst(declarator))
-    { }
+    {}
 
 storage_class_specifier_no_typedef:
 | EXTERN
@@ -860,12 +859,12 @@ identifier_list:
 
 declaration_list:
 | /*empty*/
-    { }
+    {}
 | declaration_list declaration
-    { }
+    {}
 
 function_definition:
 | function_definition_begin LBRACE block_item_list? close_context RBRACE
-    { }
+    {}
 | function_definition_begin LBRACE block_item_list? close_context error
     { unclosed "{" "}" $startpos($2) $endpos }

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -392,17 +392,17 @@ declaration_specifiers_no_typedef_name:
 *)
 declaration_specifiers:
 | ioption(declaration_specifiers_no_type) TYPEDEF_NAME                   declaration_specifiers_no_type?
-| ioption(declaration_specifiers_no_type) type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
+| declaration_specifiers_no_type?         type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
     {}
 
 (* This matches declaration_specifiers that do contains once the
    "typedef" keyword. To avoid conflicts, we also encode the
    constraint described in the comment for [declaration_specifiers]. *)
 declaration_specifiers_typedef:
-| ioption(declaration_specifiers_no_type) TYPEDEF                        declaration_specifiers_no_type?         TYPEDEF_NAME                   declaration_specifiers_no_type?
+| declaration_specifiers_no_type?         TYPEDEF                        declaration_specifiers_no_type?         TYPEDEF_NAME                   declaration_specifiers_no_type?
 | ioption(declaration_specifiers_no_type) TYPEDEF_NAME                   declaration_specifiers_no_type?         TYPEDEF                        declaration_specifiers_no_type?
-| ioption(declaration_specifiers_no_type) TYPEDEF                        declaration_specifiers_no_type?         type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
-| ioption(declaration_specifiers_no_type) type_specifier_no_typedef_name declaration_specifiers_no_typedef_name? TYPEDEF                        declaration_specifiers_no_typedef_name?
+| declaration_specifiers_no_type?         TYPEDEF                        declaration_specifiers_no_type?         type_specifier_no_typedef_name declaration_specifiers_no_typedef_name?
+| declaration_specifiers_no_type?         type_specifier_no_typedef_name declaration_specifiers_no_typedef_name? TYPEDEF                        declaration_specifiers_no_typedef_name?
     {}
 
 (* A type specifier which is not a typedef name. *)


### PR DESCRIPTION
Passing --no-stdlib ensures that there is no dependency on Menhir's
standard library.
Passing -v, which is equivalent to --explain --dump, requests the
generation of pre_parser.automaton, a description of the automaton.

General comment:
In agreement with Xavier Leroy and Jacques-Henri Jourdan, I have been
working on an experimental approach to improving the syntax error messages
in CompCert's pre_parser. For the moment, I am planning to make a series of
pull requests that tend to clean up or improve pre_parser.mly, without affecting
its behavior. This tiny pull request is mostly a way of checking that I understand
how pull requests work. Thanks!

Francois Pottier.