### PR TITLE
Revised elaboration of attributes

### DIFF
--- a/cfrontend/C2C.ml
+++ b/cfrontend/C2C.ml
@@ -267,6 +267,19 @@ let builtins =
   { typedefs = builtins_generic.typedefs @ CBuiltins.builtins.typedefs;
     functions = builtins_generic.functions @ CBuiltins.builtins.functions }
 
+(** ** The known attributes *)
+
+let attributes = [
+  (* type-related *)
+  ("aligned", Cutil.Attr_type);
+  (* struct-related *)
+  ("packed", Cutil.Attr_struct);
+  (* function-related (currently none) *)
+  (* name-related *)
+  ("section", Cutil.Attr_name)
+]
+  
+
 (** ** Functions used to handle string literals *)
 
 let stringNum = ref 0   (* number of next global for string literals *)

--- a/cfrontend/C2C.ml
+++ b/cfrontend/C2C.ml
@@ -274,7 +274,8 @@ let attributes = [
   ("aligned", Cutil.Attr_type);
   (* struct-related *)
   ("packed", Cutil.Attr_struct);
-  (* function-related (currently none) *)
+  (* function-related *)
+  ("noreturn", Cutil.Attr_function);
   (* name-related *)
   ("section", Cutil.Attr_name)
 ]

--- a/cfrontend/C2C.ml
+++ b/cfrontend/C2C.ml
@@ -1098,7 +1098,7 @@ let convertFundef loc env fd =
   Hashtbl.add decl_atom id'
     { a_storage = fd.fd_storage;
       a_alignment = None;
-      a_sections = Sections.for_function env id' fd.fd_ret;
+      a_sections = Sections.for_function env id' fd.fd_attrib;
       a_access = Sections.Access_default;
       a_inline = fd.fd_inline && not fd.fd_vararg;  (* PR#15 *)
       a_loc = loc };

--- a/common/Sections.ml
+++ b/common/Sections.ml
@@ -189,8 +189,7 @@ let for_variable env id ty init =
 
 (* Determine sections for a function definition *)
 
-let for_function env id ty_res =
-  let attr = Cutil.attributes_of_type env ty_res in
+let for_function env id attr =
   let si_code =
     try
       (* 1- Section explicitly associated with #use_section *)

--- a/common/Sections.mli
+++ b/common/Sections.mli
@@ -47,5 +47,5 @@ val use_section_for: AST.ident -> string -> bool
 
 val for_variable: Env.t -> AST.ident -> C.typ -> bool ->
                                           section_name * access_mode
-val for_function: Env.t -> AST.ident -> C.typ -> section_name list
+val for_function: Env.t -> AST.ident -> C.attributes -> section_name list
 val for_stringlit: unit -> section_name

--- a/cparser/Cprint.ml
+++ b/cparser/Cprint.ml
@@ -142,13 +142,14 @@ let rec dcl ?(pp_indication=true) pp ty n =
       dcl pp t n'
   | TArray(t, sz, a) ->
       let n' pp =
+        n pp;
         begin match a with
-        | [] -> n pp
-        | _  -> fprintf pp " (%a%t)" attributes a n
+        | [] -> fprintf pp "["
+        | _  -> fprintf pp "[%a " attributes a
         end;
         begin match sz with
-        | None -> fprintf pp "[]"
-        | Some i -> fprintf pp "[%Ld]" i
+        | None -> fprintf pp "]"
+        | Some i -> fprintf pp "%Ld]" i
         end in
       dcl pp t n'
   | TFun(tres, args, vararg, a) ->

--- a/cparser/Cprint.ml
+++ b/cparser/Cprint.ml
@@ -156,10 +156,8 @@ let rec dcl ?(pp_indication=true) pp ty n =
         dcl pp ty
           (fun pp -> fprintf pp " %a" ident id) in
       let n' pp =
-        begin match a with
-        | [] -> n pp
-        | _  -> fprintf pp " (%a%t)" attributes a n
-        end;
+        attributes pp a;
+        n pp;
         fprintf pp "(";
         if pp_indication then fprintf pp "@[<hov 0>";
         begin match args with

--- a/cparser/Cutil.ml
+++ b/cparser/Cutil.ml
@@ -92,6 +92,12 @@ let attr_is_standard = function
 (* Is an attribute type-related (true) or variable-related (false)? *)
 
 let attr_is_type_related = function
+  | AConst | AVolatile | ARestrict | AAlignas _ -> true
+  | Attr(_, _) -> false
+
+(* Is an attribute related to structs, unions and enum (true) or not (false)? *)
+
+let attr_is_struct_related = function
   | Attr(("packed" | "__packed__"), _) -> true
   | _ -> false
 

--- a/cparser/Cutil.mli
+++ b/cparser/Cutil.mli
@@ -54,6 +54,8 @@ val change_attributes_type : Env.t -> (attributes -> attributes) -> typ -> typ
   (* Apply the given function to the top-level attributes of the given type *)
 val attr_is_type_related: attribute -> bool
   (* Is an attribute type-related (true) or variable-related (false)? *)
+val attr_is_struct_related: attribute -> bool
+  (* Is an attribute related to structs, unions and enum (true) or not (false)? *)
 val attr_inherited_by_members: attribute -> bool
   (* Is an attribute of a composite inherited by members of the composite? *)
 val strip_attributes_type: typ -> attribute list -> typ

--- a/cparser/Cutil.mli
+++ b/cparser/Cutil.mli
@@ -52,16 +52,31 @@ val erase_attributes_type : Env.t -> typ -> typ
   (* Erase the attributes of the given type. *)
 val change_attributes_type : Env.t -> (attributes -> attributes) -> typ -> typ
   (* Apply the given function to the top-level attributes of the given type *)
-val attr_is_type_related: attribute -> bool
-  (* Is an attribute type-related (true) or variable-related (false)? *)
-val attr_is_struct_related: attribute -> bool
-  (* Is an attribute related to structs, unions and enum (true) or not (false)? *)
+
+type attribute_class =
+  | Attr_name           (* Attribute applies to the names being declared  *)
+  | Attr_type           (* Attribute applies to types *)
+  | Attr_struct         (* Attribute applies to struct, union and enum *)
+  | Attr_function       (* Attribute applies to function types and decls *)
+  | Attr_unknown        (* Not a declared attribute *)
+
+val declare_attribute: string -> attribute_class -> unit
+val declare_attributes: (string * attribute_class) list -> unit
+  (* Register the given custom attribute names with the given classes. *)
+val class_of_attribute: attribute -> attribute_class
+  (* Return the class of the given attribute.  Standard attributes
+     have class [Attr_type].  Custom attributes have the class that
+     was given to them using [declare_attribute], or [Attr_unknown]
+     if not declared. *)
 val attr_inherited_by_members: attribute -> bool
   (* Is an attribute of a composite inherited by members of the composite? *)
+
+
 val strip_attributes_type: typ -> attribute list -> typ
   (* Remove all attributes from the given type that are not contained in the list *)
 val strip_last_attribute: typ -> attribute option * typ
   (* Remove the last top level attribute and return it *)
+
 
 (* Type compatibility *)
 

--- a/cparser/Elab.ml
+++ b/cparser/Elab.ml
@@ -481,8 +481,10 @@ let typespec_order t1 t2 = compare (typespec_rank t1) (typespec_rank t2)
    attributes from the given type and return those attributes separately. *)
 
 let get_nontype_attrs env ty =
-  let (ta, nta) = List.partition attr_is_type_related (attributes_of_type env ty) in
-  (change_attributes_type env (fun _ -> ta) ty, nta)
+  let nta =
+    List.filter (fun a -> not (attr_is_type_related a))
+                (attributes_of_type env ty) in
+  (remove_attributes_type env nta ty, nta)
 
 (* Is a specifier an anonymous struct/union in the sense of ISO C2011? *)
 

--- a/cparser/GCC.ml
+++ b/cparser/GCC.ml
@@ -13,7 +13,7 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-(* GCC built-ins *)
+(* GCC built-ins and attributes *)
 
 open C
 open Cutil
@@ -221,3 +221,25 @@ let builtins = {
   "__builtin_va_copy",  (voidType, [ voidPtrType; voidPtrType ], false)
 ]
 }
+
+let attributes = [ (* a subset of those of GCC 5 *)
+  (* type-related *)
+  ("aligned", Attr_type); ("may_alias", Attr_type); ("visibility", Attr_type);
+  (* struct-related *)
+  ("packed", Attr_struct); ("designated_init", Attr_struct);
+  (* function-related *)
+  ("cdecl", Attr_function); ("stdcall", Attr_function);
+  ("fastcall", Attr_function); ("thiscall", Attr_function);
+  ("const", Attr_function); ("noreturn", Attr_name);
+  (* name-related *)
+  ("cleanup", Attr_name); ("common", Attr_name); ("nocommon", Attr_name);
+  ("deprecated", Attr_name); ("section", Attr_name);
+  ("shared", Attr_name); ("tls_model", Attr_name); ("unused", Attr_name);
+  ("used", Attr_name); ("weak", Attr_name);
+  ("dllimport", Attr_name); ("dllexport", Attr_name);
+  ("alway_inline", Attr_name); ("gnu_inline", Attr_name);
+  ("artificial", Attr_name); ("flatten", Attr_name);
+  ("error", Attr_name); ("warning", Attr_name);
+  ("constructor", Attr_name); ("destructor", Attr_name);
+  ("externally_visible", Attr_name); ("interrupt", Attr_name)
+]

--- a/cparser/GCC.mli
+++ b/cparser/GCC.mli
@@ -13,6 +13,7 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-(* GCC built-ins *)
+(* GCC built-ins and attributes *)
 
 val builtins: Builtins.t
+val attributes: (string * Cutil.attribute_class) list

--- a/driver/Driver.ml
+++ b/driver/Driver.ml
@@ -540,6 +540,7 @@ let _ =
       | _         -> assert false
       end;
     Builtins.set C2C.builtins;
+    Cutil.declare_attributes C2C.attributes;
     CPragmas.initialize();
     parse_cmdline cmdline_actions;
     DebugInit.init (); (* Initialize the debug functions *)

--- a/test/regression/attribs1.c
+++ b/test/regression/attribs1.c
@@ -24,7 +24,7 @@ __attribute((__section__("myconst"))) const int e = 12;
 const char filler4 = 1;
 __attribute((__section__("myconst"))) const int f = 34;
 
-__attribute((__section__("mycode"))) int myfunc(int x) { return x + 1; }
+__attribute((__section__("mycode"))) int * myfunc(int * x) { return x + 1; }
 
 /* Alignment with typedefs and structs */
 


### PR DESCRIPTION
[This is work in progress and this pull request is intended for discussion.  Do not merge yet. ]

The treatment of attributes in the current CompCert is often surprising.  For example,
```
   attribute(XXX) char * x;
```
is parsed as "x is a pointer to a (char modified by attribute XXX)", while for most attributes (e.g. section attributes) the expected meaning is "x, modified by attribute XXX, has type pointer to char".

CompCert's current treatment comes from the fact that attributes are processed very much like the standard type modifiers `const` and `volatile`, i.e.
```
   const char * x;
```
is really "x is a pointer to a const char", not "x is a const pointer to char".

This experiment introduces a distinction between type-related attributes (which include the standard modifiers `const` and `volatile`) and other attributes.  The other, non-type-related attributes are "floated up" during elaboration so that they apply to the variable or function being declared or defined.  In the examples above,
```
   attribute(XXX) char * x;    // "attribute(XXX)" applies to "x"
   const char * x;             // "const" applies to "char"
```
This may be a step in the right direction but is not the final story.  In particular, the `packed` attribute is special-cased when applied to `struct`, like it was before, and future attributes concerning calling conventions would need to be floated up to function types but not higher than that.