### PR TITLE
Adapt to a fix in zify

### DIFF
--- a/backend/Inliningspec.v
+++ b/backend/Inliningspec.v
@@ -72,7 +72,7 @@ Qed.
 
 Lemma shiftpos_eq: forall x y, Zpos (shiftpos x y) = (Zpos x + Zpos y) - 1.
 Proof.
-  intros. unfold shiftpos. zify.  rewrite Pos2Z.inj_sub. auto.
+  intros. unfold shiftpos. zify.  try rewrite Pos2Z.inj_sub. auto.
   zify. omega.
 Qed.
 


### PR DESCRIPTION
See Coq pull request #673 (and original bug #5336).
With the fixed version of zify, this proof in Inliningspec.v could actually be shortened to `intros. unfold shiftpos. now zify.`, but the proposed patch has the advantage of being compatible with both the released versions of Coq, and the coming ones.