### PR TITLE
Update cminor support for single-precision floats

### DIFF
--- a/backend/CMlexer.mll
+++ b/backend/CMlexer.mll
@@ -25,6 +25,7 @@ let floatlit =
  ("-"? (['0'-'9'] ['0'-'9' '_']*
   ('.' ['0'-'9' '_']* )?
   (['e' 'E'] ['+' '-']? ['0'-'9'] ['0'-'9' '_']*)? )) | "inf" | "nan"
+let floatlithex = "0X" ['0'-'9' 'a'-'f' 'A'-'F']+
 let ident = ['A'-'Z' 'a'-'z' '_'] ['A'-'Z' 'a'-'z' '_' '$' '0'-'9']*
 let qident = '\'' [ ^ '\'' ]+ '\''
 let temp = "$" ['1'-'9'] ['0'-'9']*
@@ -167,6 +168,11 @@ rule token = parse
                 LONGLIT(Int64.of_string(String.sub s 0 (String.length s - 2))) }
   | intlit    { INTLIT(Int32.of_string(Lexing.lexeme lexbuf)) }
   | floatlit     { FLOATLIT(float_of_string(Lexing.lexeme lexbuf)) }
+  | floatlithex  { let s = Lexing.lexeme lexbuf in
+                   match String.length s with
+		   | 18 -> FLOATLIT(Int64.float_of_bits(Int64.of_string s))
+		   | 10 -> FLOATLIT(Int32.float_of_bits(Int64.to_int32(Int64.of_string s)))
+                   | er -> raise(Error("illegal floating-point literal: "^s)) }
   | stringlit { let s = Lexing.lexeme lexbuf in
                 STRINGLIT(String.sub s 1 (String.length s - 2)) }
   | ident | temp  { IDENT(Lexing.lexeme lexbuf) }

--- a/backend/CMlexer.mll
+++ b/backend/CMlexer.mll
@@ -123,6 +123,7 @@ rule token = parse
   | "-"    { MINUS }
   | "->"    { MINUSGREATER }
   | "-f"    { MINUSF }
+  | "-s"    { MINUSS }
   | "-l"    { MINUSL }
   | "%"    { PERCENT }
   | "%l"    { PERCENTL }
@@ -131,6 +132,7 @@ rule token = parse
   | "+"    { PLUS }
   | "+f"    { PLUSF }
   | "+l"    { PLUSL }
+  | "+s"    { PLUSS }
   | "}"    { RBRACE }
   | "}}"    { RBRACERBRACE }
   | "]"    { RBRACKET }
@@ -140,14 +142,17 @@ rule token = parse
   | ";"    { SEMICOLON }
   | "/"    { SLASH }
   | "/f"    { SLASHF }
+  | "/s"    { SLASHS }
   | "/l"    { SLASHL }
   | "/lu"    { SLASHLU }
   | "/u"    { SLASHU }
   | "single" { SINGLE }
+  | "singleofint" { SINGLEOFINT }
   | "stack"    { STACK }
   | "*" { STAR }
   | "*f"    { STARF }
   | "*l"    { STARL }
+  | "*s"    { STARS }
   | "switch"    { SWITCH }
   | "switchl"    { SWITCHL }
   | "tailcall"  { TAILCALL }

--- a/backend/CMparser.mly
+++ b/backend/CMparser.mly
@@ -331,6 +331,7 @@ let mkmatch expr cases =
 %token MATCH
 %token MINUS
 %token MINUSF
+%token MINUSS
 %token MINUSL
 %token MINUSGREATER
 %token PERCENT
@@ -339,6 +340,7 @@ let mkmatch expr cases =
 %token PERCENTLU
 %token PLUS
 %token PLUSF
+%token PLUSS
 %token PLUSL
 %token RBRACE
 %token RBRACERBRACE
@@ -348,14 +350,17 @@ let mkmatch expr cases =
 %token RPAREN
 %token SEMICOLON
 %token SINGLE
+%token SINGLEOFINT
 %token SLASH
 %token SLASHF
+%token SLASHS
 %token SLASHU
 %token SLASHL
 %token SLASHLU
 %token STACK
 %token STAR
 %token STARF
+%token STARS
 %token STARL
 %token <string> STRINGLIT
 %token SWITCH
@@ -376,9 +381,9 @@ let mkmatch expr cases =
 %left AMPERSAND AMPERSANDL
 %left EQUALEQUAL BANGEQUAL LESS LESSEQUAL GREATER GREATEREQUAL EQUALEQUALU BANGEQUALU LESSU LESSEQUALU GREATERU GREATEREQUALU EQUALEQUALF BANGEQUALF LESSF LESSEQUALF GREATERF GREATEREQUALF EQUALEQUALL BANGEQUALL LESSL LESSEQUALL GREATERL GREATEREQUALL EQUALEQUALLU BANGEQUALLU LESSLU LESSEQUALLU GREATERLU GREATEREQUALLU
 %left LESSLESS GREATERGREATER GREATERGREATERU LESSLESSL GREATERGREATERL GREATERGREATERLU
-%left PLUS PLUSF PLUSL MINUS MINUSF MINUSL
-%left STAR SLASH PERCENT STARF SLASHF SLASHU PERCENTU STARL SLASHL SLASHLU PERCENTL PERCENTLU
-%nonassoc BANG TILDE TILDEL p_uminus ABSF INTOFFLOAT INTUOFFLOAT FLOATOFINT FLOATOFINTU INT8S INT8U INT16S INT16U FLOAT32 INTOFLONG LONGOFINT LONGOFINTU LONGOFFLOAT LONGUOFFLOAT FLOATOFLONG FLOATOFLONGU
+%left PLUS PLUSF PLUSS PLUSL MINUS MINUSF MINUSS MINUSL
+%left STAR SLASH PERCENT STARF STARS SLASHF SLASHS SLASHU PERCENTU STARL SLASHL SLASHLU PERCENTL PERCENTLU
+%nonassoc BANG TILDE TILDEL p_uminus ABSF INTOFFLOAT INTUOFFLOAT FLOATOFINT SINGLEOFINT FLOATOFINTU INT8S INT8U INT16S INT16U INT32 INT64 FLOAT32 FLOAT64 INTOFLONG LONGOFINT LONGOFINTU LONGOFFLOAT LONGUOFFLOAT FLOATOFLONG FLOATOFLONGU
 %left LPAREN
 
 /* Entry point */
@@ -580,10 +585,12 @@ expr:
   | AMPERSAND INTLIT                            { Rconst(Oaddrstack(coqint_of_camlint $2)) }
   | MINUS expr    %prec p_uminus                { Runop(Onegint, $2) }
   | MINUSF expr   %prec p_uminus                { Runop(Onegf, $2) }
+  | MINUSS expr   %prec p_uminus                { Runop(Onegfs, $2) }
   | ABSF expr                                   { Runop(Oabsf, $2) }
   | INTOFFLOAT expr                             { Runop(Ointoffloat, $2) }
   | INTUOFFLOAT expr                            { Runop(Ointuoffloat, $2) }
   | FLOATOFINT expr                             { Runop(Ofloatofint, $2) }
+  | SINGLEOFINT expr                            { Runop(Osingleofint, $2) }
   | FLOATOFINTU expr                            { Runop(Ofloatofintu, $2) }
   | TILDE expr                                  { Runop(Onotint, $2) }
   | BANG expr                                   { Rbinop(Ocmpu Ceq, $2, intconst 0l) }
@@ -592,6 +599,7 @@ expr:
   | INT16S expr                                 { Runop(Ocast16signed, $2) }
   | INT16U expr                                 { Runop(Ocast16unsigned, $2) }
   | FLOAT32 expr                                { Runop(Osingleoffloat, $2) }
+  | FLOAT64 expr                                { Runop(Ofloatofsingle, $2) }
   | MINUSL expr %prec p_uminus                  { Runop(Onegl, $2) }
   | TILDEL expr                                 { Runop(Onotl, $2) }
   | INTOFLONG expr                              { Runop(Ointoflong, $2) }
@@ -628,9 +636,13 @@ expr:
   | expr GREATERGREATERL expr                   { Rbinop(Oshrl, $1, $3) }
   | expr GREATERGREATERLU expr                  { Rbinop(Oshrlu, $1, $3) }
   | expr PLUSF expr                             { Rbinop(Oaddf, $1, $3) }
+  | expr PLUSS expr                             { Rbinop(Oaddfs, $1, $3) }
   | expr MINUSF expr                            { Rbinop(Osubf, $1, $3) }
+  | expr MINUSS expr                            { Rbinop(Osubfs, $1, $3) }
   | expr STARF expr                             { Rbinop(Omulf, $1, $3) }
+  | expr STARS expr                             { Rbinop(Omulfs, $1, $3) }
   | expr SLASHF expr                            { Rbinop(Odivf, $1, $3) }
+  | expr SLASHS expr                            { Rbinop(Odivfs, $1, $3) }
   | expr EQUALEQUAL expr                        { Rbinop(Ocmp Ceq, $1, $3) }
   | expr BANGEQUAL expr                         { Rbinop(Ocmp Cne, $1, $3) }
   | expr LESS expr                              { Rbinop(Ocmp Clt, $1, $3) }

--- a/backend/PrintCminor.ml
+++ b/backend/PrintCminor.ml
@@ -18,7 +18,6 @@
 open Format
 open Camlcoq
 open Datatypes
-open Integers
 open AST
 open PrintAST
 open Cminor
@@ -82,12 +81,12 @@ let name_of_unop = function
   | Osingleoflongu -> "singleoflongu"
 
 let comparison_name = function
-  | Ceq -> "=="
-  | Cne -> "!="
-  | Clt -> "<"
-  | Cle -> "<="
-  | Cgt -> ">"
-  | Cge -> ">="
+  | Integers.Ceq -> "=="
+  | Integers.Cne -> "!="
+  | Integers.Clt -> "<"
+  | Integers.Cle -> "<="
+  | Integers.Cgt -> ">"
+  | Integers.Cge -> ">="
 
 let name_of_binop = function
   | Oadd -> "+"
@@ -148,9 +147,9 @@ let rec expr p (prec, e) =
   | Econst(Ointconst n) ->
       fprintf p "%ld" (camlint_of_coqint n)
   | Econst(Ofloatconst f) ->
-      fprintf p "%F" (camlfloat_of_coqfloat f)
+      fprintf p "0X%.16LX" (Int64.bits_of_float (camlfloat_of_coqfloat f))
   | Econst(Osingleconst f) ->
-      fprintf p "%Ff" (camlfloat_of_coqfloat32 f)
+      fprintf p "0X%.8lX" (Int32.bits_of_float (camlfloat_of_coqfloat32 f))
   | Econst(Olongconst n) ->
       fprintf p "%LdLL" (camlint64_of_coqint n)
   | Econst(Oaddrsymbol(id, ofs)) ->
@@ -326,8 +325,8 @@ let print_init_data p = function
   | Init_int16 i -> fprintf p "int16 %ld" (camlint_of_coqint i)
   | Init_int32 i -> fprintf p "%ld" (camlint_of_coqint i)
   | Init_int64 i -> fprintf p "%LdLL" (camlint64_of_coqint i)
-  | Init_float32 f -> fprintf p "float32 %F" (camlfloat_of_coqfloat f)
-  | Init_float64 f -> fprintf p "%.16F" (camlfloat_of_coqfloat f)
+  | Init_float32 f -> fprintf p "float32 0X%.8lX" (Int32.bits_of_float (camlfloat_of_coqfloat f))
+  | Init_float64 f -> fprintf p "0X%.16LX" (Int64.bits_of_float (camlfloat_of_coqfloat f))
   | Init_space i -> fprintf p "[%ld]" (camlint_of_coqint i)
   | Init_addrof(id,off) -> fprintf p "%ld(\"%s\")" (camlint_of_coqint off) (extern_atom id)
 

--- a/backend/PrintCminor.ml
+++ b/backend/PrintCminor.ml
@@ -327,7 +327,7 @@ let print_init_data p = function
   | Init_int32 i -> fprintf p "%ld" (camlint_of_coqint i)
   | Init_int64 i -> fprintf p "%LdLL" (camlint64_of_coqint i)
   | Init_float32 f -> fprintf p "float32 %F" (camlfloat_of_coqfloat f)
-  | Init_float64 f -> fprintf p "%F" (camlfloat_of_coqfloat f)
+  | Init_float64 f -> fprintf p "%.16F" (camlfloat_of_coqfloat f)
   | Init_space i -> fprintf p "[%ld]" (camlint_of_coqint i)
   | Init_addrof(id,off) -> fprintf p "%ld(\"%s\")" (camlint_of_coqint off) (extern_atom id)
 

--- a/ia32/PrintOp.ml
+++ b/ia32/PrintOp.ml
@@ -119,6 +119,9 @@ let print_operation reg pp = function
   | Omakelong, [r1;r2] -> fprintf pp "makelong(%a,%a)" reg r1 reg r2
   | Olowlong, [r1] -> fprintf pp "lowlong(%a)" reg r1
   | Ohighlong, [r1] -> fprintf pp "highlong(%a)" reg r1
+  | Onot, [r1] -> fprintf pp "not(%a)" reg r1
+  | Omulhs, [r1;r2] -> fprintf pp "mulhs(%a,%a)" reg r1 reg r2
+  | Omulhu, [r1;r2] -> fprintf pp "mulhu(%a,%a)" reg r1 reg r2
   | Ocmp c, args -> print_condition reg pp (c, args)
   | _ -> fprintf pp "<bad operator>"
 


### PR DESCRIPTION
The cminor parser and associated support files have become out of date
with respect to the support for single-precision floats in CompCert-2.6 onwards.
Also dumping .rtl was producing previously invalid ops for not/mulhs/mulhu.
