### PR TITLE
Config option

### DIFF
--- a/driver/Configuration.ml
+++ b/driver/Configuration.ml
@@ -10,7 +10,6 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-open Filename
 open Printf
 
 let search_argv key =
@@ -23,8 +22,8 @@ let search_argv key =
   !res
 
 let absolute_path base file =
-  if is_relative file then
-    concat base file
+  if Filename.is_relative file then
+    Filename.concat base file
   else
     file
 
@@ -41,14 +40,14 @@ let ini_file_name =
         let ini_name = match search_argv "-target" with
         | Some s -> s^".ini"
         | None -> "compcert.ini" in
-        let exe_dir = dirname Sys.executable_name in
+        let exe_dir = Filename.dirname Sys.executable_name in
         let share_dir =
-          concat (concat exe_dir parent_dir_name)
+          Filename.concat (Filename.concat exe_dir Filename.parent_dir_name)
             "share" in
         let share_compcert_dir =
-          concat share_dir "compcert" in
+          Filename.concat share_dir "compcert" in
         let search_path = [exe_dir;share_dir;share_compcert_dir] in
-        let files = List.map (fun s -> concat s ini_name) search_path in
+        let files = List.map (fun s -> Filename.concat s ini_name) search_path in
         try
           List.find  Sys.file_exists files
         with Not_found ->
@@ -57,7 +56,7 @@ let ini_file_name =
             exit 2
           end
 
-let ini_dir = dirname ini_file_name
+let ini_dir = Filename.dirname ini_file_name
 
 (* Read in the .ini file *)
 
@@ -98,7 +97,7 @@ let tool_absolute_path tools =
   match tools with
   | [] -> []
   | tool::args -> let tool =
-      if is_implicit tool && dirname tool = current_dir_name then
+      if Filename.is_implicit tool && Filename.dirname tool = Filename.current_dir_name then
         tool
       else
         absolute_path ini_dir tool in

--- a/driver/Configuration.ml
+++ b/driver/Configuration.ml
@@ -21,12 +21,18 @@ let search_argv key =
   done;
   !res
 
+let absolute_path base file =
+  if Filename.is_relative file then
+    Filename.concat base file
+  else
+    file
+
 (* Locate the .ini file, which is either in the same directory as
   the executable or in the directory ../share *)
 
 let ini_file_name =
   match search_argv "--conf" with
-  | Some s -> s
+  | Some s -> absolute_path (Sys.getcwd ()) s
   | None ->
       try
         Sys.getenv "COMPCERT_CONFIG"
@@ -46,6 +52,8 @@ let ini_file_name =
             eprintf "Cannot find compcert.ini configuration file.\n";
             exit 2
           end
+
+let ini_dir = Filename.dirname ini_file_name
 
 (* Read in the .ini file *)
 
@@ -104,7 +112,8 @@ let has_standard_headers =
   | v -> bad_config "has_standard_headers" [v]
 let stdlib_path =
   if has_runtime_lib then
-    get_config_string "stdlib_path"
+    let path = get_config_string "stdlib_path" in
+    absolute_path ini_dir path
   else
     ""
 let asm_supports_cfi =

--- a/driver/Configuration.ml
+++ b/driver/Configuration.ml
@@ -32,12 +32,15 @@ let absolute_path base file =
   the executable or in the directory ../share *)
 
 let ini_file_name =
-  match search_argv "--conf" with
+  match search_argv "-conf" with
   | Some s -> absolute_path (Sys.getcwd ()) s
   | None ->
       try
         Sys.getenv "COMPCERT_CONFIG"
       with Not_found ->
+        let ini_name = match search_argv "-target" with
+        | Some s -> s^".ini"
+        | None -> "compcert.ini" in
         let exe_dir = dirname Sys.executable_name in
         let share_dir =
           concat (concat exe_dir parent_dir_name)
@@ -45,7 +48,7 @@ let ini_file_name =
         let share_compcert_dir =
           concat share_dir "compcert" in
         let search_path = [exe_dir;share_dir;share_compcert_dir] in
-        let files = List.map (fun s -> concat s "compcert.ini") search_path in
+        let files = List.map (fun s -> concat s ini_name) search_path in
         try
           List.find  Sys.file_exists files
         with Not_found ->

--- a/driver/Driver.ml
+++ b/driver/Driver.ml
@@ -572,7 +572,8 @@ let cmdline_actions =
   Exact "-falign-branch-targets", Integer(fun n -> option_falignbranchtargets := n);
   Exact "-falign-cond-branches", Integer(fun n -> option_faligncondbranchs := n);
 (* Target processor options *)
-  Exact "--conf", String (fun _ -> ()); (* Ignore option since it is already handled *)
+  Exact "-conf", String (fun _ -> ()); (* Ignore option since it is already handled *)
+  Exact "-target", String (fun _ -> ()); (* Ignore option since it is already handled *)
   Exact "-mthumb", Set option_mthumb;
   Exact "-marm", Unset option_mthumb;
 (* Assembling options *)


### PR DESCRIPTION
This PR allows it to use relative paths in the .ini files for tools and libraries. The paths are relative to the given .ini file.

It also introduces a new option `-target` that allows it to select .ini files with the given name.