### PR TITLE
Moved file functions in own file. [Rebase of #169]

### DIFF
--- a/driver/Assembler.ml
+++ b/driver/Assembler.ml
@@ -26,7 +26,7 @@ let assemble ifile ofile =
   ] in
   let exc = command cmd in
   if exc <> 0 then begin
-    safe_remove ofile;
+    File.safe_remove ofile;
     command_error "assembler" exc;
     exit 2
   end

--- a/driver/Driveraux.mli
+++ b/driver/Driveraux.mli
@@ -19,21 +19,15 @@ val command: ?stdout:string -> string list -> int
 val command_error: string -> int -> unit
    (** Generate an error message for the given command and exit code *)
 
-val safe_remove: string -> unit
-   (** Remove the given file if it exists *)
-
 val output_filename: ?final:bool -> string -> string -> string -> string
    (** Determine names for output files.  We use -o option if specified
        and if this is the final destination file (not a dump file).
        Otherwise, we generate a file in the current directory. *)
 
-val output_filename_default: string -> string
-   (** Return either the file specified by -o or the given file name *)
-
 val ensure_inputfile_exists: string -> unit
    (** Test whether the given input file exists *)
 
-val print_error:out_channel -> Errors.errcode list -> unit
+val print_errorcodes: string -> Errors.errcode list -> 'a
    (** Printing of error messages *)
 
 val explode_comma_option: string -> string list

--- a/driver/Frontend.ml
+++ b/driver/Frontend.ml
@@ -35,7 +35,7 @@ let preprocess ifile ofile =
   ] in
   let exc = command ?stdout:output cmd in
   if exc <> 0 then begin
-    if ofile <> "-" then safe_remove ofile;
+    if ofile <> "-" then File.safe_remove ofile;
     command_error "preprocessor" exc;
     eprintf "Error during preprocessing.\n";
     exit 2

--- a/exportclight/Clightgen.ml
+++ b/exportclight/Clightgen.ml
@@ -32,12 +32,11 @@ let compile_c_ast sourcename csyntax ofile =
         begin match SimplLocals.transf_program p with
         | Errors.OK p' -> p'
         | Errors.Error msg ->
-            print_error stderr msg;
-            exit 2
+          print_errorcodes sourcename msg
         end
     | Errors.Error msg ->
-        print_error stderr msg;
-        exit 2 in
+      print_errorcodes sourcename msg
+  in
   (* Dump Clight in C syntax if requested *)
   if !option_dclight then begin
     let ofile = Filename.chop_suffix sourcename ".c" ^ ".light.c" in

--- a/lib/File.ml
+++ b/lib/File.ml
@@ -22,11 +22,21 @@ type input_file =
     suffix: string;
   }
 
+let access file =
+  try
+    Unix.access file [Unix.R_OK];
+    true
+  with Unix.Unix_error _ ->
+    false
+
 (* Create a new input file and ensure it's existence *)
 let new_input_file file suffix =
   if not (Sys.file_exists file) then begin
     eprintf "error: no such file or directory: '%s'\n" file;
     exit 2
+  end else if not (access file) then begin
+      eprintf "ccomp: fatal error: %s:  Permission denied\n" file;
+      exit 2;
   end;
   {
     name = file;

--- a/lib/File.ml
+++ b/lib/File.ml
@@ -1,0 +1,68 @@
+(* *********************************************************************)
+(*                                                                     *)
+(*              The Compcert verified compiler                         *)
+(*                                                                     *)
+(*          Xavier Leroy, INRIA Paris-Rocquencourt                     *)
+(*      Bernhard Schommer, AbsInt Angewandte Informatik GmbH           *)
+(*                                                                     *)
+(*  Copyright Institut National de Recherche en Informatique et en     *)
+(*  Automatique.  All rights reserved.  This file is distributed       *)
+(*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+(*                                                                     *)
+(* *********************************************************************)
+
+
+open Printf
+open Clflags
+
+(* Type for input file *)
+type input_file =
+  {
+    name : string;
+    suffix: string;
+  }
+
+(* Create a new input file and ensure it's existence *)
+let new_input_file file suffix =
+  if not (Sys.file_exists file) then begin
+    eprintf "error: no such file or directory: '%s'\n" file;
+    exit 2
+  end;
+  {
+    name = file;
+    suffix = suffix;
+  }
+
+(* Get the name of the input file *)
+let input_name file = file.name
+
+(* Get the input channel from the input file *)
+let open_input_file file =
+  open_in_bin file.name
+
+(* Safe removal of files *)
+let safe_remove file =
+  try Sys.remove file with Sys_error _ -> ()
+
+(* Generate a temporary file with the given suffix that is removed on exit *)
+let temp_file suffix =
+  let file = Filename.temp_file "compcert" suffix in
+  at_exit (fun () -> safe_remove file);
+  file
+
+(* Determine names for output files.  We use -o option if specified
+   and if this is the final destination file (not a dump file).
+   Otherwise, we generate a file in the current directory. *)
+let output_filename ?(final = false) source_file output_suffix =
+  match !option_o with
+  | Some file when final -> file
+  | _ ->
+    Filename.basename (Filename.chop_suffix source_file.name source_file.suffix)
+    ^ output_suffix
+
+(* A variant of [output_filename] where the default output name is fixed *)
+
+let output_filename_default default_file =
+  match !option_o with
+  | Some file -> file
+  | None -> default_file

--- a/lib/File.mli
+++ b/lib/File.mli
@@ -1,0 +1,38 @@
+(* *********************************************************************)
+(*                                                                     *)
+(*              The Compcert verified compiler                         *)
+(*                                                                     *)
+(*          Xavier Leroy, INRIA Paris-Rocquencourt                     *)
+(*      Bernhard Schommer, AbsInt Angewandte Informatik GmbH           *)
+(*                                                                     *)
+(*  Copyright Institut National de Recherche en Informatique et en     *)
+(*  Automatique.  All rights reserved.  This file is distributed       *)
+(*  under the terms of the INRIA Non-Commercial License Agreement.     *)
+(*                                                                     *)
+(* *********************************************************************)
+
+val safe_remove: string -> unit
+   (** Remove the given file if it exists *)
+
+val temp_file: string -> string
+    (** Generate a temporary file wiht the given suffix that is removed on exit *)
+
+val output_filename_default: string -> string
+   (** Return either the file specified by -o or the given file name *)
+
+type input_file
+   (** Type for input files *)
+
+val input_name : input_file -> string
+   (** Return the name of the input file *)
+
+val new_input_file : string -> string -> input_file
+   (** Return a new input_file from a given file with extension *)
+
+val open_input_file : input_file -> in_channel
+  (** Open an in_channel from the input file *)
+
+val output_filename: ?final:bool -> input_file -> string -> string
+   (** Determine names for output files.  We use -o option if specified
+       and if this is the final destination file (not a dump file).
+       Otherwise, we generate a file in the current directory. *)


### PR DESCRIPTION
The file functions are moved into an own library file. The
temp_file function now registers a delete function at exit. This
avoids the double check for temp files in driver.

Currently unused is the input_file type and functions since most
functions using this are affected by the other changes in PR #158
and changing them would result in doubled work.