### PR TITLE
Handle dcompcertc and dparsedc like all dump opts

### DIFF
--- a/driver/Driver.ml
+++ b/driver/Driver.ml
@@ -43,6 +43,8 @@ let compile_c_ast sourcename csyntax ofile =
   let set_dest dst opt ext =
     dst := if !opt then Some (output_filename sourcename ".c" ext)
                    else None in
+  set_dest dparse_destination option_dparse ".parsed.c";
+  set_dest dcompcertc_destination option_dcmedium ".compcert.c";
   set_dest PrintClight.destination option_dclight ".light.c";
   set_dest PrintCminor.destination option_dcminor ".cm";
   set_dest PrintRTL.destination option_drtl ".rtl";

--- a/driver/Frontend.mli
+++ b/driver/Frontend.mli
@@ -11,6 +11,12 @@
 (*                                                                     *)
 (* *********************************************************************)
 
+val dparse_destination: string option ref
+  (** Destination file for parsed c file dump *)
+
+val dcompcertc_destination: string option ref
+  (** Destination file for CompCert C file dump *)
+
 val preprocess: string -> string -> unit
   (** From C to preprocessed C *)
 


### PR DESCRIPTION
The dcompcert and dparsedc option now also set a variable for the
dump file instead of being handled by looking at the clflag.

Another part of PR #158 .