### PR TITLE
Extend Asmexpand to handle more cases of BA_splitlong

### DIFF
--- a/backend/Asmexpandaux.ml
+++ b/backend/Asmexpandaux.ml
@@ -154,3 +154,16 @@ let expand_debug id sp preg simple l =
     | b::rest -> List.rev ((List.rev (b::bcc)@List.rev acc)@rest) (* We found the first non debug location *)
     | [] -> List.rev acc (* This actually can never happen *) in
   aux None [] (move_debug [] [] (List.rev l))
+
+(* Count leading or trailing zero bits of 32bit immediates represented as Coq Integers *)
+
+let count_zeros shiftfn accstart imm =
+  let rec cnt acc x = if x = 0l then
+    acc
+  else
+    cnt (Int32.sub acc 1l) (shiftfn x 1) in
+  coqint_of_camlint (cnt accstart (camlint_of_coqint imm))
+
+let count_leading_zeros imm = count_zeros Int32.shift_right_logical 32l imm
+let count_trailing_zeros imm = count_zeros Int32.shift_left 32l imm
+let count_trailing_zeros_plus32 imm = count_zeros Int32.shift_left 64l imm

--- a/backend/Asmexpandaux.mli
+++ b/backend/Asmexpandaux.mli
@@ -34,3 +34,9 @@ val get_current_function: unit -> coq_function
 val expand_debug: positive -> int -> (preg -> int) -> (instruction -> unit) -> instruction list -> unit
   (* Expand builtin debug function. Takes the function id, the register number of the stackpointer, a
      function to get the dwarf mapping of varibale names  and for the expansion of simple instructions *)
+val count_leading_zeros: Integers.Int.int -> Integers.Int.int
+    (* Count number of leading zero bits *)
+val count_trailing_zeros: Integers.Int.int -> Integers.Int.int
+    (* Count number of trailing zero bits *)
+val count_trailing_zeros_plus32: Integers.Int.int -> Integers.Int.int
+    (* Count number of trailing zero bits, add 32 to the result *)


### PR DESCRIPTION
This PR is a partial fix (currently only ia32) for the Asmexpand problem in code like this:

 volatile long long x;
 void f(unsigned int i) { x = i; }


