### PR TITLE
Simple mcpu

### DIFF
--- a/configure
+++ b/configure
@@ -39,7 +39,6 @@ Supported targets:
 
 For PowerPC targets, the "ppc-" prefix can be refined into:
   ppc64-           PowerPC 64 bits
-  e5500-           Freescale e5500 core (PowerPC 64 bits + EREF extensions)
 
 For ARM targets, the "arm-" prefix can be refined into:
   armv6-           ARMv6   + VFPv2
@@ -88,11 +87,10 @@ struct_passing=""
 struct_return=""
 
 case "$target" in
-  powerpc-*|ppc-*|powerpc64-*|ppc64-*|e5500-*)
+  powerpc-*|ppc-*|powerpc64-*|ppc64-*)
     arch="powerpc"
     case "$target" in
       powerpc64-*|ppc64-*) model="ppc64";;
-      e5500-*) model="e5500";;
       *) model="ppc32";;
     esac
     abi="eabi"
@@ -310,7 +308,7 @@ for mk in make gmake gnumake; do
         break;;
   esac
 done
-if test -z "$make"; then 
+if test -z "$make"; then
   echo "NOT FOUND"
   echo "Error: make sure GNU Make version 3.80 or later is installed."
   missingtools=true
@@ -363,9 +361,8 @@ cat >> Makefile.config <<'EOF'
 ARCH=
 
 # Hardware variant
-# MODEL=ppc32     # for plain PowerPC 
+# MODEL=ppc32     # for plain PowerPC
 # MODEL=ppc64     # for PowerPC with 64-bit instructions
-# MODEL=e5500     # for Freescale e5500 PowerPC variant
 # MODEL=armv6     # for ARM
 # MODEL=armv7a    # for ARM
 # MODEL=armv7r    # for ARM

--- a/driver/Clflags.ml
+++ b/driver/Clflags.ml
@@ -33,6 +33,7 @@ let option_falignfunctions = ref (None: int option)
 let option_falignbranchtargets = ref 0
 let option_faligncondbranchs = ref 0
 let option_finline_asm = ref false
+let option_mcpu = ref "generic"
 let option_mthumb = ref (Configuration.model = "armv7m")
 let option_Osize = ref false
 let option_dparse = ref false

--- a/driver/Driver.ml
+++ b/driver/Driver.ml
@@ -574,6 +574,11 @@ let cmdline_actions =
 (* Target processor options *)
   Exact "-mthumb", Set option_mthumb;
   Exact "-marm", Unset option_mthumb;
+  Prefix "-mcpu=", Self (fun s -> let s = String.sub s 6 ((String.length s) -6) in
+  if Configuration.model <> "ppc64" || s <> "e5500" then begin
+    eprintf "Unrecognized argument in option `-mcpu=%s'\n" s; exit 2
+  end else
+    option_mcpu := s);
 (* Assembling options *)
   Prefix "-Wa,", Self (fun s -> if Configuration.system = "diab" then
     assembler_options := List.rev_append (explode_comma_option s) !assembler_options

--- a/powerpc/Asmexpand.ml
+++ b/powerpc/Asmexpand.ml
@@ -26,7 +26,7 @@ exception Error of string
 (* FreeScale's EREF extensions *)
 
 let eref =
-  match Configuration.model with
+  match !Clflags.option_mcpu with
   | "e5500" -> true
   | _ -> false
 

--- a/powerpc/extractionMachdep.v
+++ b/powerpc/extractionMachdep.v
@@ -28,6 +28,5 @@ Extract Constant Asm.preg_eq => "fun (x: preg) (y: preg) -> x = y".
 Extract Constant Archi.ppc64 =>
   "begin match Configuration.model with
    | ""ppc64"" -> true
-   | ""e5500"" -> true
    | _ -> false
    end".

--- a/runtime/Makefile
+++ b/runtime/Makefile
@@ -14,8 +14,6 @@ VPATH=$(ARCH)
 ifeq ($(ARCH),powerpc)
 ifeq ($(MODEL),ppc64)
 VPATH=powerpc/ppc64 $(ARCH)
-else ifeq ($(MODEL),e5500)
-VPATH=powerpc/ppc64 $(ARCH)
 endif
 endif
 


### PR DESCRIPTION
This branch provides a new command line option mcpu for specifying the e5500 as target processor instead of using the model configuration e5500.