### PR TITLE
Introduced configuration variable for gnu systems.

### DIFF
--- a/debug/DebugInit.ml
+++ b/debug/DebugInit.ml
@@ -13,19 +13,18 @@
 open Clflags
 open Commandline
 open Debug
-open Driveraux
 
 
 let init_debug () =
   implem :=
-  if Configuration.system = "diab" then
+  if Configuration.gnu_toolchain then
+    {DebugInformation.default_debug with generate_debug_info = (fun a b -> Some (Dwarfgen.gen_gnu_debug_info a b));
+     add_fun_addr = DebugInformation.gnu_add_fun_addr}
+  else
     let gen = (fun a b -> Some (Dwarfgen.gen_diab_debug_info a b)) in
     {DebugInformation.default_debug with generate_debug_info = gen;
      add_diab_info = DebugInformation.add_diab_info;
      add_fun_addr = DebugInformation.diab_add_fun_addr;}
-  else
-    {DebugInformation.default_debug with generate_debug_info = (fun a b -> Some (Dwarfgen.gen_gnu_debug_info a b));
-     add_fun_addr = DebugInformation.gnu_add_fun_addr}
 
 let init_none () =
   implem := default_implem
@@ -46,7 +45,7 @@ let debugging_help =
                  (<n>=0: none, <n>=1: only-globals, <n>=2: globals + locals
                  without locations, <n>=3: full;)
 |}
-^ (if gnu_system then gnu_debugging_help else "")
+^ (if Configuration.gnu_toolchain then gnu_debugging_help else "")
 
 let gnu_debugging_actions =
   let version version () =
@@ -67,4 +66,4 @@ let debugging_actions =
    Exact "-g2", Unit (depth 2);
    Exact "-g3", Unit (depth 3);]
   @
-  (if gnu_system then gnu_debugging_actions else [])
+  (if Configuration.gnu_toolchain then gnu_debugging_actions else [])

--- a/driver/Assembler.ml
+++ b/driver/Assembler.ml
@@ -32,11 +32,11 @@ let assemble ifile ofile =
   end
 
 let assembler_actions =
- [ Prefix "-Wa,", Self (fun s -> if gnu_system then
+ [ Prefix "-Wa,", Self (fun s -> if Configuration.gnu_toolchain then
     assembler_options := s :: !assembler_options
   else
     assembler_options := List.rev_append (explode_comma_option s) !assembler_options);
-  Exact "-Xassembler", String (fun s -> if gnu_system then
+  Exact "-Xassembler", String (fun s -> if Configuration.gnu_toolchain then
     assembler_options := s::"-Xassembler":: !assembler_options
   else
     assembler_options := s::!assembler_options );]

--- a/driver/Configuration.ml
+++ b/driver/Configuration.ml
@@ -115,6 +115,12 @@ let asm =
 let linker =
   tool_absolute_path (get_config_list "linker")@(opt_config_list "linker_options")
 
+let get_bool_config key =
+  match get_config_string key with
+  | "true" -> true
+  | "false" -> false
+  | v -> bad_config key [v]
+
 let arch =
   match get_config_string "arch" with
   | "powerpc"|"arm"|"x86" as a -> a
@@ -127,27 +133,15 @@ let is_big_endian =
   | "little" -> false
   | v -> bad_config "endianness" [v]
 let system = get_config_string "system"
-let has_runtime_lib =
-  match get_config_string "has_runtime_lib" with
-  | "true" -> true
-  | "false" -> false
-  | v -> bad_config "has_runtime_lib" [v]
-let has_standard_headers =
-  match get_config_string "has_standard_headers" with
-  | "true" -> true
-  | "false" -> false
-  | v -> bad_config "has_standard_headers" [v]
+let has_runtime_lib = get_bool_config "has_runtime_lib"
+let has_standard_headers = get_bool_config "has_standard_headers"
 let stdlib_path =
   if has_runtime_lib then
     let path = get_config_string "stdlib_path" in
     absolute_path ini_dir path
   else
     ""
-let asm_supports_cfi =
-  match get_config_string "asm_supports_cfi" with
-  | "true" -> true
-  | "false" -> false
-  | v -> bad_config "asm_supports_cfi" [v]
+let asm_supports_cfi = get_bool_config "asm_supports_cfi"
 
 
 type struct_passing_style =
@@ -188,3 +182,5 @@ let response_file_style =
   | "gnu" -> Gnu
   | "diab" -> Diab
   | v -> bad_config "response_file_style" [v]
+
+let gnu_toolchain = system <> "diab"

--- a/driver/Configuration.mli
+++ b/driver/Configuration.mli
@@ -74,3 +74,6 @@ type response_file_style =
 
 val response_file_style: response_file_style
   (** Style of supported responsefiles *)
+
+val gnu_toolchain: bool
+  (** Does the targeted system use the gnu toolchain *)

--- a/driver/Driveraux.ml
+++ b/driver/Driveraux.ml
@@ -14,9 +14,6 @@
 open Printf
 open Clflags
 
-(* Is this a gnu based tool chain *)
-let gnu_system = Configuration.system <> "diab"
-
 (* Safe removal of files *)
 let safe_remove file =
   try Sys.remove file with Sys_error _ -> ()

--- a/driver/Driveraux.mli
+++ b/driver/Driveraux.mli
@@ -36,9 +36,6 @@ val ensure_inputfile_exists: string -> unit
 val print_error:out_channel -> Errors.errcode list -> unit
    (** Printing of error messages *)
 
-val gnu_system: bool
-   (** Are the target tools gnu tools? *)
-
 val explode_comma_option: string -> string list
    (** Split option at commas *)
 

--- a/driver/Frontend.ml
+++ b/driver/Frontend.ml
@@ -125,7 +125,7 @@ let prepro_actions = [
   Exact "-Xpreprocessor", String (fun s ->
     prepro_options := s :: !prepro_options);
   Exact "-include", String (fun s -> prepro_options := s :: "-include" :: !prepro_options);]
-  @ (if gnu_system then gnu_prepro_actions else [])
+  @ (if Configuration.gnu_toolchain then gnu_prepro_actions else [])
 
 let gnu_prepro_help =
 {|  -M            Ouput a rule suitable for make describing the
@@ -163,4 +163,4 @@ let prepro_help = {|Preprocessing options:
   -Wp,<opt>      Pass option <opt> to the preprocessor
   -Xpreprocessor <opt> Pass option <opt> to the preprocessor
 |}
-  ^ (if gnu_system then gnu_prepro_help else "")
+  ^ (if Configuration.gnu_toolchain then gnu_prepro_help else "")

--- a/driver/Linker.ml
+++ b/driver/Linker.ml
@@ -48,7 +48,7 @@ let linker_help =
   -l<lib>        Link library <lib>
   -L<dir>        Add <dir> to search path for libraries
 |} ^
- (if gnu_system then gnu_linker_help else "") ^
+ (if Configuration.gnu_toolchain then gnu_linker_help else "") ^
 {|  -s             Remove all symbol table and relocation information from the
                  executable
   -static        Prevent linking with the shared libraries
@@ -63,14 +63,14 @@ let linker_help =
 let linker_actions =
   [ Prefix "-l", Self push_linker_arg;
     Prefix "-L", Self push_linker_arg; ] @
-  (if gnu_system then
+  (if Configuration.gnu_toolchain then
     [ Exact "-nostartfiles", Self push_linker_arg;
       Exact "-nodefaultlibs", Self push_linker_arg;
       Exact "-nostdlib", Self push_linker_arg;]
   else []) @
   [ Exact "-s", Self push_linker_arg;
     Exact "-static", Self push_linker_arg;
-    Exact "-T", String (fun s -> if gnu_system then begin
+    Exact "-T", String (fun s -> if Configuration.gnu_toolchain then begin
       push_linker_arg ("-T");
       push_linker_arg(s)
     end else


### PR DESCRIPTION
The variable gnu_toolchain is true if a gnu toolchain is used and
false in all other cases. The variable avoids the explicit test
whether the system string is diab and should be easier to change.

Separated changes from #158 for easier review.