### PR TITLE
Fix in cparser/GNUmakefile.

### DIFF
--- a/configure
+++ b/configure
@@ -281,7 +281,7 @@ else
   ocaml_opt_comp=false
 fi
 
-MENHIR_REQUIRED=20151023
+MENHIR_REQUIRED=20151110
 echo "Testing Menhir... " | tr -d '\n'
 menhir_ver=`menhir --version 2>/dev/null | sed -n -e 's/^.*version \([0-9]*\).*$/\1/p'`
 case "$menhir_ver" in

--- a/cparser/GNUmakefile
+++ b/cparser/GNUmakefile
@@ -68,7 +68,7 @@ DATABASE := handcrafted.messages
 
 # We use (GNU) cut when de-lexing examples sentences.
 
-CUT      := $(shell if which gcut >&/dev/null ; then echo gcut ; else echo cut ; fi)
+CUT       = $(shell if command -v gcut >/dev/null ; then echo gcut ; else echo cut ; fi)
 
 # ------------------------------------------------------------------------------
 

--- a/cparser/Lexer.mll
+++ b/cparser/Lexer.mll
@@ -470,7 +470,7 @@ and singleline_comment = parse
     let lexbuf = Lexing.from_string text in
     lexbuf.lex_curr_p <- {lexbuf.lex_curr_p with pos_fname = filename; pos_lnum = 1};
     let module I = Pre_parser.MenhirInterpreter in
-    let checkpoint = Pre_parser.Incremental.translation_unit_file()
+    let checkpoint = Pre_parser.Incremental.translation_unit_file lexbuf.lex_curr_p
     and supplier = I.lexer_lexbuf_to_supplier lexer lexbuf
     and succeed () = ()
     and fail checkpoint =


### PR DESCRIPTION
Remove "&" which was a typo and did not make sense.
Use "command -v" instead of "which" (more efficient).
Use "=" instead of ":=" (more efficient).