### PR TITLE
Ensure FunInd or Recdef is imported if functional induction is used

### DIFF
--- a/arm/CombineOpproof.v
+++ b/arm/CombineOpproof.v
@@ -13,6 +13,7 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
+Require Import FunInd.
 Require Import Coqlib.
 Require Import AST.
 Require Import Integers.

--- a/backend/Allocproof.v
+++ b/backend/Allocproof.v
@@ -13,6 +13,7 @@
 (** Correctness proof for the [Allocation] pass (validated translation from
   RTL to LTL). *)
 
+Require Import FunInd.
 Require Import FSets.
 Require Import Coqlib Ordered Maps Errors Integers Floats.
 Require Import AST Linking Lattice Kildall.

--- a/backend/Deadcodeproof.v
+++ b/backend/Deadcodeproof.v
@@ -12,6 +12,7 @@
 
 (** Elimination of unneeded computations over RTL: correctness proof. *)
 
+Require Import FunInd.
 Require Import Coqlib Maps Errors Integers Floats Lattice Kildall.
 Require Import AST Linking.
 Require Import Values Memory Globalenvs Events Smallstep.

--- a/backend/Selectionproof.v
+++ b/backend/Selectionproof.v
@@ -12,6 +12,7 @@
 
 (** Correctness of instruction selection *)
 
+Require Import FunInd.
 Require Import Coqlib Maps.
 Require Import AST Linking Errors Integers Values Memory Events Globalenvs Smallstep.
 Require Import Switch Cminor Op CminorSel.

--- a/backend/ValueAnalysis.v
+++ b/backend/ValueAnalysis.v
@@ -10,6 +10,7 @@
 (*                                                                     *)
 (* *********************************************************************)
 
+Require Import FunInd.
 Require Import Coqlib Maps Integers Floats Lattice Kildall.
 Require Import Compopts AST Linking.
 Require Import Values Memory Globalenvs Events.

--- a/backend/ValueDomain.v
+++ b/backend/ValueDomain.v
@@ -10,6 +10,7 @@
 (*                                                                     *)
 (* *********************************************************************)
 
+Require Import FunInd.
 Require Import Zwf Coqlib Maps Integers Floats Lattice.
 Require Import Compopts AST.
 Require Import Values Memory Globalenvs Events.

--- a/cfrontend/Cexec.v
+++ b/cfrontend/Cexec.v
@@ -12,6 +12,7 @@
 
 (** Animating the CompCert C semantics *)
 
+Require Import FunInd.
 Require Import Axioms Classical.
 Require Import String Coqlib Decidableplus.
 Require Import Errors Maps Integers Floats.

--- a/cfrontend/SimplExprproof.v
+++ b/cfrontend/SimplExprproof.v
@@ -12,6 +12,7 @@
 
 (** Correctness proof for expression simplification. *)
 
+Require Import FunInd.
 Require Import Coqlib Maps Errors Integers.
 Require Import AST Linking.
 Require Import Values Memory Events Globalenvs Smallstep.

--- a/common/Globalenvs.v
+++ b/common/Globalenvs.v
@@ -33,7 +33,7 @@
   place during program linking and program loading in a real operating
   system. *)
 
-Require Recdef.
+Require Import Recdef.
 Require Import Zwf.
 Require Import Axioms Coqlib Errors Maps AST Linking.
 Require Import Integers Floats Values Memory.

--- a/lib/Heaps.v
+++ b/lib/Heaps.v
@@ -21,6 +21,7 @@
     (If an element is already in a heap, inserting it again does nothing.)
 *)
 
+Require Import FunInd.
 Require Import Coqlib.
 Require Import FSets.
 Require Import Ordered.

--- a/lib/Intv.v
+++ b/lib/Intv.v
@@ -18,7 +18,7 @@
 Require Import Coqlib.
 Require Import Zwf.
 Require Coq.Program.Wf.
-Require Recdef.
+Require Import Recdef.
 
 Definition interv : Type := (Z * Z)%type.
 

--- a/lib/Parmov.v
+++ b/lib/Parmov.v
@@ -55,7 +55,7 @@
 Require Import Relations.
 Require Import Axioms.
 Require Import Coqlib.
-Require Recdef.
+Require Import Recdef.
 
 Section PARMOV.
 

--- a/powerpc/CombineOpproof.v
+++ b/powerpc/CombineOpproof.v
@@ -13,6 +13,7 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
+Require Import FunInd.
 Require Import Coqlib.
 Require Import AST.
 Require Import Integers.

--- a/riscV/CombineOpproof.v
+++ b/riscV/CombineOpproof.v
@@ -13,6 +13,7 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
+Require Import FunInd.
 Require Import Coqlib.
 Require Import AST.
 Require Import Integers.

--- a/x86/CombineOpproof.v
+++ b/x86/CombineOpproof.v
@@ -13,6 +13,7 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
+Require Import FunInd.
 Require Import Coqlib.
 Require Import Integers Values Memory.
 Require Import Op RTL CSEdomain.


### PR DESCRIPTION
Coq 8.7 does not load FunInd in prelude anymore, so importing FunInd becomes necessary in a couple of places. 

In Coq 8.7, `Recdef` exports `FunInd`, hence if `Recdef` is imported, `FunInd` does not have to be required separately.

With this change, CompCert compiles with Coq 8.7+alpha (coq/coq@d074e889b3cdfe8c292d3c52a4ed005789384fc0). This change should still be compatible with Coq 8.6. I did one build each for ppc, arm, and x86 with Coq 8.6.1.

An **alternative to this patch** is to just add `Require Export FunInd` in `Coqlib.v`. If that is prefered, feel free to close this PR.