### PR TITLE
Fix a bug in the pre-parser.

### DIFF
--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -665,6 +665,7 @@ direct_declarator:
 | i = declarator_identifier
     { set_id_type i VarId; (i, Decl_ident) }
 | LPAREN save_context x = declarator RPAREN
+    { x }
 | x = direct_declarator LBRACK type_qualifier_list? optional(assignment_expression, RBRACK)
     { match snd x with
       | Decl_ident -> (fst x, Decl_other)

--- a/test/regression/parsing.c
+++ b/test/regression/parsing.c
@@ -162,6 +162,23 @@ void (*krk(a, b, c))(int)
 
 int hhh(int());
 
+int (testparen)(int T) {
+  return T;
+}
+
+int (testparen2(int T)) {
+  return T;
+}
+
+int ((testparen3)(int T)) {
+  return T;
+}
+
+int ((((((((((testparen10))))))))))(int T) {
+  return T;
+}
+
+
 int main () {
   f(g);
   i();


### PR DESCRIPTION
The parameters of the function may not be inserted in the function scope when the function declaration contains parentheses.