### PR TITLE
Moved file functions in own file.

### DIFF
--- a/driver/Assembler.ml
+++ b/driver/Assembler.ml
@@ -26,7 +26,7 @@ let assemble ifile ofile =
   ] in
   let exc = command cmd in
   if exc <> 0 then begin
-    safe_remove ofile;
+    File.safe_remove ofile;
     command_error "assembler" exc;
     exit 2
   end

--- a/driver/Driver.ml
+++ b/driver/Driver.ml
@@ -57,8 +57,8 @@ let compile_c_ast sourcename csyntax ofile =
     | Errors.OK asm ->
         asm
     | Errors.Error msg ->
-        eprintf "%s: %a" sourcename print_error msg;
-        exit 2 in
+      print_errorcodes sourcename msg
+  in
   (* Dump Asm in binary and JSON format *)
   if !option_sdump then begin
     let sf = output_filename sourcename ".c" !sdump_suffix in
@@ -113,8 +113,8 @@ let compile_cminor_file ifile ofile =
     | Errors.OK asm ->
         asm
     | Errors.Error msg ->
-        eprintf "%s: %a" ifile print_error msg;
-        exit 2 in
+      print_errorcodes ifile msg
+  in
   (* Print Asm in text form *)
   let oc = open_out ofile in
   PrintAsm.print_program oc asm;
@@ -125,39 +125,32 @@ let compile_cminor_file ifile ofile =
 let process_c_file sourcename =
   ensure_inputfile_exists sourcename;
   if !option_E then begin
-    preprocess sourcename (output_filename_default "-");
+    preprocess sourcename (File.output_filename_default "-");
     ""
   end else begin
     let preproname = if !option_dprepro then
       output_filename sourcename ".c" ".i"
     else
-      Filename.temp_file "compcert" ".i" in
+      File.temp_file ".i" in
     preprocess sourcename preproname;
     let name =
       if !option_interp then begin
         Machine.config := Machine.compcert_interpreter !Machine.config;
         let csyntax = parse_c_file sourcename preproname in
-        if not !option_dprepro then
-          safe_remove preproname;
        Interp.execute csyntax;
         ""
       end else if !option_S then begin
         compile_c_file sourcename preproname
           (output_filename ~final:true sourcename ".c" ".s");
-        if not !option_dprepro then
-          safe_remove preproname;
         ""
       end else begin
         let asmname =
           if !option_dasm
           then output_filename sourcename ".c" ".s"
-          else Filename.temp_file "compcert" ".s" in
+          else File.temp_file ".s" in
         compile_c_file sourcename preproname asmname;
-        if not !option_dprepro then
-          safe_remove preproname;
         let objname = output_filename ~final: !option_c sourcename ".c" ".o" in
         assemble asmname objname;
-        if not !option_dasm then safe_remove asmname;
         objname
       end in
     if !dump_options then
@@ -183,11 +176,10 @@ let process_i_file sourcename =
     let asmname =
       if !option_dasm
       then output_filename sourcename ".c" ".s"
-      else Filename.temp_file "compcert" ".s" in
+      else File.temp_file ".s" in
     compile_c_file sourcename sourcename asmname;
     let objname = output_filename ~final: !option_c sourcename ".c" ".o" in
     assemble asmname objname;
-    if not !option_dasm then safe_remove asmname;
     if !dump_options then
       Optionsprinter.print (output_filename sourcename ".c" ".opt.json") !stdlib_path;
     objname
@@ -205,11 +197,10 @@ let process_cminor_file sourcename =
     let asmname =
       if !option_dasm
       then output_filename sourcename ".cm" ".s"
-      else Filename.temp_file "compcert" ".s" in
+      else File.temp_file ".s" in
     compile_cminor_file sourcename asmname;
     let objname = output_filename ~final: !option_c sourcename ".cm" ".o" in
     assemble asmname objname;
-    if not !option_dasm then safe_remove asmname;
     if !dump_options then
       Optionsprinter.print (output_filename sourcename ".cm" ".opt.json") !stdlib_path;
     objname
@@ -226,14 +217,13 @@ let process_s_file sourcename =
 let process_S_file sourcename =
   ensure_inputfile_exists sourcename;
   if !option_E then begin
-    preprocess sourcename (output_filename_default "-");
+    preprocess sourcename (File.output_filename_default "-");
     ""
   end else begin
-    let preproname = Filename.temp_file "compcert" ".s" in
+    let preproname = File.temp_file ".s" in
     preprocess sourcename preproname;
     let objname = output_filename ~final: !option_c sourcename ".S" ".o" in
     assemble preproname objname;
-    safe_remove preproname;
     objname
   end
 
@@ -242,7 +232,7 @@ let process_S_file sourcename =
 let process_h_file sourcename =
   if !option_E then begin
     ensure_inputfile_exists sourcename;
-    preprocess sourcename (output_filename_default "-");
+    preprocess sourcename (File.output_filename_default "-");
     ""
   end else begin
     eprintf "Error: input file %s ignored (not in -E mode)\n" sourcename;
@@ -556,7 +546,7 @@ let _ =
       end;
     let linker_args = time "Total compilation time" perform_actions () in
     if (not nolink) && linker_args <> [] then begin
-      linker (output_filename_default "a.out") linker_args
+      linker (File.output_filename_default "a.out") linker_args
     end;
    if  Cerrors.check_errors () then exit 2
   with Sys_error msg ->

--- a/driver/Driveraux.ml
+++ b/driver/Driveraux.ml
@@ -93,13 +93,6 @@ let output_filename ?(final = false) source_file source_suffix output_suffix =
     Filename.basename (Filename.chop_suffix source_file source_suffix)
     ^ output_suffix
 
-(* A variant of [output_filename] where the default output name is fixed *)
-
-let output_filename_default default_file =
-  match !option_o with
-  | Some file -> file
-  | None -> default_file
-
 (* All input files should exist *)
 
 let ensure_inputfile_exists name =
@@ -109,14 +102,14 @@ let ensure_inputfile_exists name =
   end
 (* Printing of error messages *)
 
-let print_error oc msg =
-  let print_one_error = function
+let print_errorcodes file msg =
+  let print_one_error oc = function
   | Errors.MSG s -> output_string oc (Camlcoq.camlstring_of_coqstring s)
   | Errors.CTX i -> output_string oc (Camlcoq.extern_atom i)
   | Errors.POS i -> fprintf oc "%ld" (Camlcoq.P.to_int32 i)
   in
-    List.iter print_one_error msg;
-    output_char oc '\n'
+  eprintf "%s: %a\n" file (fun oc msg -> List.iter (print_one_error oc) msg) msg;
+  exit 2
 
 (* Command-line parsing *)
 let explode_comma_option s =
@@ -125,17 +118,23 @@ let explode_comma_option s =
   | _ :: tl -> tl
 
 (* Record actions to be performed after parsing the command line *)
+type action =
+  | File_action of ((string -> string) * string)
+  | Linker_action of string
 
-let actions : ((string -> string) * string) list ref = ref []
+let actions : action list ref = ref []
 
 let push_action fn arg =
-  actions := (fn, arg) :: !actions
+  actions := File_action(fn, arg) :: !actions
 
 let push_linker_arg arg =
-  push_action (fun s -> s) arg
+  actions := Linker_action arg :: !actions
 
 let perform_actions () =
   let rec perform = function
   | [] -> []
-  | (fn, arg) :: rem -> let res = fn arg in res :: perform rem
+  | act :: rem -> let res = action act in res :: perform rem
+  and action = function
+    | File_action (f,s) -> f s
+    | Linker_action s -> s
   in perform (List.rev !actions)

--- a/driver/Driveraux.mli
+++ b/driver/Driveraux.mli
@@ -19,21 +19,15 @@ val command: ?stdout:string -> string list -> int
 val command_error: string -> int -> unit
    (** Generate an error message for the given command and exit code *)
 
-val safe_remove: string -> unit
-   (** Remove the given file if it exists *)
-
 val output_filename: ?final:bool -> string -> string -> string -> string
    (** Determine names for output files.  We use -o option if specified
        and if this is the final destination file (not a dump file).
        Otherwise, we generate a file in the current directory. *)
 
-val output_filename_default: string -> string
-   (** Return either the file specified by -o or the given file name *)
-
 val ensure_inputfile_exists: string -> unit
    (** Test whether the given input file exists *)
 
-val print_error:out_channel -> Errors.errcode list -> unit
+val print_errorcodes: string -> Errors.errcode list -> 'a
    (** Printing of error messages *)
 
 val gnu_system: bool

--- a/driver/Frontend.ml
+++ b/driver/Frontend.ml
@@ -35,7 +35,7 @@ let preprocess ifile ofile =
   ] in
   let exc = command ?stdout:output cmd in
   if exc <> 0 then begin
-    if ofile <> "-" then safe_remove ofile;
+    if ofile <> "-" then File.safe_remove ofile;
     command_error "preprocessor" exc;
     eprintf "Error during preprocessing.\n";
     exit 2

--- a/exportclight/Clightgen.ml
+++ b/exportclight/Clightgen.ml
@@ -32,12 +32,11 @@ let compile_c_ast sourcename csyntax ofile =
         begin match SimplLocals.transf_program p with
         | Errors.OK p' -> p'
         | Errors.Error msg ->
-            print_error stderr msg;
-            exit 2
+          print_errorcodes sourcename msg
         end
     | Errors.Error msg ->
-        print_error stderr msg;
-        exit 2 in
+      print_errorcodes sourcename msg
+  in
   (* Dump Clight in C syntax if requested *)
   if !option_dclight then begin
     let ofile = Filename.chop_suffix sourcename ".c" ^ ".light.c" in

--- a/lib/File.ml
+++ b/lib/File.ml
@@ -1,0 +1,68 @@
+(* *********************************************************************)
+(*                                                                     *)
+(*              The Compcert verified compiler                         *)
+(*                                                                     *)
+(*          Xavier Leroy, INRIA Paris-Rocquencourt                     *)
+(*      Bernhard Schommer, AbsInt Angewandte Informatik GmbH           *)
+(*                                                                     *)
+(*  Copyright Institut National de Recherche en Informatique et en     *)
+(*  Automatique.  All rights reserved.  This file is distributed       *)
+(*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+(*                                                                     *)
+(* *********************************************************************)
+
+
+open Printf
+open Clflags
+
+(* Type for input file *)
+type input_file =
+  {
+    name : string;
+    suffix: string;
+  }
+
+(* Create a new input file and ensure it's existence *)
+let new_input_file file suffix =
+  if not (Sys.file_exists file) then begin
+    eprintf "error: no such file or directory: '%s'\n" file;
+    exit 2
+  end;
+  {
+    name = file;
+    suffix = suffix;
+  }
+
+(* Get the name of the input file *)
+let input_name file = file.name
+
+(* Get the input channel from the input file *)
+let open_input_file file =
+  open_in_bin file.name
+
+(* Safe removal of files *)
+let safe_remove file =
+  try Sys.remove file with Sys_error _ -> ()
+
+(* Generate a temporary file with the given suffix that is removed on exit *)
+let temp_file suffix =
+  let file = Filename.temp_file "compcert" suffix in
+  at_exit (fun () -> safe_remove file);
+  file
+
+(* Determine names for output files.  We use -o option if specified
+   and if this is the final destination file (not a dump file).
+   Otherwise, we generate a file in the current directory. *)
+let output_filename ?(final = false) source_file output_suffix =
+  match !option_o with
+  | Some file when final -> file
+  | _ ->
+    Filename.basename (Filename.chop_suffix source_file.name source_file.suffix)
+    ^ output_suffix
+
+(* A variant of [output_filename] where the default output name is fixed *)
+
+let output_filename_default default_file =
+  match !option_o with
+  | Some file -> file
+  | None -> default_file

--- a/lib/File.mli
+++ b/lib/File.mli
@@ -1,0 +1,38 @@
+(* *********************************************************************)
+(*                                                                     *)
+(*              The Compcert verified compiler                         *)
+(*                                                                     *)
+(*          Xavier Leroy, INRIA Paris-Rocquencourt                     *)
+(*      Bernhard Schommer, AbsInt Angewandte Informatik GmbH           *)
+(*                                                                     *)
+(*  Copyright Institut National de Recherche en Informatique et en     *)
+(*  Automatique.  All rights reserved.  This file is distributed       *)
+(*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+(*                                                                     *)
+(* *********************************************************************)
+
+val safe_remove: string -> unit
+   (** Remove the given file if it exists *)
+
+val temp_file: string -> string
+    (** Generate a temporary file wiht the given suffix that is removed on exit *)
+
+val output_filename_default: string -> string
+   (** Return either the file specified by -o or the given file name *)
+
+type input_file
+   (** Type for input files *)
+
+val input_name : input_file -> string
+   (** Return the name of the input file *)
+
+val new_input_file : string -> string -> input_file
+   (** Return a new input_file from a given file with extension *)
+
+val open_input_file : input_file -> in_channel
+  (** Open an in_channel from the input file *)
+
+val output_filename: ?final:bool -> input_file -> string -> string
+   (** Determine names for output files.  We use -o option if specified
+       and if this is the final destination file (not a dump file).
+       Otherwise, we generate a file in the current directory. *)


### PR DESCRIPTION
The file functions are moved into an own library file. The
temp_file function now registers a delete function at exit. This
avoids the double check for temp files in driver.

Currently unused is the input_file type and functions since most
functions using this are affected by the other changes in PR #158
and changing them would result in doubled work.

Another prequisite for the option pipe PR #158