### PR TITLE
porting to 8.6. Warning: an Admitted in Deadcodeproof.

### DIFF
--- a/backend/Deadcodeproof.v
+++ b/backend/Deadcodeproof.v
@@ -978,11 +978,13 @@ Ltac UseTransfer :=
   eapply match_succ_states; eauto. simpl; auto.
   destruct res; auto. apply eagree_set_undef; auto.
   eapply magree_storebytes_left; eauto.
-  exploit aaddr_arg_sound; eauto. 
-  intros (bc & A & B & C).
-  intros. eapply nlive_contains; eauto.
+  exploit aaddr_arg_sound; eauto.
+  intros (bc & A & B & C); intros.
   erewrite Mem.loadbytes_length in H0 by eauto.
-  rewrite nat_of_Z_eq in H0 by omega. auto.
+  rewrite nat_of_Z_eq in H0 by omega.
+  eapply nlive_contains; eauto.
+  subst adst.
+  admit.
 + (* annot *)
   destruct (transfer_builtin_args (kill_builtin_res res ne, nm) _x1) as (ne1, nm1) eqn:TR.
   InvSoundState.
@@ -1089,7 +1091,7 @@ Ltac UseTransfer :=
   econstructor; split.
   constructor.
   econstructor; eauto. apply mextends_agree; auto.
-Qed.
+Admitted.
 
 Lemma transf_initial_states:
   forall st1, initial_state prog st1 ->

--- a/backend/Inliningproof.v
+++ b/backend/Inliningproof.v
@@ -1171,25 +1171,32 @@ Proof.
   rewrite <- SP in MS0.
   eapply match_stacks_invariant; eauto.
     intros. destruct (eq_block b1 stk).
-    subst b1. rewrite D in H8; inv H8. subst b2. eelim Plt_strict; eauto.
-    rewrite E in H8; auto.
-    intros. exploit Mem.perm_alloc_inv. eexact H. eauto.
-    destruct (eq_block b1 stk); intros; auto.
-    subst b1. rewrite D in H8; inv H8. subst b2. eelim Plt_strict; eauto.
-    intros. eapply Mem.perm_alloc_1; eauto.
-    intros. exploit Mem.perm_alloc_inv. eexact A. eauto.
-    rewrite dec_eq_false; auto.
-  auto. auto. auto. eauto. auto.
-  rewrite H5. apply agree_regs_init_regs. eauto. auto. inv H1; auto. congruence. auto.
-  eapply Mem.valid_new_block; eauto.
-  red; intros. split.
-  eapply Mem.perm_alloc_2; eauto. inv H1; xomega.
-  intros; red; intros. exploit Mem.perm_alloc_inv. eexact H. eauto.
-  destruct (eq_block b stk); intros.
-  subst. rewrite D in H9; inv H9. inv H1; xomega.
-  rewrite E in H9; auto. eelim Mem.fresh_block_alloc. eexact A. eapply Mem.mi_mappedblocks; eauto.
-  auto.
-  intros. exploit Mem.perm_alloc_inv; eauto. rewrite dec_eq_true. omega.
+    + subst b1. rewrite D in H8; inv H8. eelim Plt_strict; eauto.
+    + rewrite E in H8; auto.
+    + intros. exploit Mem.perm_alloc_inv. eexact H. eauto.
+      destruct (eq_block b1 stk); intros; auto.
+      subst b1. rewrite D in H8; inv H8. eelim Plt_strict; eauto.
+    + intros. eapply Mem.perm_alloc_1; eauto.
+    + intros. exploit Mem.perm_alloc_inv. eexact A. eauto.
+      rewrite dec_eq_false; auto.
+    + auto.
+    + auto.
+    + auto.
+      eauto.
+    + auto.
+    + rewrite H5. apply agree_regs_init_regs. eauto. auto. inv H1; auto.
+    + congruence.
+    + auto.
+    + eapply Mem.valid_new_block; eauto.
+    + red; intros. split.
+      eapply Mem.perm_alloc_2; eauto. inv H1; xomega.
+      intros; red; intros. exploit Mem.perm_alloc_inv. eexact H. eauto.
+      destruct (eq_block b stk); intros.
+      subst. rewrite D in H9; inv H9. inv H1; xomega.
+      rewrite E in H9; auto. eelim Mem.fresh_block_alloc. eexact A.
+      eapply Mem.mi_mappedblocks; eauto.
+    + auto.
+    + intros. exploit Mem.perm_alloc_inv; eauto. rewrite dec_eq_true. omega.
 
 - (* internal function, inlined *)
   inversion FB; subst.

--- a/backend/NeedDomain.v
+++ b/backend/NeedDomain.v
@@ -1254,10 +1254,10 @@ Proof.
   assert (Genv.find_symbol ge id = Some b) by (eapply H; eauto).
   split; simpl; auto; intros.
   rewrite PTree.gsspec in H6. destruct (peq id0 id).
-+ inv H6. destruct H3. congruence. destruct gl!id as [iv0|] eqn:NG.
-  rewrite ISet.In_add. intros [P|P]. omega. eelim GL; eauto.
-  rewrite ISet.In_interval. omega.
-+ eauto.
+  + inv H6. destruct H3. congruence. destruct gl!id as [iv0|] eqn:NG.
+    subst iv'; rewrite ISet.In_add. intros [P|P]. omega. eelim GL; eauto.
+    subst iv'; rewrite ISet.In_interval. omega.
+  + eauto.
 - (* Stk ofs *)
   split; simpl; auto; intros. destruct H3.
   elim H3. subst b'. eapply bc_stack; eauto.

--- a/backend/RTLgen.v
+++ b/backend/RTLgen.v
@@ -107,8 +107,8 @@ Inductive res (A: Type) (s: state): Type :=
   | Error: Errors.errmsg -> res A s
   | OK: A -> forall (s': state), state_incr s s' -> res A s.
 
-Implicit Arguments OK [A s].
-Implicit Arguments Error [A s].
+Arguments OK [A s].
+Arguments Error [A s].
 
 Definition mon (A: Type) : Type := forall (s: state), res A s.
 

--- a/backend/RTLgenproof.v
+++ b/backend/RTLgenproof.v
@@ -1082,7 +1082,7 @@ End CORRECTNESS_EXPR.
 
 (** ** Measure over CminorSel states *)
 
-Open Local Scope nat_scope.
+Local Open Scope nat_scope.
 
 Fixpoint size_stmt (s: stmt) : nat :=
   match s with

--- a/backend/SelectDivproof.v
+++ b/backend/SelectDivproof.v
@@ -17,7 +17,7 @@ Require Import AST Integers Floats Values Memory Globalenvs Events.
 Require Import Cminor Op CminorSel.
 Require Import SelectOp SelectOpproof SplitLong SplitLongproof SelectLong SelectLongproof SelectDiv.
 
-Open Local Scope cminorsel_scope.
+Local Open Scope cminorsel_scope.
 
 (** * Main approximation theorems *)
 

--- a/backend/SplitLongproof.v
+++ b/backend/SplitLongproof.v
@@ -18,8 +18,8 @@ Require Import AST Errors Integers Floats.
 Require Import Values Memory Globalenvs Events Cminor Op CminorSel.
 Require Import SelectOp SelectOpproof SplitLong.
 
-Open Local Scope cminorsel_scope.
-Open Local Scope string_scope.
+Local Open Scope cminorsel_scope.
+Local Open Scope string_scope.
 
 (** * Axiomatization of the helper functions *)
 

--- a/backend/Stacking.v
+++ b/backend/Stacking.v
@@ -169,7 +169,7 @@ Definition transl_code
 Definition transl_body (f: Linear.function) (fe: frame_env) :=
   save_callee_save fe (transl_code fe f.(Linear.fn_code)).
 
-Open Local Scope string_scope.
+Local Open Scope string_scope.
 
 Definition transf_function (f: Linear.function) : res Mach.function :=
   let fe := make_env (function_bounds f) in

--- a/backend/Unusedglobproof.v
+++ b/backend/Unusedglobproof.v
@@ -1015,7 +1015,7 @@ Proof.
   { rewrite STK, TSTK.
     apply match_stacks_incr with j; auto.
     intros. destruct (eq_block b1 stk).
-    subst b1. rewrite F in H1; inv H1. subst b2. split; apply Ple_refl.
+    subst b1. rewrite F in H1; inv H1. split; apply Ple_refl.
     rewrite G in H1 by auto. congruence. }
   econstructor; split.
   eapply exec_function_internal; eauto.

--- a/cfrontend/Cexec.v
+++ b/cfrontend/Cexec.v
@@ -131,7 +131,7 @@ Definition val_of_eventval (ev: eventval) (t: typ) : option val :=
 Ltac mydestr :=
   match goal with
   | [ |- None = Some _ -> _ ] => intro X; discriminate
-  | [ |- Some _ = Some _ -> _ ] => intro X; inv X
+  | [ |- Some _ = Some _ -> _ ] => let X := fresh in (intro X; inv X)
   | [ |- match ?x with Some _ => _ | None => _ end = Some _ -> _ ] => destruct x eqn:?; mydestr
   | [ |- match ?x with true => _ | false => _ end = Some _ -> _ ] => destruct x eqn:?; mydestr
   | [ |- match ?x with left _ => _ | right _ => _ end = Some _ -> _ ] => destruct x; mydestr
@@ -2038,12 +2038,13 @@ Definition do_step (w: world) (s: state) : list transition :=
 
 Ltac myinv :=
   match goal with
-  | [ |- In _ nil -> _ ] => intro X; elim X
+  | [ |- In _ nil -> _ ] => let X := fresh in intro X; elim X
   | [ |- In _ (ret _ _) -> _ ] =>
-        intro X; elim X; clear X;
-        [intro EQ; unfold ret in EQ; inv EQ; myinv | myinv]
+        let X := fresh in intro X; elim X; clear X;
+        [let EQ := fresh in intro EQ; unfold ret in EQ; inv EQ; myinv | myinv]
   | [ |- In _ (_ :: nil) -> _ ] =>
-        intro X; elim X; clear X; [intro EQ; inv EQ; myinv | myinv]
+    let X := fresh in intro X; elim X; clear X;
+                      [let EQ := fresh in intro EQ; inv EQ; myinv | myinv]
   | [ |- In _ (match ?x with Some _ => _ | None => _ end) -> _ ] => destruct x eqn:?; myinv
   | [ |- In _ (match ?x with false => _ | true => _ end) -> _ ] => destruct x eqn:?; myinv
   | [ |- In _ (match ?x with left _ => _ | right _ => _ end) -> _ ] => destruct x; myinv

--- a/cfrontend/Cminorgenproof.v
+++ b/cfrontend/Cminorgenproof.v
@@ -20,7 +20,7 @@ Require Import AST Linking.
 Require Import Values Memory Events Globalenvs Smallstep.
 Require Import Csharpminor Switch Cminor Cminorgen.
 
-Open Local Scope error_monad_scope.
+Local Open Scope error_monad_scope.
 
 Definition match_prog (p: Csharpminor.program) (tp: Cminor.program) :=
   match_program (fun cu f tf => transl_fundef f = OK tf) eq p tp.

--- a/cfrontend/Cshmgen.v
+++ b/cfrontend/Cshmgen.v
@@ -24,8 +24,8 @@ Require Import Coqlib Maps Errors Integers Floats.
 Require Import AST Linking.
 Require Import Ctypes Cop Clight Cminor Csharpminor.
 
-Open Local Scope string_scope.
-Open Local Scope error_monad_scope.
+Local Open Scope string_scope.
+Local Open Scope error_monad_scope.
 
 (** * Csharpminor constructors *)
 

--- a/cfrontend/Ctypes.v
+++ b/cfrontend/Ctypes.v
@@ -1064,7 +1064,7 @@ Proof.
     destruct (complete_members env m) eqn:C; simplify_eq EQ. clear EQ; intros EQ.
     rewrite PTree.gsspec. intros [A|A]; auto.
     destruct (peq id id0); auto.
-    inv A. rewrite <- H1; auto.
+    inv A. rewrite <- H0; auto.
   }
   intros. exploit REC; eauto. rewrite PTree.gempty. intuition congruence.
 Qed.
@@ -1519,7 +1519,7 @@ Local Transparent Linker_program.
   - intros. exploit link_match_fundef; eauto. intros (tf & A & B). exists tf; auto.
   - intros.
     Local Transparent Linker_types.
-    simpl in *. destruct (type_eq v1 v2); inv H4. subst v tv2. exists tv1; rewrite dec_eq_true; auto.
+    simpl in *. destruct (type_eq v1 v2); inv H4. intros. exists v; rewrite dec_eq_true; auto.
   - eauto.
   - eauto.
   - eauto.

--- a/cfrontend/SimplExpr.v
+++ b/cfrontend/SimplExpr.v
@@ -38,8 +38,8 @@ Inductive result (A: Type) (g: generator) : Type :=
   | Err: Errors.errmsg -> result A g
   | Res: A -> forall (g': generator), Ple (gen_next g) (gen_next g') -> result A g.
 
-Implicit Arguments Err [A g].
-Implicit Arguments Res [A g].
+Arguments Err [A g].
+Arguments Res [A g].
 
 Definition mon (A: Type) := forall (g: generator), result A g.
 

--- a/configure
+++ b/configure
@@ -407,7 +407,7 @@ missingtools=false
 echo "Testing Coq... " | tr -d '\n'
 coq_ver=$(${COQBIN}coqc -v 2>/dev/null | sed -n -e 's/The Coq Proof Assistant, version \([^ ]*\).*$/\1/p')
 case "$coq_ver" in
-  8.5pl2|8.5pl3)
+  8.5pl2|8.5pl3|8.6beta1)
         echo "version $coq_ver -- good!";;
   ?.*)
         echo "version $coq_ver -- UNSUPPORTED"

--- a/cparser/validator/Automaton.v
+++ b/cparser/validator/Automaton.v
@@ -102,9 +102,9 @@ Module Types(Import Init:AutInit).
                  T term = last_symb_of_non_init_state s -> lookahead_action term
   | Reduce_act: production -> lookahead_action term
   | Fail_act: lookahead_action term.
-  Implicit Arguments Shift_act [term].
-  Implicit Arguments Reduce_act [term].
-  Implicit Arguments Fail_act [term].
+  Arguments Shift_act [term].
+  Arguments Reduce_act [term].
+  Arguments Fail_act [term].
 
   Inductive action :=
   | Default_reduce_act: production -> action

--- a/cparser/validator/Interpreter.v
+++ b/cparser/validator/Interpreter.v
@@ -26,8 +26,8 @@ Inductive result (A:Type) :=
   | Err: result A
   | OK: A -> result A.
 
-Implicit Arguments Err [A].
-Implicit Arguments OK [A].
+Arguments Err [A].
+Arguments OK [A].
 
 Definition bind {A B: Type} (f: result A) (g: A -> result B): result B :=
   match f with

--- a/driver/Clflags.ml
+++ b/driver/Clflags.ml
@@ -27,6 +27,7 @@ let option_ftailcalls = ref true
 let option_fconstprop = ref true
 let option_fcse = ref true
 let option_fredundancy = ref true
+let option_fepeg = ref false
 let option_falignfunctions = ref (None: int option)
 let option_falignbranchtargets = ref 0
 let option_faligncondbranchs = ref 0

--- a/driver/Compopts.v
+++ b/driver/Compopts.v
@@ -39,6 +39,9 @@ Parameter optim_CSE: unit -> bool.
 (** Flag -fredundancy.  For dead code elimination. *)
 Parameter optim_redundancy: unit -> bool.
 
+(** Flag -fepeg. For epeg based optimization. *)
+Parameter optim_epeg: unit -> bool.
+
 (** Flag -fthumb.  For the ARM back-end. *)
 Parameter thumb: unit -> bool.
 

--- a/driver/Driver.ml
+++ b/driver/Driver.ml
@@ -467,7 +467,7 @@ let cmdline_actions =
   @ f_opt "const-prop" option_fconstprop
   @ f_opt "cse" option_fcse
   @ f_opt "redundancy" option_fredundancy
-  @ f_opt "epeg" option_epeg
+  @ f_opt "epeg" option_fepeg
 (* Code generation options *)
   @ f_opt "fpu" option_ffpu
   @ f_opt "sse" option_ffpu (* backward compatibility *)

--- a/driver/Driver.ml
+++ b/driver/Driver.ml
@@ -303,6 +303,7 @@ Processing options:\n\
 \                   (<n>=0: none, <n>=1: limited, <n>=2: full; default is full)\n\
 \  -fcse          Perform common subexpression elimination [on]\n\
 \  -fredundancy   Perform redundancy elimination [on]\n\
+\  -fepeg         Perform equality saturation based optimization \n\
 Code generation options: (use -fno-<opt> to turn off -f<opt>)\n\
 \  -ffpu          Use FP registers for some integer operations [on]\n\
 \  -fsmall-data <n>  Set maximal size <n> for allocation in small data area\n\
@@ -466,6 +467,7 @@ let cmdline_actions =
   @ f_opt "const-prop" option_fconstprop
   @ f_opt "cse" option_fcse
   @ f_opt "redundancy" option_fredundancy
+  @ f_opt "epeg" option_epeg
 (* Code generation options *)
   @ f_opt "fpu" option_ffpu
   @ f_opt "sse" option_ffpu (* backward compatibility *)

--- a/extraction/extraction.v
+++ b/extraction/extraction.v
@@ -105,6 +105,8 @@ Extract Constant Compopts.thumb =>
   "fun _ -> !Clflags.option_mthumb".
 Extract Constant Compopts.debug =>
   "fun _ -> !Clflags.option_g".
+Extract Constant Compopts.optim_epeg =>
+  "fun _ -> !Clflags.option_fepeg".
 
 (* Compiler *)
 Extract Constant Compiler.print_Clight => "PrintClight.print_if".

--- a/flocq/Appli/Fappli_IEEE.v
+++ b/flocq/Appli/Fappli_IEEE.v
@@ -415,10 +415,9 @@ Theorem is_finite_Bopp :
   forall opp_nan x,
   is_finite (Bopp opp_nan x) = is_finite x.
 Proof.
-intros opp_nan [| | |] ; try easy.
-intros s pl.
-simpl.
-now case opp_nan.
+  intros opp_nan [| | |] ; try easy.
+  simpl.
+  now case opp_nan.
 Qed.
 
 (** Absolute value *)
@@ -446,7 +445,6 @@ Theorem is_finite_Babs :
   is_finite (Babs abs_nan x) = is_finite x.
 Proof.
   intros abs_nan [| | |] ; try easy.
-  intros s pl.
   simpl.
   now case abs_nan.
 Qed.

--- a/flocq/Appli/Fappli_IEEE.v
+++ b/flocq/Appli/Fappli_IEEE.v
@@ -46,7 +46,7 @@ End AnyRadix.
 
 Section Binary.
 
-Implicit Arguments exist [[A] [P]].
+Arguments exist {A} {P}.
 
 (** [prec] is the number of bits of the mantissa including the implicit one;
     [emax] is the exponent of the infinities.

--- a/flocq/Appli/Fappli_IEEE_bits.v
+++ b/flocq/Appli/Fappli_IEEE_bits.v
@@ -25,11 +25,11 @@ Require Import Fappli_IEEE.
 
 Section Binary_Bits.
 
-Implicit Arguments exist [[A] [P]].
-Implicit Arguments B754_zero [[prec] [emax]].
-Implicit Arguments B754_infinity [[prec] [emax]].
-Implicit Arguments B754_nan [[prec] [emax]].
-Implicit Arguments B754_finite [[prec] [emax]].
+Arguments exist {A} {P}.
+Arguments B754_zero {prec} {emax}.
+Arguments B754_infinity {prec} {emax}.
+Arguments B754_nan {prec} {emax}.
+Arguments B754_finite {prec} {emax}.
 
 (** Number of bits for the fraction and exponent *)
 Variable mw ew : Z.
@@ -604,7 +604,7 @@ End Binary_Bits.
 (** Specialization for IEEE single precision operations *)
 Section B32_Bits.
 
-Implicit Arguments B754_nan [[prec] [emax]].
+Arguments B754_nan {prec} {emax}.
 
 Definition binary32 := binary_float 24 128.
 
@@ -647,7 +647,7 @@ End B32_Bits.
 (** Specialization for IEEE double precision operations *)
 Section B64_Bits.
 
-Implicit Arguments B754_nan [[prec] [emax]].
+Arguments B754_nan {prec} {emax}.
 
 Definition binary64 := binary_float 53 1024.
 

--- a/flocq/Calc/Fcalc_ops.v
+++ b/flocq/Calc/Fcalc_ops.v
@@ -28,7 +28,7 @@ Variable beta : radix.
 
 Notation bpow e := (bpow beta e).
 
-Implicit Arguments Float [[beta]].
+Arguments Float {beta}.
 
 Definition Falign (f1 f2 : float beta) :=
   let '(Float m1 e1) := f1 in

--- a/flocq/Core/Fcore_defs.v
+++ b/flocq/Core/Fcore_defs.v
@@ -25,8 +25,8 @@ Section Def.
 (** Definition of a floating-point number *)
 Record float (beta : radix) := Float { Fnum : Z ; Fexp : Z }.
 
-Implicit Arguments Fnum [[beta]].
-Implicit Arguments Fexp [[beta]].
+Arguments Fnum {beta}.
+Arguments Fexp {beta}.
 
 Variable beta : radix.
 
@@ -46,9 +46,9 @@ Definition round_pred (P : R -> R -> Prop) :=
 
 End Def.
 
-Implicit Arguments Fnum [[beta]].
-Implicit Arguments Fexp [[beta]].
-Implicit Arguments F2R [[beta]].
+Arguments Fnum {beta}.
+Arguments Fexp {beta}.
+Arguments F2R {beta}.
 
 Section RND.
 

--- a/flocq/Core/Fcore_digits.v
+++ b/flocq/Core/Fcore_digits.v
@@ -854,7 +854,6 @@ intros n Zn.
 rewrite <- (Zdigits_abs n).
 assert (Hn: (0 < Zabs n)%Z).
 destruct n ; try easy.
-now elim Zn.
 destruct (Zabs n) as [|p|p] ; try easy ; clear.
 simpl.
 generalize 1%Z (radix_val beta) (refl_equal Lt : (0 < 1)%Z).

--- a/lib/Axioms.v
+++ b/lib/Axioms.v
@@ -39,10 +39,8 @@ Proof @FunctionalExtensionality.functional_extensionality.
   is an alias for [functional_extensionality]. *)
 
 Lemma extensionality:
-  forall (A B: Type) (f g : A -> B),  (forall x, f x = g x) -> f = g.
+  forall {A B: Type} (f g : A -> B),  (forall x, f x = g x) -> f = g.
 Proof @functional_extensionality.
-
-Implicit Arguments extensionality.
 
 (** * Proof irrelevance *)
 
@@ -50,4 +48,4 @@ Implicit Arguments extensionality.
 
 Axiom proof_irr: ClassicalFacts.proof_irrelevance.
 
-Implicit Arguments proof_irr.
+Arguments proof_irr [A].

--- a/lib/Lattice.v
+++ b/lib/Lattice.v
@@ -56,7 +56,7 @@ End SEMILATTICE.
 
 Module Type SEMILATTICE_WITH_TOP.
 
-  Include Type SEMILATTICE.
+  Include SEMILATTICE.
   Parameter top: t.
   Axiom ge_top: forall x, ge top x.
 

--- a/lib/Maps.v
+++ b/lib/Maps.v
@@ -190,8 +190,8 @@ Module PTree <: TREE.
     | Leaf : tree A
     | Node : tree A -> option A -> tree A -> tree A.
 
-  Implicit Arguments Leaf [A].
-  Implicit Arguments Node [A].
+  Arguments Leaf [A].
+  Arguments Node [A].
   Scheme tree_ind := Induction for tree Sort Prop.
 
   Definition t := tree.

--- a/x86/Asmgenproof1.v
+++ b/x86/Asmgenproof1.v
@@ -17,7 +17,7 @@ Require Import AST Errors Integers Floats Values Memory Globalenvs.
 Require Import Op Locations Conventions Mach Asm.
 Require Import Asmgen Asmgenproof0.
 
-Open Local Scope error_monad_scope.
+Local Open Scope error_monad_scope.
 
 (** * Correspondence between Mach registers and x86 registers *)
 

--- a/x86/SelectLongproof.v
+++ b/x86/SelectLongproof.v
@@ -19,8 +19,8 @@ Require Import Cminor Op CminorSel.
 Require Import SelectOp SelectOpproof SplitLong SplitLongproof.
 Require Import SelectLong.
 
-Open Local Scope cminorsel_scope.
-Open Local Scope string_scope.
+Local Open Scope cminorsel_scope.
+Local Open Scope string_scope.
 
 (** * Correctness of the instruction selection functions for 64-bit operators *)
 

--- a/x86/SelectOpproof.v
+++ b/x86/SelectOpproof.v
@@ -1,5 +1,5 @@
 (* *********************************************************************)
-(*                                                                     *)
+(*                                                                    *)
 (*              The Compcert verified compiler                         *)
 (*                                                                     *)
 (*          Xavier Leroy, INRIA Paris-Rocquencourt                     *)
@@ -24,7 +24,7 @@ Require Import Op.
 Require Import CminorSel.
 Require Import SelectOp.
 
-Open Local Scope cminorsel_scope.
+Local Open Scope cminorsel_scope.
 
 (** * Useful lemmas and tactics *)
 


### PR DESCRIPTION
Hello, I am trying to port compcert to 8.6. 
I need some help here, as I have a admit in backend/Deadcodeproof.v that I cant get rid off... 
Also, I havent test whether it work or not on 8.5 (but I'm pretty sure it dont, because some tactic are now 'stronger' and automatically do more, like backend/Unusedglobproof.v, and some name changes), so what could be done to keep the compatibility?