### PR TITLE
Do not rely on the hints of BigNumPrelude

### DIFF
--- a/cparser/validator/Alphabet.v
+++ b/cparser/validator/Alphabet.v
@@ -249,7 +249,7 @@ erewrite <- IHn, <- Zabs_nat_Zsucc in H |- *; eauto; try omega.
 rewrite phi_incr, Zmod_small; intuition; try omega.
 apply inj_lt in H.
 pose proof Zle_le_succ.
-do 2 rewrite inj_Zabs_nat, Zabs_eq in H; eauto.
+do 2 rewrite inj_Zabs_nat, Zabs_eq in H; now eauto.
 Qed.
 
 (** Previous class instances for [option A] **)


### PR DESCRIPTION
BigNumPrelude will soon leave Coq stdlib with the rest of the bignums library (apart from Int31 files) to become a separate package, see [PR#498](https://github.com/coq/coq/pull/498).

With this (very minor) patch, Compcert compiles with or without the hints declared in BigNumPrelude.

Best,
Pierre L.