### PR TITLE
CompCert for Lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,9 +25,9 @@ DIRS=lib common $(ARCHDIRS) backend cfrontend driver debug\
   flocq/Core flocq/Prop flocq/Calc flocq/Appli exportclight \
   cparser cparser/validator
 
-RECDIRS=lib common $(ARCHDIRS) backend cfrontend driver flocq exportclight cparser
+RECDIRS=lib common $(ARCHDIRS) backend cfrontend driver exportclight cparser
 
-COQINCLUDES=$(foreach d, $(RECDIRS), -R $(d) compcert.$(d))
+COQINCLUDES=$(foreach d, $(RECDIRS), -Q $(d) compcert) -Q flocq flocq
 
 COQC="$(COQBIN)coqc" -q $(COQINCLUDES) $(COQCOPTS)
 COQDEP="$(COQBIN)coqdep" $(COQINCLUDES)
@@ -236,7 +236,7 @@ driver/Version.ml: VERSION
 	>driver/Version.ml
 
 cparser/Parser.v: cparser/Parser.vy
-	$(MENHIR) --coq cparser/Parser.vy
+	$(MENHIR) --coq cparser/Parser.vy --coq-dirpath compcert.validator
 
 depend: $(GENERATED) depend1
 

--- a/arm/Archi.v
+++ b/arm/Archi.v
@@ -17,8 +17,8 @@
 (** Architecture-dependent parameters for ARM *)
 
 Require Import ZArith.
-Require Import Fappli_IEEE.
-Require Import Fappli_IEEE_bits.
+Require Import flocq.Appli.Fappli_IEEE.
+Require Import flocq.Appli.Fappli_IEEE_bits.
 
 Definition ptr64 := false.
 

--- a/arm/Asm.v
+++ b/arm/Asm.v
@@ -13,19 +13,19 @@
 
 (** Abstract syntax and semantics for ARM assembly language *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Smallstep.
-Require Import Locations.
-Require Stacklayout.
-Require Import Conventions.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
+Require Import compcert.Locations.
+Require compcert.Stacklayout.
+Require Import compcert.Conventions.
 
 (** * Abstract syntax *)
 

--- a/arm/Asmgen.v
+++ b/arm/Asmgen.v
@@ -12,16 +12,16 @@
 
 (** Translation from Mach to ARM. *)
 
-Require Import Coqlib.
-Require Import Errors.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Op.
-Require Import Locations.
-Require Import Mach.
-Require Import Asm.
-Require Import Compopts.
+Require Import compcert.Coqlib.
+Require Import compcert.Errors.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Op.
+Require Import compcert.Locations.
+Require Import compcert.Mach.
+Require Import compcert.Asm.
+Require Import compcert.Compopts.
 
 Local Open Scope string_scope.
 Local Open Scope error_monad_scope.

--- a/arm/Asmgenproof.v
+++ b/arm/Asmgenproof.v
@@ -12,11 +12,11 @@
 
 (** Correctness proof for ARM code generation: main proof. *)
 
-Require Import Coqlib Errors.
-Require Import Integers Floats AST Linking Compopts.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Op Locations Mach Conventions Asm.
-Require Import Asmgen Asmgenproof0 Asmgenproof1.
+Require Import compcert.Coqlib compcert.Errors.
+Require Import compcert.Integers compcert.Floats compcert.AST compcert.Linking compcert.Compopts.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Locations compcert.Mach compcert.Conventions compcert.Asm.
+Require Import compcert.Asmgen compcert.Asmgenproof0 compcert.Asmgenproof1.
 
 Local Transparent Archi.ptr64.
 

--- a/arm/Asmgenproof1.v
+++ b/arm/Asmgenproof1.v
@@ -12,23 +12,23 @@
 
 (** Correctness proof for ARM code generation: auxiliary results. *)
 
-Require Import Coqlib.
-Require Import Errors.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Op.
-Require Import Locations.
-Require Import Mach.
-Require Import Compopts.
-Require Import Asm.
-Require Import Asmgen.
-Require Import Conventions.
-Require Import Asmgenproof0.
+Require Import compcert.Coqlib.
+Require Import compcert.Errors.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Op.
+Require Import compcert.Locations.
+Require Import compcert.Mach.
+Require Import compcert.Compopts.
+Require Import compcert.Asm.
+Require Import compcert.Asmgen.
+Require Import compcert.Conventions.
+Require Import compcert.Asmgenproof0.
 
 Local Transparent Archi.ptr64.
 

--- a/arm/CombineOp.v
+++ b/arm/CombineOp.v
@@ -13,11 +13,11 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Op.
-Require Import CSEdomain.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Op.
+Require Import compcert.CSEdomain.
 
 Section COMBINE.
 

--- a/arm/CombineOpproof.v
+++ b/arm/CombineOpproof.v
@@ -13,16 +13,16 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Values.
-Require Import Memory.
-Require Import Op.
-Require Import Registers.
-Require Import RTL.
-Require Import CSEdomain.
-Require Import CombineOp.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.RTL.
+Require Import compcert.CSEdomain.
+Require Import compcert.CombineOp.
 
 Section COMBINE.
 

--- a/arm/ConstpropOp.vp
+++ b/arm/ConstpropOp.vp
@@ -13,14 +13,14 @@
 (** Static analysis and strength reduction for operators
   and conditions.  This is the machine-dependent part of [Constprop]. *)
 
-Require Import Coqlib.
-Require Import Compopts.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Op.
-Require Import Registers.
-Require Import ValueDomain.
+Require Import compcert.Coqlib.
+Require Import compcert.Compopts.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.ValueDomain.
 
 (** * Converting known values to constants *)
 

--- a/arm/ConstpropOpproof.v
+++ b/arm/ConstpropOpproof.v
@@ -12,20 +12,20 @@
 
 (** Correctness proof for constant propagation (processor-dependent part). *)
 
-Require Import Coqlib.
-Require Import Compopts.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Events.
-Require Import Op.
-Require Import Registers.
-Require Import RTL.
-Require Import ValueDomain.
-Require Import ConstpropOp.
+Require Import compcert.Coqlib.
+Require Import compcert.Compopts.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Events.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.RTL.
+Require Import compcert.ValueDomain.
+Require Import compcert.ConstpropOp.
 
 Local Transparent Archi.ptr64.
 

--- a/arm/Conventions1.v
+++ b/arm/Conventions1.v
@@ -13,12 +13,12 @@
 (** Function calling conventions and other conventions regarding the use of
     machine registers and stack slots. *)
 
-Require Import Coqlib.
-Require Import Decidableplus.
-Require Import AST.
-Require Import Events.
-Require Import Locations.
-Require Archi.
+Require Import compcert.Coqlib.
+Require Import compcert.Decidableplus.
+Require Import compcert.AST.
+Require Import compcert.Events.
+Require Import compcert.Locations.
+Require compcert.Archi.
 
 (** * Classification of machine registers *)
 

--- a/arm/Machregs.v
+++ b/arm/Machregs.v
@@ -11,11 +11,11 @@
 (* *********************************************************************)
 
 Require Import String.
-Require Import Coqlib.
-Require Import Decidableplus.
-Require Import Maps.
-Require Import AST.
-Require Import Op.
+Require Import compcert.Coqlib.
+Require Import compcert.Decidableplus.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Op.
 
 (** ** Machine registers *)
 

--- a/arm/NeedOp.v
+++ b/arm/NeedOp.v
@@ -10,16 +10,16 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Op.
-Require Import NeedDomain.
-Require Import RTL.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Op.
+Require Import compcert.NeedDomain.
+Require Import compcert.RTL.
 
 (** Neededness analysis for ARM operators *)
 

--- a/arm/Op.v
+++ b/arm/Op.v
@@ -24,15 +24,15 @@
   syntax and dynamic semantics of the Cminor language.
 *)
 
-Require Import Axioms.
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Events.
+Require Import compcert.Axioms.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Events.
 
 Set Implicit Arguments.
 Local Transparent Archi.ptr64.

--- a/arm/SelectLong.vp
+++ b/arm/SelectLong.vp
@@ -12,10 +12,10 @@
 
 (** Instruction selection for 64-bit integer operations *)
 
-Require Import Coqlib.
-Require Import Compopts.
-Require Import AST Integers Floats.
-Require Import Op CminorSel.
-Require Import SelectOp SplitLong.
+Require Import compcert.Coqlib.
+Require Import compcert.Compopts.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SplitLong.
 
 (** This file is empty because we use the default implementation provided in [SplitLong]. *)

--- a/arm/SelectLongproof.v
+++ b/arm/SelectLongproof.v
@@ -12,11 +12,11 @@
 
 (** Instruction selection for 64-bit integer operations *)
 
-Require Import String Coqlib Maps Integers Floats Errors.
-Require Archi.
-Require Import AST Values Memory Globalenvs Events.
-Require Import Cminor Op CminorSel.
-Require Import SelectOp SelectOpproof SplitLong SplitLongproof.
-Require Import SelectLong.
+Require Import String compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Errors.
+Require compcert.Archi.
+Require Import compcert.AST compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Cminor compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SelectOpproof compcert.SplitLong compcert.SplitLongproof.
+Require Import compcert.SelectLong.
 
 (** This file is empty because we use the default implementation provided in [SplitLong]. *)

--- a/arm/SelectOp.vp
+++ b/arm/SelectOp.vp
@@ -36,13 +36,13 @@
   module [Selection] implements the actual instruction selection pass.
 *)
 
-Require Import Coqlib.
-Require Import Compopts.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Op.
-Require Import CminorSel.
+Require Import compcert.Coqlib.
+Require Import compcert.Compopts.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Op.
+Require Import compcert.CminorSel.
 
 Local Open Scope cminorsel_scope.
 

--- a/arm/SelectOpproof.v
+++ b/arm/SelectOpproof.v
@@ -12,18 +12,18 @@
 
 (** Correctness of instruction selection for operators *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Cminor.
-Require Import Op.
-Require Import CminorSel.
-Require Import SelectOp.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Cminor.
+Require Import compcert.Op.
+Require Import compcert.CminorSel.
+Require Import compcert.SelectOp.
 
 Local Open Scope cminorsel_scope.
 Local Transparent Archi.ptr64.

--- a/arm/Stacklayout.v
+++ b/arm/Stacklayout.v
@@ -12,9 +12,9 @@
 
 (** Machine- and ABI-dependent layout information for activation records. *)
 
-Require Import Coqlib.
-Require Import Memory Separation.
-Require Import Bounds.
+Require Import compcert.Coqlib.
+Require Import compcert.Memory compcert.Separation.
+Require Import compcert.Bounds.
 
 (** The general shape of activation records is as follows,
   from bottom (lowest offsets) to top:

--- a/arm/ValueAOp.v
+++ b/arm/ValueAOp.v
@@ -10,17 +10,17 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import Coqlib.
-Require Import Compopts.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Op.
-Require Import ValueDomain.
-Require Import RTL.
+Require Import compcert.Coqlib.
+Require Import compcert.Compopts.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Op.
+Require Import compcert.ValueDomain.
+Require Import compcert.RTL.
 
 (** Value analysis for ARM operators *)
 

--- a/backend/Allocation.v
+++ b/backend/Allocation.v
@@ -12,11 +12,11 @@
 
 (** Register allocation by external oracle and a posteriori validation. *)
 
-Require Import FSets FSetAVLplus.
-Require Import Coqlib Ordered Maps Errors Integers Floats.
-Require Import AST Lattice Kildall Memdata.
-Require Archi.
-Require Import Op Registers RTL Locations Conventions RTLtyping LTL.
+Require Import FSets compcert.FSetAVLplus.
+Require Import compcert.Coqlib compcert.Ordered compcert.Maps compcert.Errors compcert.Integers compcert.Floats.
+Require Import compcert.AST compcert.Lattice compcert.Kildall compcert.Memdata.
+Require compcert.Archi.
+Require Import compcert.Op compcert.Registers compcert.RTL compcert.Locations compcert.Conventions compcert.RTLtyping compcert.LTL.
 
 (** The validation algorithm used here is described in
   "Validating register allocation and spilling",

--- a/backend/Allocproof.v
+++ b/backend/Allocproof.v
@@ -14,12 +14,12 @@
   RTL to LTL). *)
 
 Require Import FSets.
-Require Import Coqlib Ordered Maps Errors Integers Floats.
-Require Import AST Linking Lattice Kildall.
-Require Import Values Memory Globalenvs Events Smallstep.
-Require Archi.
-Require Import Op Registers RTL Locations Conventions RTLtyping LTL.
-Require Import Allocation.
+Require Import compcert.Coqlib compcert.Ordered compcert.Maps compcert.Errors compcert.Integers compcert.Floats.
+Require Import compcert.AST compcert.Linking compcert.Lattice compcert.Kildall.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs compcert.Events compcert.Smallstep.
+Require compcert.Archi.
+Require Import compcert.Op compcert.Registers compcert.RTL compcert.Locations compcert.Conventions compcert.RTLtyping compcert.LTL.
+Require Import compcert.Allocation.
 
 Definition match_prog (p: RTL.program) (tp: LTL.program) :=
   match_program (fun _ f tf => transf_fundef f = OK tf) eq p tp.

--- a/backend/Asmgenproof0.v
+++ b/backend/Asmgenproof0.v
@@ -12,22 +12,22 @@
 
 (** Correctness proof for Asm generation: machine-independent framework *)
 
-Require Import Coqlib.
-Require Intv.
-Require Import AST.
-Require Import Errors.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Events.
-Require Import Smallstep.
-Require Import Locations.
-Require Import Mach.
-Require Import Asm.
-Require Import Asmgen.
-Require Import Conventions.
+Require Import compcert.Coqlib.
+Require compcert.Intv.
+Require Import compcert.AST.
+Require Import compcert.Errors.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Events.
+Require Import compcert.Smallstep.
+Require Import compcert.Locations.
+Require Import compcert.Mach.
+Require Import compcert.Asm.
+Require Import compcert.Asmgen.
+Require Import compcert.Conventions.
 
 (** * Processor registers and register states *)
 

--- a/backend/Bounds.v
+++ b/backend/Bounds.v
@@ -13,13 +13,13 @@
 (** Computation of resource bounds for Linear code. *)
 
 Require Import FSets FSetAVL.
-Require Import Coqlib Ordered.
-Require Intv.
-Require Import AST.
-Require Import Op.
-Require Import Machregs Locations.
-Require Import Linear.
-Require Import Conventions.
+Require Import compcert.Coqlib compcert.Ordered.
+Require compcert.Intv.
+Require Import compcert.AST.
+Require Import compcert.Op.
+Require Import compcert.Machregs compcert.Locations.
+Require Import compcert.Linear.
+Require Import compcert.Conventions.
 
 Module RegOrd := OrderedIndexed (IndexedMreg).
 Module RegSet := FSetAVL.Make (RegOrd).

--- a/backend/CSE.v
+++ b/backend/CSE.v
@@ -13,11 +13,11 @@
 (** Common subexpression elimination over RTL.  This optimization
   proceeds by value numbering over extended basic blocks. *)
 
-Require Import Coqlib Maps Errors Integers Floats Lattice Kildall.
-Require Import AST Linking.
-Require Import Values Memory.
-Require Import Op Registers RTL.
-Require Import ValueDomain ValueAnalysis CSEdomain CombineOp.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors compcert.Integers compcert.Floats compcert.Lattice compcert.Kildall.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory.
+Require Import compcert.Op compcert.Registers compcert.RTL.
+Require Import compcert.ValueDomain compcert.ValueAnalysis compcert.CSEdomain compcert.CombineOp.
 
 (** The idea behind value numbering algorithms is to associate
   abstract identifiers (``value numbers'') to the contents of registers

--- a/backend/CSEdomain.v
+++ b/backend/CSEdomain.v
@@ -13,14 +13,14 @@
 (** The abstract domain for value numbering, used in common
     subexpression elimination. *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Values.
-Require Import Memory.
-Require Import Op.
-Require Import Registers.
-Require Import RTL.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.RTL.
 
 (** Value numbers are represented by positive integers.  Equations are
   of the form [valnum = rhs] or [valnum >= rhs], where the right-hand

--- a/backend/CSEproof.v
+++ b/backend/CSEproof.v
@@ -12,12 +12,12 @@
 
 (** Correctness proof for common subexpression elimination. *)
 
-Require Import Coqlib Maps Errors Integers Floats Lattice Kildall.
-Require Import AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Op Registers RTL.
-Require Import ValueDomain ValueAOp ValueAnalysis.
-Require Import CSEdomain CombineOp CombineOpproof CSE.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors compcert.Integers compcert.Floats compcert.Lattice compcert.Kildall.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Registers compcert.RTL.
+Require Import compcert.ValueDomain compcert.ValueAOp compcert.ValueAnalysis.
+Require Import compcert.CSEdomain compcert.CombineOp compcert.CombineOpproof compcert.CSE.
 
 Definition match_prog (prog tprog: RTL.program) :=
   match_program (fun cu f tf => transf_fundef (romem_for cu) f = OK tf) eq prog tprog.

--- a/backend/CleanupLabels.v
+++ b/backend/CleanupLabels.v
@@ -21,8 +21,8 @@
   branched to. *)
 
 Require Import FSets FSetAVL.
-Require Import Coqlib Ordered.
-Require Import Linear.
+Require Import compcert.Coqlib compcert.Ordered.
+Require Import compcert.Linear.
 
 Module Labelset := FSetAVL.Make(OrderedPositive).
 

--- a/backend/CleanupLabelsproof.v
+++ b/backend/CleanupLabelsproof.v
@@ -13,11 +13,11 @@
 (** Correctness proof for clean-up of labels *)
 
 Require Import FSets.
-Require Import Coqlib Ordered Integers.
-Require Import AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Op Locations Linear.
-Require Import CleanupLabels.
+Require Import compcert.Coqlib compcert.Ordered compcert.Integers.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Locations compcert.Linear.
+Require Import compcert.CleanupLabels.
 
 Module LabelsetFacts := FSetFacts.Facts(Labelset).
 

--- a/backend/Cminor.v
+++ b/backend/Cminor.v
@@ -15,17 +15,17 @@
 
 (** Abstract syntax and semantics for the Cminor language. *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Events.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Smallstep.
-Require Import Switch.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Events.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
+Require Import compcert.Switch.
 
 (** * Abstract syntax *)
 

--- a/backend/CminorSel.v
+++ b/backend/CminorSel.v
@@ -12,17 +12,17 @@
 
 (** The Cminor language after instruction selection. *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Events.
-Require Import Values.
-Require Import Memory.
-Require Import Cminor.
-Require Import Op.
-Require Import Globalenvs.
-Require Import Smallstep.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Events.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Cminor.
+Require Import compcert.Op.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
 
 (** * Abstract syntax *)
 

--- a/backend/Constprop.v
+++ b/backend/Constprop.v
@@ -14,12 +14,12 @@
   performed at RTL level.  It proceeds by a standard dataflow analysis
   and the corresponding code rewriting. *)
 
-Require Import Coqlib Maps Integers Floats Lattice Kildall.
-Require Import AST Linking.
-Require Compopts Machregs.
-Require Import Op Registers RTL.
-Require Import Liveness ValueDomain ValueAOp ValueAnalysis.
-Require Import ConstpropOp.
+Require Import compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Lattice compcert.Kildall.
+Require Import compcert.AST compcert.Linking.
+Require compcert.Compopts compcert.Machregs.
+Require Import compcert.Op compcert.Registers compcert.RTL.
+Require Import compcert.Liveness compcert.ValueDomain compcert.ValueAOp compcert.ValueAnalysis.
+Require Import compcert.ConstpropOp.
 
 (** The code transformation builds on the results of the static analysis
   of values from module [ValueAnalysis].  It proceeds instruction by

--- a/backend/Constpropproof.v
+++ b/backend/Constpropproof.v
@@ -12,13 +12,13 @@
 
 (** Correctness proof for constant propagation. *)
 
-Require Import Coqlib Maps Integers Floats Lattice Kildall.
-Require Import AST Linking.
-Require Import Values Events Memory Globalenvs Smallstep.
-Require Compopts Machregs.
-Require Import Op Registers RTL.
-Require Import Liveness ValueDomain ValueAOp ValueAnalysis.
-Require Import ConstpropOp ConstpropOpproof Constprop.
+Require Import compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Lattice compcert.Kildall.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Events compcert.Memory compcert.Globalenvs compcert.Smallstep.
+Require compcert.Compopts compcert.Machregs.
+Require Import compcert.Op compcert.Registers compcert.RTL.
+Require Import compcert.Liveness compcert.ValueDomain compcert.ValueAOp compcert.ValueAnalysis.
+Require Import compcert.ConstpropOp compcert.ConstpropOpproof compcert.Constprop.
 
 Definition match_prog (prog tprog: program) :=
   match_program (fun cu f tf => tf = transf_fundef (romem_for cu) f) eq prog tprog.

--- a/backend/Conventions.v
+++ b/backend/Conventions.v
@@ -13,10 +13,10 @@
 (** Function calling conventions and other conventions regarding the use of
     machine registers and stack slots. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Locations.
-Require Export Conventions1.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Locations.
+Require Export compcert.Conventions1.
 
 (** The processor-dependent and EABI-dependent definitions are in
     [arch/abi/Conventions1.v].  This file adds various processor-independent

--- a/backend/Deadcode.v
+++ b/backend/Deadcode.v
@@ -12,10 +12,10 @@
 
 (** Elimination of unneeded computations over RTL. *)
 
-Require Import Coqlib Maps Errors Integers Floats Lattice Kildall.
-Require Import AST Linking.
-Require Import Memory Registers Op RTL.
-Require Import ValueDomain ValueAnalysis NeedDomain NeedOp.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors compcert.Integers compcert.Floats compcert.Lattice compcert.Kildall.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Memory compcert.Registers compcert.Op compcert.RTL.
+Require Import compcert.ValueDomain compcert.ValueAnalysis compcert.NeedDomain compcert.NeedOp.
 
 (** * Part 1: the static analysis *)
 

--- a/backend/Deadcodeproof.v
+++ b/backend/Deadcodeproof.v
@@ -12,11 +12,11 @@
 
 (** Elimination of unneeded computations over RTL: correctness proof. *)
 
-Require Import Coqlib Maps Errors Integers Floats Lattice Kildall.
-Require Import AST Linking.
-Require Import Values Memory Globalenvs Events Smallstep.
-Require Import Registers Op RTL.
-Require Import ValueDomain ValueAnalysis NeedDomain NeedOp Deadcode.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors compcert.Integers compcert.Floats compcert.Lattice compcert.Kildall.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs compcert.Events compcert.Smallstep.
+Require Import compcert.Registers compcert.Op compcert.RTL.
+Require Import compcert.ValueDomain compcert.ValueAnalysis compcert.NeedDomain compcert.NeedOp compcert.Deadcode.
 
 Definition match_prog (prog tprog: RTL.program) :=
   match_program (fun cu f tf => transf_fundef (romem_for cu) f = OK tf) eq prog tprog.

--- a/backend/Debugvar.v
+++ b/backend/Debugvar.v
@@ -13,9 +13,9 @@
 (** Computation of live ranges for local variables that carry
     debugging information. *)
 
-Require Import Axioms Coqlib Maps Iteration Errors.
-Require Import Integers Floats AST.
-Require Import Machregs Locations Conventions Linear.
+Require Import compcert.Axioms compcert.Coqlib compcert.Maps compcert.Iteration compcert.Errors.
+Require Import compcert.Integers compcert.Floats compcert.AST.
+Require Import compcert.Machregs compcert.Locations compcert.Conventions compcert.Linear.
 
 (** A debug info is a [builtin_arg loc] expression that safely evaluates
    in any context. *)

--- a/backend/Debugvarproof.v
+++ b/backend/Debugvarproof.v
@@ -12,11 +12,11 @@
 
 (** Correctness proof for the [Debugvar] pass. *)
 
-Require Import Axioms Coqlib Maps Iteration Errors.
-Require Import Integers Floats AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Machregs Locations Conventions Op Linear.
-Require Import Debugvar.
+Require Import compcert.Axioms compcert.Coqlib compcert.Maps compcert.Iteration compcert.Errors.
+Require Import compcert.Integers compcert.Floats compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Machregs compcert.Locations compcert.Conventions compcert.Op compcert.Linear.
+Require Import compcert.Debugvar.
 
 (** * Relational characterization of the transformation *)
 

--- a/backend/Inlining.v
+++ b/backend/Inlining.v
@@ -12,9 +12,9 @@
 
 (** RTL function inlining *)
 
-Require Import Coqlib Wfsimpl Maps Errors Integers.
-Require Import AST Linking.
-Require Import Op Registers RTL.
+Require Import compcert.Coqlib compcert.Wfsimpl compcert.Maps compcert.Errors compcert.Integers.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Op compcert.Registers compcert.RTL.
 
 (** ** Environment of inlinable functions *)
 

--- a/backend/Inliningproof.v
+++ b/backend/Inliningproof.v
@@ -12,10 +12,10 @@
 
 (** RTL function inlining: semantic preservation *)
 
-Require Import Coqlib Wfsimpl Maps Errors Integers.
-Require Import AST Linking Values Memory Globalenvs Events Smallstep.
-Require Import Op Registers RTL.
-Require Import Inlining Inliningspec.
+Require Import compcert.Coqlib compcert.Wfsimpl compcert.Maps compcert.Errors compcert.Integers.
+Require Import compcert.AST compcert.Linking compcert.Values compcert.Memory compcert.Globalenvs compcert.Events compcert.Smallstep.
+Require Import compcert.Op compcert.Registers compcert.RTL.
+Require Import compcert.Inlining compcert.Inliningspec.
 
 Definition match_prog (prog tprog: program) :=
   match_program (fun cunit f tf => transf_fundef (funenv_program cunit) f = OK tf) eq prog tprog.

--- a/backend/Inliningspec.v
+++ b/backend/Inliningspec.v
@@ -12,10 +12,10 @@
 
 (** RTL function inlining: relational specification *)
 
-Require Import Coqlib Wfsimpl Maps Errors Integers.
-Require Import AST Linking.
-Require Import Op Registers RTL.
-Require Import Inlining.
+Require Import compcert.Coqlib compcert.Wfsimpl compcert.Maps compcert.Errors compcert.Integers.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Op compcert.Registers compcert.RTL.
+Require Import compcert.Inlining.
 
 (** ** Soundness of function environments. *)
 

--- a/backend/Kildall.v
+++ b/backend/Kildall.v
@@ -12,10 +12,10 @@
 
 (** Solvers for dataflow inequations. *)
 
-Require Import Coqlib.
-Require Import Iteration.
-Require Import Maps.
-Require Import Lattice.
+Require Import compcert.Coqlib.
+Require Import compcert.Iteration.
+Require Import compcert.Maps.
+Require Import compcert.Lattice.
 
 (* To avoid useless definitions of inductors in extracted code. *)
 Local Unset Elimination Schemes.
@@ -1536,7 +1536,7 @@ End BBlock_solver.
   greatest node in the working list.  For backward analysis,
   we will similarly pick the smallest node in the working list. *)
 
-Require Import Heaps.
+Require Import compcert.Heaps.
 
 Module NodeSetForward <: NODE_SET.
   Definition t := PHeap.t.

--- a/backend/LTL.v
+++ b/backend/LTL.v
@@ -15,9 +15,9 @@
   LTL (``Location Transfer Language'') is the target language
   for register allocation and the source language for linearization. *)
 
-Require Import Coqlib Maps.
-Require Import AST Integers Values Events Memory Globalenvs Smallstep.
-Require Import Op Locations Conventions.
+Require Import compcert.Coqlib compcert.Maps.
+Require Import compcert.AST compcert.Integers compcert.Values compcert.Events compcert.Memory compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Locations compcert.Conventions.
 
 (** * Abstract syntax *)
 

--- a/backend/Linear.v
+++ b/backend/Linear.v
@@ -16,9 +16,9 @@
     expressed as a graph of basic blocks, but as a linear list of
     instructions with explicit labels and ``goto'' instructions. *)
 
-Require Import Coqlib.
-Require Import AST Integers Values Memory Events Globalenvs Smallstep.
-Require Import Op Locations LTL Conventions.
+Require Import compcert.Coqlib.
+Require Import compcert.AST compcert.Integers compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Locations compcert.LTL compcert.Conventions.
 
 (** * Abstract syntax *)
 

--- a/backend/Linearize.v
+++ b/backend/Linearize.v
@@ -13,8 +13,8 @@
 (** Linearization of the control-flow graph: translation from LTL to Linear *)
 
 Require Import FSets FSetAVL.
-Require Import Coqlib Maps Ordered Errors Lattice Kildall.
-Require Import AST Op Locations LTL Linear.
+Require Import compcert.Coqlib compcert.Maps compcert.Ordered compcert.Errors compcert.Lattice compcert.Kildall.
+Require Import compcert.AST compcert.Op compcert.Locations compcert.LTL compcert.Linear.
 
 Open Scope error_monad_scope.
 

--- a/backend/Linearizeproof.v
+++ b/backend/Linearizeproof.v
@@ -13,11 +13,11 @@
 (** Correctness proof for code linearization *)
 
 Require Import FSets.
-Require Import Coqlib Maps Ordered Errors Lattice Kildall Integers.
-Require Import AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Op Locations LTL Linear.
-Require Import Linearize.
+Require Import compcert.Coqlib compcert.Maps compcert.Ordered compcert.Errors compcert.Lattice compcert.Kildall compcert.Integers.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Locations compcert.LTL compcert.Linear.
+Require Import compcert.Linearize.
 
 Module NodesetFacts := FSetFacts.Facts(Nodeset).
 

--- a/backend/Lineartyping.v
+++ b/backend/Lineartyping.v
@@ -12,19 +12,19 @@
 
 (** Type-checking Linear code. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Values.
-Require Import Globalenvs.
-Require Import Memory.
-Require Import Events.
-Require Import Op.
-Require Import Machregs.
-Require Import Locations.
-Require Import Conventions.
-Require Import LTL.
-Require Import Linear.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Values.
+Require Import compcert.Globalenvs.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.Op.
+Require Import compcert.Machregs.
+Require Import compcert.Locations.
+Require Import compcert.Conventions.
+Require Import compcert.LTL.
+Require Import compcert.Linear.
 
 (** The rules are presented as boolean-valued functions so that we
   get an executable type-checker for free. *)

--- a/backend/Liveness.v
+++ b/backend/Liveness.v
@@ -12,14 +12,14 @@
 
 (** Liveness analysis over RTL *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import Lattice.
-Require Import AST.
-Require Import Op.
-Require Import Registers.
-Require Import RTL.
-Require Import Kildall.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.Lattice.
+Require Import compcert.AST.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.RTL.
+Require Import compcert.Kildall.
 
 (** A register [r] is live at a point [p] if there exists a path
   from [p] to some instruction that uses [r] as argument,

--- a/backend/Locations.v
+++ b/backend/Locations.v
@@ -14,12 +14,12 @@
   the results of register allocation (file [Allocation]). *)
 
 Require Import OrderedType.
-Require Import Coqlib.
-Require Import Maps.
-Require Import Ordered.
-Require Import AST.
-Require Import Values.
-Require Export Machregs.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.Ordered.
+Require Import compcert.AST.
+Require Import compcert.Values.
+Require Export compcert.Machregs.
 
 (** * Representation of locations *)
 

--- a/backend/Mach.v
+++ b/backend/Mach.v
@@ -16,19 +16,19 @@
   code.
 *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Events.
-Require Import Smallstep.
-Require Import Op.
-Require Import Locations.
-Require Import Conventions.
-Require Stacklayout.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Events.
+Require Import compcert.Smallstep.
+Require Import compcert.Op.
+Require Import compcert.Locations.
+Require Import compcert.Conventions.
+Require compcert.Stacklayout.
 
 (** * Abstract syntax *)
 

--- a/backend/NeedDomain.v
+++ b/backend/NeedDomain.v
@@ -12,21 +12,21 @@
 
 (** Abstract domain for neededness analysis *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import IntvSets.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Events.
-Require Import Lattice.
-Require Import Registers.
-Require Import ValueDomain.
-Require Import Op.
-Require Import RTL.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.IntvSets.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Events.
+Require Import compcert.Lattice.
+Require Import compcert.Registers.
+Require Import compcert.ValueDomain.
+Require Import compcert.Op.
+Require Import compcert.RTL.
 
 (** * Neededness for values *)
 

--- a/backend/RTL.v
+++ b/backend/RTL.v
@@ -16,9 +16,9 @@
   intermediate language after Cminor and CminorSel.
 *)
 
-Require Import Coqlib Maps.
-Require Import AST Integers Values Events Memory Globalenvs Smallstep.
-Require Import Op Registers.
+Require Import compcert.Coqlib compcert.Maps.
+Require Import compcert.AST compcert.Integers compcert.Values compcert.Events compcert.Memory compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Registers.
 
 (** * Abstract syntax *)
 

--- a/backend/RTLgen.v
+++ b/backend/RTLgen.v
@@ -12,16 +12,16 @@
 
 (** Translation from CminorSel to RTL. *)
 
-Require Import Coqlib.
-Require Errors.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Switch.
-Require Import Op.
-Require Import Registers.
-Require Import CminorSel.
-Require Import RTL.
+Require Import compcert.Coqlib.
+Require compcert.Errors.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Switch.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.CminorSel.
+Require Import compcert.RTL.
 
 Local Open Scope string_scope.
 

--- a/backend/RTLgenproof.v
+++ b/backend/RTLgenproof.v
@@ -12,10 +12,10 @@
 
 (** Correctness proof for RTL generation. *)
 
-Require Import Coqlib Maps AST Linking.
-Require Import Integers Values Memory Events Smallstep Globalenvs.
-Require Import Switch Registers Cminor Op CminorSel RTL.
-Require Import RTLgen RTLgenspec.
+Require Import compcert.Coqlib compcert.Maps compcert.AST compcert.Linking.
+Require Import compcert.Integers compcert.Values compcert.Memory compcert.Events compcert.Smallstep compcert.Globalenvs.
+Require Import compcert.Switch compcert.Registers compcert.Cminor compcert.Op compcert.CminorSel compcert.RTL.
+Require Import compcert.RTLgen compcert.RTLgenspec.
 
 (** * Correspondence between Cminor environments and RTL register sets *)
 
@@ -346,7 +346,7 @@ Qed.
 
 (** * The simulation argument *)
 
-Require Import Errors.
+Require Import compcert.Errors.
 
 Definition match_prog (p: CminorSel.program) (tp: RTL.program) :=
   match_program (fun cu f tf => transl_fundef f = Errors.OK tf) eq p tp.

--- a/backend/RTLgenspec.v
+++ b/backend/RTLgenspec.v
@@ -20,17 +20,17 @@
   the source Cminor code and the the generated RTL code
   (see module [RTLgenproof]). *)
 
-Require Import Coqlib.
-Require Errors.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Switch.
-Require Import Op.
-Require Import Registers.
-Require Import CminorSel.
-Require Import RTL.
-Require Import RTLgen.
+Require Import compcert.Coqlib.
+Require compcert.Errors.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Switch.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.CminorSel.
+Require Import compcert.RTL.
+Require Import compcert.RTLgen.
 
 (** * Reasoning about monadic computations *)
 

--- a/backend/RTLtyping.v
+++ b/backend/RTLtyping.v
@@ -12,20 +12,20 @@
 
 (** Typing rules and a type inference algorithm for RTL. *)
 
-Require Import Coqlib.
-Require Import Errors.
-Require Import Unityping.
-Require Import Maps.
-Require Import AST.
-Require Import Op.
-Require Import Registers.
-Require Import Globalenvs.
-Require Import Values.
-Require Import Integers.
-Require Import Memory.
-Require Import Events.
-Require Import RTL.
-Require Import Conventions.
+Require Import compcert.Coqlib.
+Require Import compcert.Errors.
+Require Import compcert.Unityping.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.Globalenvs.
+Require Import compcert.Values.
+Require Import compcert.Integers.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.RTL.
+Require Import compcert.Conventions.
 
 (** * The type system *)
 

--- a/backend/Registers.v
+++ b/backend/Registers.v
@@ -17,12 +17,12 @@
   intermediate language.  We also define finite sets and finite maps
   over pseudo-registers. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Maps.
-Require Import Ordered.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Maps.
+Require Import compcert.Ordered.
 Require FSetAVL.
-Require Import Values.
+Require Import compcert.Values.
 
 Definition reg: Type := positive.
 

--- a/backend/Renumber.v
+++ b/backend/Renumber.v
@@ -12,10 +12,10 @@
 
 (** Postorder renumbering of RTL control-flow graphs. *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import Postorder.
-Require Import RTL.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.Postorder.
+Require Import compcert.RTL.
 
 (** CompCert's dataflow analyses (module [Kildall]) are more precise
   and run faster when the sequence [1, 2, 3, ...]  is a postorder

--- a/backend/Renumberproof.v
+++ b/backend/Renumberproof.v
@@ -12,10 +12,10 @@
 
 (** Postorder renumbering of RTL control-flow graphs. *)
 
-Require Import Coqlib Maps Postorder.
-Require Import AST Linking.
-Require Import Values Memory Globalenvs Events Smallstep.
-Require Import Op Registers RTL Renumber.
+Require Import compcert.Coqlib compcert.Maps compcert.Postorder.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs compcert.Events compcert.Smallstep.
+Require Import compcert.Op compcert.Registers compcert.RTL compcert.Renumber.
 
 Definition match_prog (p tp: RTL.program) :=
   match_program (fun ctx f tf => tf = transf_fundef f) eq p tp.

--- a/backend/SelectDiv.vp
+++ b/backend/SelectDiv.vp
@@ -12,10 +12,10 @@
 
 (** Instruction selection for division and modulus *)
 
-Require Import Coqlib.
-Require Import Compopts.
-Require Import AST Integers Floats.
-Require Import Op CminorSel SelectOp SplitLong SelectLong.
+Require Import compcert.Coqlib.
+Require Import compcert.Compopts.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.CminorSel compcert.SelectOp compcert.SplitLong compcert.SelectLong.
 
 Local Open Scope cminorsel_scope.
 

--- a/backend/SelectDivproof.v
+++ b/backend/SelectDivproof.v
@@ -12,10 +12,10 @@
 
 (** Correctness of instruction selection for integer division *)
 
-Require Import Zquot Coqlib.
-Require Import AST Integers Floats Values Memory Globalenvs Events.
-Require Import Cminor Op CminorSel.
-Require Import SelectOp SelectOpproof SplitLong SplitLongproof SelectLong SelectLongproof SelectDiv.
+Require Import Zquot compcert.Coqlib.
+Require Import compcert.AST compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Cminor compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SelectOpproof compcert.SplitLong compcert.SplitLongproof compcert.SelectLong compcert.SelectLongproof compcert.SelectDiv.
 
 Local Open Scope cminorsel_scope.
 

--- a/backend/Selection.v
+++ b/backend/Selection.v
@@ -23,12 +23,12 @@
   The source language is Cminor and the target language is CminorSel. *)
 
 Require String.
-Require Import Coqlib Maps.
-Require Import AST Errors Integers Globalenvs Switch.
-Require Cminor.
-Require Import Op CminorSel.
-Require Import SelectOp SplitLong SelectLong SelectDiv.
-Require Machregs.
+Require Import compcert.Coqlib compcert.Maps.
+Require Import compcert.AST compcert.Errors compcert.Integers compcert.Globalenvs compcert.Switch.
+Require compcert.Cminor.
+Require Import compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SplitLong compcert.SelectLong compcert.SelectDiv.
+Require compcert.Machregs.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope error_monad_scope.

--- a/backend/Selectionproof.v
+++ b/backend/Selectionproof.v
@@ -12,11 +12,11 @@
 
 (** Correctness of instruction selection *)
 
-Require Import Coqlib Maps.
-Require Import AST Linking Errors Integers Values Memory Events Globalenvs Smallstep.
-Require Import Switch Cminor Op CminorSel.
-Require Import SelectOp SelectDiv SplitLong SelectLong Selection.
-Require Import SelectOpproof SelectDivproof SplitLongproof SelectLongproof.
+Require Import compcert.Coqlib compcert.Maps.
+Require Import compcert.AST compcert.Linking compcert.Errors compcert.Integers compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Switch compcert.Cminor compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SelectDiv compcert.SplitLong compcert.SelectLong compcert.Selection.
+Require Import compcert.SelectOpproof compcert.SelectDivproof compcert.SplitLongproof compcert.SelectLongproof.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope error_monad_scope.

--- a/backend/SplitLong.vp
+++ b/backend/SplitLong.vp
@@ -13,10 +13,10 @@
 (** Instruction selection for 64-bit integer operations *)
 
 Require String.
-Require Import Coqlib.
-Require Import AST Integers Floats.
-Require Import Op CminorSel.
-Require Import SelectOp.
+Require Import compcert.Coqlib.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope string_scope.

--- a/backend/SplitLongproof.v
+++ b/backend/SplitLongproof.v
@@ -13,10 +13,10 @@
 (** Correctness of instruction selection for integer division *)
 
 Require Import String.
-Require Import Coqlib Maps.
-Require Import AST Errors Integers Floats.
-Require Import Values Memory Globalenvs Events Cminor Op CminorSel.
-Require Import SelectOp SelectOpproof SplitLong.
+Require Import compcert.Coqlib compcert.Maps.
+Require Import compcert.AST compcert.Errors compcert.Integers compcert.Floats.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs compcert.Events compcert.Cminor compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SelectOpproof compcert.SplitLong.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope string_scope.

--- a/backend/Stacking.v
+++ b/backend/Stacking.v
@@ -12,10 +12,10 @@
 
 (** Layout of activation records; translation from Linear to Mach. *)
 
-Require Import Coqlib Errors.
-Require Import Integers AST.
-Require Import Op Locations Linear Mach.
-Require Import Bounds Conventions Stacklayout Lineartyping.
+Require Import compcert.Coqlib compcert.Errors.
+Require Import compcert.Integers compcert.AST.
+Require Import compcert.Op compcert.Locations compcert.Linear compcert.Mach.
+Require Import compcert.Bounds compcert.Conventions compcert.Stacklayout compcert.Lineartyping.
 
 (** * Layout of activation records *)
 

--- a/backend/Stackingproof.v
+++ b/backend/Stackingproof.v
@@ -14,12 +14,12 @@
 
 (** This file proves semantic preservation for the [Stacking] pass. *)
 
-Require Import Coqlib Errors.
-Require Import Integers AST Linking.
-Require Import Values Memory Separation Events Globalenvs Smallstep.
-Require Import LTL Op Locations Linear Mach.
-Require Import Bounds Conventions Stacklayout Lineartyping.
-Require Import Stacking.
+Require Import compcert.Coqlib compcert.Errors.
+Require Import compcert.Integers compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Separation compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.LTL compcert.Op compcert.Locations compcert.Linear compcert.Mach.
+Require Import compcert.Bounds compcert.Conventions compcert.Stacklayout compcert.Lineartyping.
+Require Import compcert.Stacking.
 
 Local Open Scope sep_scope.
 

--- a/backend/Tailcall.v
+++ b/backend/Tailcall.v
@@ -12,7 +12,7 @@
 
 (** Recognition of tail calls. *)
 
-Require Import Coqlib Maps AST Registers Op RTL Conventions.
+Require Import compcert.Coqlib compcert.Maps compcert.AST compcert.Registers compcert.Op compcert.RTL compcert.Conventions.
 
 (** An [Icall] instruction that stores its result in register [rreg]
   can be turned into a tail call if:

--- a/backend/Tailcallproof.v
+++ b/backend/Tailcallproof.v
@@ -12,9 +12,9 @@
 
 (** Recognition of tail calls: correctness proof *)
 
-Require Import Coqlib Maps Integers AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Op Registers RTL Conventions Tailcall.
+Require Import compcert.Coqlib compcert.Maps compcert.Integers compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Registers compcert.RTL compcert.Conventions compcert.Tailcall.
 
 (** * Syntactic properties of the code transformation *)
 

--- a/backend/Tunneling.v
+++ b/backend/Tunneling.v
@@ -12,9 +12,9 @@
 
 (** Branch tunneling (optimization of branches to branches). *)
 
-Require Import Coqlib Maps UnionFind.
-Require Import AST.
-Require Import LTL.
+Require Import compcert.Coqlib compcert.Maps compcert.UnionFind.
+Require Import compcert.AST.
+Require Import compcert.LTL.
 
 (** Branch tunneling shortens sequences of branches (with no intervening
   computations) by rewriting the branch and conditional branch instructions

--- a/backend/Tunnelingproof.v
+++ b/backend/Tunnelingproof.v
@@ -12,11 +12,11 @@
 
 (** Correctness proof for the branch tunneling optimization. *)
 
-Require Import Coqlib Maps UnionFind.
-Require Import AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Op Locations LTL.
-Require Import Tunneling.
+Require Import compcert.Coqlib compcert.Maps compcert.UnionFind.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Locations compcert.LTL.
+Require Import compcert.Tunneling.
 
 Definition match_prog (p tp: program) :=
   match_program (fun ctx f tf => tf = tunnel_fundef f) eq p tp.

--- a/backend/Unusedglob.v
+++ b/backend/Unusedglob.v
@@ -12,9 +12,9 @@
 
 (** Elimination of unreferenced static definitions *)
 
-Require Import FSets Coqlib Maps Ordered Iteration Errors.
-Require Import AST Linking.
-Require Import Op Registers RTL.
+Require Import FSets compcert.Coqlib compcert.Maps compcert.Ordered compcert.Iteration compcert.Errors.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Op compcert.Registers compcert.RTL.
 
 Local Open Scope string_scope.
 

--- a/backend/Unusedglobproof.v
+++ b/backend/Unusedglobproof.v
@@ -12,11 +12,11 @@
 
 (** Elimination of unreferenced static definitions *)
 
-Require Import FSets Coqlib Maps Ordered Iteration Errors.
-Require Import AST Linking.
-Require Import Integers Values Memory Globalenvs Events Smallstep.
-Require Import Op Registers RTL.
-Require Import Unusedglob.
+Require Import FSets compcert.Coqlib compcert.Maps compcert.Ordered compcert.Iteration compcert.Errors.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Integers compcert.Values compcert.Memory compcert.Globalenvs compcert.Events compcert.Smallstep.
+Require Import compcert.Op compcert.Registers compcert.RTL.
+Require Import compcert.Unusedglob.
 
 Module ISF := FSetFacts.Facts(IS).
 Module ISP := FSetProperties.Properties(IS).

--- a/backend/ValueAnalysis.v
+++ b/backend/ValueAnalysis.v
@@ -10,11 +10,11 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import Coqlib Maps Integers Floats Lattice Kildall.
-Require Import Compopts AST Linking.
-Require Import Values Memory Globalenvs Events.
-Require Import Registers Op RTL.
-Require Import ValueDomain ValueAOp Liveness.
+Require Import compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Lattice compcert.Kildall.
+Require Import compcert.Compopts compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Registers compcert.Op compcert.RTL.
+Require Import compcert.ValueDomain compcert.ValueAOp compcert.Liveness.
 
 (** * The dataflow analysis *)
 
@@ -1851,7 +1851,7 @@ Qed.
 
 End INITIAL.
 
-Require Import Axioms.
+Require Import compcert.Axioms.
 
 Theorem sound_initial:
   forall prog st, initial_state prog st -> sound_state prog st.

--- a/backend/ValueDomain.v
+++ b/backend/ValueDomain.v
@@ -10,10 +10,10 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import Zwf Coqlib Maps Integers Floats Lattice.
-Require Import Compopts AST.
-Require Import Values Memory Globalenvs Events.
-Require Import Registers RTL.
+Require Import Zwf compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Lattice.
+Require Import compcert.Compopts compcert.AST.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Registers compcert.RTL.
 
 (** The abstract domains for value analysis *)
 

--- a/cfrontend/Cexec.v
+++ b/cfrontend/Cexec.v
@@ -12,12 +12,12 @@
 
 (** Animating the CompCert C semantics *)
 
-Require Import Axioms Classical.
-Require Import String Coqlib Decidableplus.
-Require Import Errors Maps Integers Floats.
-Require Import AST Values Memory Events Globalenvs Determinism.
-Require Import Ctypes Cop Csyntax Csem.
-Require Cstrategy.
+Require Import compcert.Axioms Classical.
+Require Import String compcert.Coqlib compcert.Decidableplus.
+Require Import compcert.Errors compcert.Maps compcert.Integers compcert.Floats.
+Require Import compcert.AST compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Determinism.
+Require Import compcert.Ctypes compcert.Cop compcert.Csyntax compcert.Csem.
+Require compcert.Cstrategy.
 
 Local Open Scope string_scope.
 Local Open Scope list_scope.

--- a/cfrontend/Clight.v
+++ b/cfrontend/Clight.v
@@ -17,19 +17,19 @@
   expressions are pure and assignments and function calls are
   statements, not expressions. *)
 
-Require Import Coqlib.
-Require Import Errors.
-Require Import Maps.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import AST.
-Require Import Memory.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Smallstep.
-Require Import Ctypes.
-Require Import Cop.
+Require Import compcert.Coqlib.
+Require Import compcert.Errors.
+Require Import compcert.Maps.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.AST.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
+Require Import compcert.Ctypes.
+Require Import compcert.Cop.
 
 (** * Abstract syntax *)
 

--- a/cfrontend/ClightBigstep.v
+++ b/cfrontend/ClightBigstep.v
@@ -15,19 +15,19 @@
 
 (** A big-step semantics for the Clight language. *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import AST.
-Require Import Memory.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Smallstep.
-Require Import Ctypes.
-Require Import Cop.
-Require Import Clight.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.AST.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
+Require Import compcert.Ctypes.
+Require Import compcert.Cop.
+Require Import compcert.Clight.
 
 Section BIGSTEP.
 

--- a/cfrontend/Cminorgen.v
+++ b/cfrontend/Cminorgen.v
@@ -13,9 +13,9 @@
 (** Translation from Csharpminor to Cminor. *)
 
 Require Import FSets FSetAVL Orders Mergesort.
-Require Import Coqlib Maps Ordered Errors Integers Floats.
-Require Import AST Linking.
-Require Import Csharpminor Cminor.
+Require Import compcert.Coqlib compcert.Maps compcert.Ordered compcert.Errors compcert.Integers compcert.Floats.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Csharpminor compcert.Cminor.
 
 Local Open Scope string_scope.
 Local Open Scope error_monad_scope.

--- a/cfrontend/Cminorgenproof.v
+++ b/cfrontend/Cminorgenproof.v
@@ -14,11 +14,11 @@
 
 Require Import Coq.Program.Equality FSets Permutation.
 Require Import FSets FSetAVL Orders Mergesort.
-Require Import Coqlib Maps Ordered Errors Integers Floats.
-Require Intv.
-Require Import AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Csharpminor Switch Cminor Cminorgen.
+Require Import compcert.Coqlib compcert.Maps compcert.Ordered compcert.Errors compcert.Integers compcert.Floats.
+Require compcert.Intv.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Csharpminor compcert.Switch compcert.Cminor compcert.Cminorgen.
 
 Local Open Scope error_monad_scope.
 

--- a/cfrontend/Cop.v
+++ b/cfrontend/Cop.v
@@ -15,14 +15,14 @@
 
 (** Arithmetic and logical operators for the Compcert C and Clight languages *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Ctypes.
-Require Archi.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Ctypes.
+Require compcert.Archi.
 
 (** * Syntax of operators. *)
 

--- a/cfrontend/Csem.v
+++ b/cfrontend/Csem.v
@@ -15,20 +15,20 @@
 
 (** Dynamic semantics for the Compcert C language *)
 
-Require Import Coqlib.
-Require Import Errors.
-Require Import Maps.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import AST.
-Require Import Memory.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Ctypes.
-Require Import Cop.
-Require Import Csyntax.
-Require Import Smallstep.
+Require Import compcert.Coqlib.
+Require Import compcert.Errors.
+Require Import compcert.Maps.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.AST.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Ctypes.
+Require Import compcert.Cop.
+Require Import compcert.Csyntax.
+Require Import compcert.Smallstep.
 
 (** * Operational semantics *)
 

--- a/cfrontend/Csharpminor.v
+++ b/cfrontend/Csharpminor.v
@@ -12,18 +12,18 @@
 
 (** Abstract syntax and semantics for the Csharpminor language. *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Switch.
-Require Cminor.
-Require Import Smallstep.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Switch.
+Require compcert.Cminor.
+Require Import compcert.Smallstep.
 
 (** Abstract syntax *)
 

--- a/cfrontend/Cshmgen.v
+++ b/cfrontend/Cshmgen.v
@@ -20,9 +20,9 @@
    Csharpminor's simpler control structures.
 *)
 
-Require Import Coqlib Maps Errors Integers Floats.
-Require Import AST Linking.
-Require Import Ctypes Cop Clight Cminor Csharpminor.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors compcert.Integers compcert.Floats.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Ctypes compcert.Cop compcert.Clight compcert.Cminor compcert.Csharpminor.
 
 Local Open Scope string_scope.
 Local Open Scope error_monad_scope.

--- a/cfrontend/Cshmgenproof.v
+++ b/cfrontend/Cshmgenproof.v
@@ -12,11 +12,11 @@
 
 (** * Correctness of the translation from Clight to C#minor. *)
 
-Require Import Coqlib Errors Maps Integers Floats.
-Require Import AST Linking.
-Require Import Values Events Memory Globalenvs Smallstep.
-Require Import Ctypes Cop Clight Cminor Csharpminor.
-Require Import Cshmgen.
+Require Import compcert.Coqlib compcert.Errors compcert.Maps compcert.Integers compcert.Floats.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Events compcert.Memory compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Ctypes compcert.Cop compcert.Clight compcert.Cminor compcert.Csharpminor.
+Require Import compcert.Cshmgen.
 
 (** * Relational specification of the transformation *)
 

--- a/cfrontend/Cstrategy.v
+++ b/cfrontend/Cstrategy.v
@@ -15,22 +15,22 @@
 
 (** A deterministic evaluation strategy for C. *)
 
-Require Import Axioms.
-Require Import Coqlib.
-Require Import Errors.
-Require Import Maps.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import AST.
-Require Import Memory.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Smallstep.
-Require Import Ctypes.
-Require Import Cop.
-Require Import Csyntax.
-Require Import Csem.
+Require Import compcert.Axioms.
+Require Import compcert.Coqlib.
+Require Import compcert.Errors.
+Require Import compcert.Maps.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.AST.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
+Require Import compcert.Ctypes.
+Require Import compcert.Cop.
+Require Import compcert.Csyntax.
+Require Import compcert.Csem.
 
 Section STRATEGY.
 

--- a/cfrontend/Csyntax.v
+++ b/cfrontend/Csyntax.v
@@ -15,9 +15,9 @@
 
 (** Abstract syntax for the Compcert C language *)
 
-Require Import Coqlib Maps Integers Floats Errors.
-Require Import AST Linking Values.
-Require Import Ctypes Cop.
+Require Import compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Errors.
+Require Import compcert.AST compcert.Linking compcert.Values.
+Require Import compcert.Ctypes compcert.Cop.
 
 (** ** Expressions *)
 

--- a/cfrontend/Ctypes.v
+++ b/cfrontend/Ctypes.v
@@ -15,9 +15,9 @@
 
 (** Type expressions for the Compcert C and Clight languages *)
 
-Require Import Axioms Coqlib Maps Errors.
-Require Import AST Linking.
-Require Archi.
+Require Import compcert.Axioms compcert.Coqlib compcert.Maps compcert.Errors.
+Require Import compcert.AST compcert.Linking.
+Require compcert.Archi.
 
 (** * Syntax of types *)
 

--- a/cfrontend/Ctyping.v
+++ b/cfrontend/Ctyping.v
@@ -16,10 +16,10 @@
 (** Typing rules and type-checking for the Compcert C language *)
 
 Require Import String.
-Require Import Coqlib Maps Integers Floats Errors.
-Require Import AST Linking.
-Require Import Values Memory Globalenvs Events.
-Require Import Ctypes Cop Csyntax Csem.
+Require Import compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Errors.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Ctypes compcert.Cop compcert.Csyntax compcert.Csem.
 
 Local Open Scope error_monad_scope.
 

--- a/cfrontend/Initializers.v
+++ b/cfrontend/Initializers.v
@@ -12,9 +12,9 @@
 
 (** Compile-time evaluation of initializers for global C variables. *)
 
-Require Import Coqlib Maps Errors.
-Require Import Integers Floats Values AST Memory Globalenvs.
-Require Import Ctypes Cop Csyntax.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors.
+Require Import compcert.Integers compcert.Floats compcert.Values compcert.AST compcert.Memory compcert.Globalenvs.
+Require Import compcert.Ctypes compcert.Cop compcert.Csyntax.
 
 Open Scope error_monad_scope.
 

--- a/cfrontend/Initializersproof.v
+++ b/cfrontend/Initializersproof.v
@@ -12,10 +12,10 @@
 
 (** Compile-time evaluation of initializers for global C variables. *)
 
-Require Import Coqlib Maps.
-Require Import Errors Integers Floats Values AST Memory Globalenvs Events Smallstep.
-Require Import Ctypes Cop Csyntax Csem.
-Require Import Initializers.
+Require Import compcert.Coqlib compcert.Maps.
+Require Import compcert.Errors compcert.Integers compcert.Floats compcert.Values compcert.AST compcert.Memory compcert.Globalenvs compcert.Events compcert.Smallstep.
+Require Import compcert.Ctypes compcert.Cop compcert.Csyntax compcert.Csem.
+Require Import compcert.Initializers.
 
 Open Scope error_monad_scope.
 

--- a/cfrontend/SimplExpr.v
+++ b/cfrontend/SimplExpr.v
@@ -13,17 +13,17 @@
 (** Translation from Compcert C to Clight.
     Side effects are pulled out of Compcert C expressions. *)
 
-Require Import Coqlib.
-Require Import Errors.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import AST.
-Require Import Ctypes.
-Require Import Cop.
-Require Import Csyntax.
-Require Import Clight.
+Require Import compcert.Coqlib.
+Require Import compcert.Errors.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.AST.
+Require Import compcert.Ctypes.
+Require Import compcert.Cop.
+Require Import compcert.Csyntax.
+Require Import compcert.Clight.
 
 Local Open Scope string_scope.
 

--- a/cfrontend/SimplExprproof.v
+++ b/cfrontend/SimplExprproof.v
@@ -12,11 +12,11 @@
 
 (** Correctness proof for expression simplification. *)
 
-Require Import Coqlib Maps Errors Integers.
-Require Import AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Ctypes Cop Csyntax Csem Cstrategy Clight.
-Require Import SimplExpr SimplExprspec.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors compcert.Integers.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Ctypes compcert.Cop compcert.Csyntax compcert.Csem compcert.Cstrategy compcert.Clight.
+Require Import compcert.SimplExpr compcert.SimplExprspec.
 
 (** ** Relational specification of the translation. *)
 

--- a/cfrontend/SimplExprspec.v
+++ b/cfrontend/SimplExprspec.v
@@ -12,9 +12,9 @@
 
 (** Relational specification of expression simplification. *)
 
-Require Import Coqlib Maps Errors Integers Floats.
-Require Import AST Linking Memory.
-Require Import Ctypes Cop Csyntax Clight SimplExpr.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors compcert.Integers compcert.Floats.
+Require Import compcert.AST compcert.Linking compcert.Memory.
+Require Import compcert.Ctypes compcert.Cop compcert.Csyntax compcert.Clight compcert.SimplExpr.
 
 Section SPEC.
 

--- a/cfrontend/SimplLocals.v
+++ b/cfrontend/SimplLocals.v
@@ -15,10 +15,10 @@
 
 Require Import FSets.
 Require FSetAVL.
-Require Import Coqlib Ordered Errors.
-Require Import AST Linking.
-Require Import Ctypes Cop Clight.
-Require Compopts.
+Require Import compcert.Coqlib compcert.Ordered compcert.Errors.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Ctypes compcert.Cop compcert.Clight.
+Require compcert.Compopts.
 
 Open Scope error_monad_scope.
 Open Scope string_scope.

--- a/cfrontend/SimplLocalsproof.v
+++ b/cfrontend/SimplLocalsproof.v
@@ -13,10 +13,10 @@
 (** Semantic preservation for the SimplLocals pass. *)
 
 Require Import FSets.
-Require Import Coqlib Errors Ordered Maps Integers Floats.
-Require Import AST Linking.
-Require Import Values Memory Globalenvs Events Smallstep.
-Require Import Ctypes Cop Clight SimplLocals.
+Require Import compcert.Coqlib compcert.Errors compcert.Ordered compcert.Maps compcert.Integers compcert.Floats.
+Require Import compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs compcert.Events compcert.Smallstep.
+Require Import compcert.Ctypes compcert.Cop compcert.Clight compcert.SimplLocals.
 
 Module VSF := FSetFacts.Facts(VSet).
 Module VSP := FSetProperties.Properties(VSet).

--- a/common/AST.v
+++ b/common/AST.v
@@ -17,8 +17,8 @@
   the abstract syntax trees of many of the intermediate languages. *)
 
 Require Import String.
-Require Import Coqlib Maps Errors Integers Floats.
-Require Archi.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors compcert.Integers compcert.Floats.
+Require compcert.Archi.
 
 Set Implicit Arguments.
 

--- a/common/Behaviors.v
+++ b/common/Behaviors.v
@@ -17,11 +17,11 @@
 
 Require Import Classical.
 Require Import ClassicalEpsilon.
-Require Import Coqlib.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Integers.
-Require Import Smallstep.
+Require Import compcert.Coqlib.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Integers.
+Require Import compcert.Smallstep.
 
 Set Implicit Arguments.
 

--- a/common/Determinism.v
+++ b/common/Determinism.v
@@ -17,13 +17,13 @@
   and deterministic semantics *)
 
 Require Import String.
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Smallstep.
-Require Import Behaviors.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
+Require Import compcert.Behaviors.
 
 (** * Deterministic worlds *)
 

--- a/common/Errors.v
+++ b/common/Errors.v
@@ -16,7 +16,7 @@
 (** Error reporting and the error monad. *)
 
 Require Import String.
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 
 Close Scope string_scope.
 

--- a/common/Events.v
+++ b/common/Events.v
@@ -16,14 +16,14 @@
 (** Observable events, execution traces, and semantics of external calls. *)
 
 Require Import String.
-Require Import Coqlib.
-Require Intv.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
+Require Import compcert.Coqlib.
+Require compcert.Intv.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
 
 (** * Events and traces *)
 

--- a/common/Globalenvs.v
+++ b/common/Globalenvs.v
@@ -35,8 +35,8 @@
 
 Require Recdef.
 Require Import Zwf.
-Require Import Axioms Coqlib Errors Maps AST Linking.
-Require Import Integers Floats Values Memory.
+Require Import compcert.Axioms compcert.Coqlib compcert.Errors compcert.Maps compcert.AST compcert.Linking.
+Require Import compcert.Integers compcert.Floats compcert.Values compcert.Memory.
 
 Notation "s #1" := (fst s) (at level 9, format "s '#1'") : pair_scope.
 Notation "s #2" := (snd s) (at level 9, format "s '#2'") : pair_scope.

--- a/common/Linking.v
+++ b/common/Linking.v
@@ -15,7 +15,7 @@
 
 (** Separate compilation and syntactic linking *)
 
-Require Import Coqlib Maps Errors AST.
+Require Import compcert.Coqlib compcert.Maps compcert.Errors compcert.AST.
 
 (** This file follows "approach A" from the paper
        "Lightweight Verification of Separate Compilation"

--- a/common/Memdata.v
+++ b/common/Memdata.v
@@ -16,12 +16,12 @@
 
 (** In-memory representation of values. *)
 
-Require Import Coqlib.
-Require Archi.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
+Require Import compcert.Coqlib.
+Require compcert.Archi.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
 
 (** * Properties of memory chunks *)
 

--- a/common/Memory.v
+++ b/common/Memory.v
@@ -27,17 +27,17 @@
 *)
 
 Require Import Zwf.
-Require Import Axioms.
-Require Import Coqlib.
-Require Intv.
-Require Import Maps.
-Require Archi.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Export Memdata.
-Require Export Memtype.
+Require Import compcert.Axioms.
+Require Import compcert.Coqlib.
+Require compcert.Intv.
+Require Import compcert.Maps.
+Require compcert.Archi.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Export compcert.Memdata.
+Require Export compcert.Memtype.
 
 (* To avoid useless definitions of inductors in extracted code. *)
 Local Unset Elimination Schemes.

--- a/common/Memtype.v
+++ b/common/Memtype.v
@@ -23,12 +23,12 @@
 - [free]: invalidate a memory block.
 *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memdata.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memdata.
 
 (** Memory states are accessed by addresses [b, ofs]: pairs of a block
   identifier [b] and a byte offset [ofs] within that block.

--- a/common/Separation.v
+++ b/common/Separation.v
@@ -30,8 +30,8 @@
   by the lemmas that help us reason about the logical assertions. *)
 
 Require Import Setoid Program.Basics.
-Require Import Coqlib Decidableplus.
-Require Import AST Integers Values Memory Events Globalenvs.
+Require Import compcert.Coqlib compcert.Decidableplus.
+Require Import compcert.AST compcert.Integers compcert.Values compcert.Memory compcert.Events compcert.Globalenvs.
 
 (** * Assertions about memory *)
 

--- a/common/Smallstep.v
+++ b/common/Smallstep.v
@@ -21,10 +21,10 @@
 
 Require Import Relations.
 Require Import Wellfounded.
-Require Import Coqlib.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Integers.
+Require Import compcert.Coqlib.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Integers.
 
 Set Implicit Arguments.
 

--- a/common/Subtyping.v
+++ b/common/Subtyping.v
@@ -15,7 +15,7 @@
 
 (* A solver for subtyping constraints. *)
 
-Require Import Recdef Coqlib Maps Errors.
+Require Import Recdef compcert.Coqlib compcert.Maps compcert.Errors.
 
 Local Open Scope nat_scope.
 Local Open Scope error_monad_scope.

--- a/common/Switch.v
+++ b/common/Switch.v
@@ -17,10 +17,10 @@
     to comparison trees. *)
 
 Require Import EqNat.
-Require Import Coqlib.
-Require Import Maps.
-Require Import Integers.
-Require Import Values.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.Integers.
+Require Import compcert.Values.
 
 (** A multi-way branch is composed of a list of (key, action) pairs,
   plus a default action.  *)

--- a/common/Unityping.v
+++ b/common/Unityping.v
@@ -15,7 +15,7 @@
 
 (* A solver for unification constraints. *)
 
-Require Import Recdef Coqlib Maps Errors.
+Require Import Recdef compcert.Coqlib compcert.Maps compcert.Errors.
 
 Local Open Scope nat_scope.
 Local Open Scope error_monad_scope.

--- a/common/Values.v
+++ b/common/Values.v
@@ -16,10 +16,10 @@
 (** This module defines the type of values that is used in the dynamic
   semantics of all our intermediate languages. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
 
 Definition block : Type := positive.
 Definition eq_block := peq.

--- a/configure
+++ b/configure
@@ -588,18 +588,18 @@ B extraction
 
 EOF
 
-echo "-R lib compcert.lib \
--R common compcert.common \
--R ${arch} compcert.${arch} \
--R backend compcert.backend \
--R cfrontend compcert.cfrontend \
--R driver compcert.driver \
--R flocq compcert.flocq \
--R exportclight compcert.exportclight \
--R cparser compcert.cparser" > _CoqProject
+echo "-Q lib compcert \
+-Q common compcert \
+-Q ${arch} compcert \
+-Q backend compcert \
+-Q cfrontend compcert \
+-Q driver compcert \
+-Q flocq flocq \
+-Q exportclight compcert \
+-Q cparser compcert" > _CoqProject
 case $arch in
     x86)
-        echo "-R x86_${bitsize} compcert.x86_${bitsize}" >> _CoqProject
+        echo "-Q x86_${bitsize} compcert" >> _CoqProject
         ;;
 esac
 

--- a/cparser/Parser.vy
+++ b/cparser/Parser.vy
@@ -15,7 +15,7 @@
 
 %{
 
-Require Import Cabs.
+Require Import compcert.Cabs.
 Require Import List.
 
 %}

--- a/cparser/validator/Automaton.v
+++ b/cparser/validator/Automaton.v
@@ -13,9 +13,9 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Grammar.
+Require compcert.validator.Grammar.
 Require Import Orders.
-Require Export Alphabet.
+Require Export compcert.validator.Alphabet.
 Require Export List.
 Require Export Syntax.
 

--- a/cparser/validator/Grammar.v
+++ b/cparser/validator/Grammar.v
@@ -15,9 +15,9 @@
 
 Require Import List.
 Require Import Syntax.
-Require Import Alphabet.
+Require Import compcert.validator.Alphabet.
 Require Import Orders.
-Require Tuples.
+Require compcert.validator.Tuples.
 
 (** The terminal non-terminal alphabets of the grammar. **)
 Module Type Alphs.

--- a/cparser/validator/Interpreter.v
+++ b/cparser/validator/Interpreter.v
@@ -16,8 +16,8 @@
 Require Import Streams.
 Require Import List.
 Require Import Syntax.
-Require Automaton.
-Require Import Alphabet.
+Require compcert.validator.Automaton.
+Require Import compcert.validator.Alphabet.
 
 Module Make(Import A:Automaton.T).
 

--- a/cparser/validator/Interpreter_complete.v
+++ b/cparser/validator/Interpreter_complete.v
@@ -18,12 +18,12 @@ Require Import ProofIrrelevance.
 Require Import Equality.
 Require Import List.
 Require Import Syntax.
-Require Import Alphabet.
+Require Import compcert.validator.Alphabet.
 Require Import Arith.
-Require Grammar.
-Require Automaton.
-Require Interpreter.
-Require Validator_complete.
+Require compcert.validator.Grammar.
+Require compcert.validator.Automaton.
+Require compcert.validator.Interpreter.
+Require compcert.validator.Validator_complete.
 
 Module Make(Import A:Automaton.T) (Import Inter:Interpreter.T A).
 Module Import Valid := Validator_complete.Make A.

--- a/cparser/validator/Interpreter_correct.v
+++ b/cparser/validator/Interpreter_correct.v
@@ -17,10 +17,10 @@ Require Import Streams.
 Require Import List.
 Require Import Syntax.
 Require Import Equality.
-Require Import Alphabet.
-Require Grammar.
-Require Automaton.
-Require Interpreter.
+Require Import compcert.validator.Alphabet.
+Require compcert.validator.Grammar.
+Require compcert.validator.Automaton.
+Require compcert.validator.Interpreter.
 
 Module Make(Import A:Automaton.T) (Import Inter:Interpreter.T A).
 

--- a/cparser/validator/Interpreter_safe.v
+++ b/cparser/validator/Interpreter_safe.v
@@ -17,11 +17,11 @@ Require Import Streams.
 Require Import Equality.
 Require Import List.
 Require Import Syntax.
-Require Import Alphabet.
-Require Grammar.
-Require Automaton.
-Require Validator_safe.
-Require Interpreter.
+Require Import compcert.validator.Alphabet.
+Require compcert.validator.Grammar.
+Require compcert.validator.Automaton.
+Require compcert.validator.Validator_safe.
+Require compcert.validator.Interpreter.
 
 Module Make(Import A:Automaton.T) (Import Inter:Interpreter.T A).
 Module Import Valid := Validator_safe.Make A.

--- a/cparser/validator/Main.v
+++ b/cparser/validator/Main.v
@@ -13,11 +13,11 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Grammar.
-Require Automaton.
-Require Interpreter_safe.
-Require Interpreter_correct.
-Require Interpreter_complete.
+Require compcert.validator.Grammar.
+Require compcert.validator.Automaton.
+Require compcert.validator.Interpreter_safe.
+Require compcert.validator.Interpreter_correct.
+Require compcert.validator.Interpreter_complete.
 Require Import Syntax.
 
 Module Make(Export Aut:Automaton.T).

--- a/cparser/validator/Validator_complete.v
+++ b/cparser/validator/Validator_complete.v
@@ -13,8 +13,8 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Automaton.
-Require Import Alphabet.
+Require compcert.validator.Automaton.
+Require Import compcert.validator.Alphabet.
 Require Import List.
 Require Import Syntax.
 

--- a/cparser/validator/Validator_safe.v
+++ b/cparser/validator/Validator_safe.v
@@ -13,8 +13,8 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Automaton.
-Require Import Alphabet.
+Require compcert.validator.Automaton.
+Require Import compcert.validator.Alphabet.
 Require Import List.
 Require Import Syntax.
 

--- a/driver/Compiler.v
+++ b/driver/Compiler.v
@@ -14,64 +14,64 @@
 
 (** Libraries. *)
 Require Import String.
-Require Import Coqlib Errors.
-Require Import AST Linking Smallstep.
+Require Import compcert.Coqlib compcert.Errors.
+Require Import compcert.AST compcert.Linking compcert.Smallstep.
 (** Languages (syntax and semantics). *)
-Require Ctypes Csyntax Csem Cstrategy Cexec.
-Require Clight.
-Require Csharpminor.
-Require Cminor.
-Require CminorSel.
-Require RTL.
-Require LTL.
-Require Linear.
-Require Mach.
-Require Asm.
+Require compcert.Ctypes compcert.Csyntax compcert.Csem compcert.Cstrategy compcert.Cexec.
+Require compcert.Clight.
+Require compcert.Csharpminor.
+Require compcert.Cminor.
+Require compcert.CminorSel.
+Require compcert.RTL.
+Require compcert.LTL.
+Require compcert.Linear.
+Require compcert.Mach.
+Require compcert.Asm.
 (** Translation passes. *)
-Require Initializers.
-Require SimplExpr.
-Require SimplLocals.
-Require Cshmgen.
-Require Cminorgen.
-Require Selection.
-Require RTLgen.
-Require Tailcall.
-Require Inlining.
-Require Renumber.
-Require Constprop.
-Require CSE.
-Require Deadcode.
-Require Unusedglob.
-Require Allocation.
-Require Tunneling.
-Require Linearize.
-Require CleanupLabels.
-Require Debugvar.
-Require Stacking.
-Require Asmgen.
+Require compcert.Initializers.
+Require compcert.SimplExpr.
+Require compcert.SimplLocals.
+Require compcert.Cshmgen.
+Require compcert.Cminorgen.
+Require compcert.Selection.
+Require compcert.RTLgen.
+Require compcert.Tailcall.
+Require compcert.Inlining.
+Require compcert.Renumber.
+Require compcert.Constprop.
+Require compcert.CSE.
+Require compcert.Deadcode.
+Require compcert.Unusedglob.
+Require compcert.Allocation.
+Require compcert.Tunneling.
+Require compcert.Linearize.
+Require compcert.CleanupLabels.
+Require compcert.Debugvar.
+Require compcert.Stacking.
+Require compcert.Asmgen.
 (** Proofs of semantic preservation. *)
-Require SimplExprproof.
-Require SimplLocalsproof.
-Require Cshmgenproof.
-Require Cminorgenproof.
-Require Selectionproof.
-Require RTLgenproof.
-Require Tailcallproof.
-Require Inliningproof.
-Require Renumberproof.
-Require Constpropproof.
-Require CSEproof.
-Require Deadcodeproof.
-Require Unusedglobproof.
-Require Allocproof.
-Require Tunnelingproof.
-Require Linearizeproof.
-Require CleanupLabelsproof.
-Require Debugvarproof.
-Require Stackingproof.
-Require Asmgenproof.
+Require compcert.SimplExprproof.
+Require compcert.SimplLocalsproof.
+Require compcert.Cshmgenproof.
+Require compcert.Cminorgenproof.
+Require compcert.Selectionproof.
+Require compcert.RTLgenproof.
+Require compcert.Tailcallproof.
+Require compcert.Inliningproof.
+Require compcert.Renumberproof.
+Require compcert.Constpropproof.
+Require compcert.CSEproof.
+Require compcert.Deadcodeproof.
+Require compcert.Unusedglobproof.
+Require compcert.Allocproof.
+Require compcert.Tunnelingproof.
+Require compcert.Linearizeproof.
+Require compcert.CleanupLabelsproof.
+Require compcert.Debugvarproof.
+Require compcert.Stackingproof.
+Require compcert.Asmgenproof.
 (** Command-line flags. *)
-Require Import Compopts.
+Require Import compcert.Compopts.
 
 (** Pretty-printers (defined in Caml). *)
 Parameter print_Clight: Clight.program -> unit.

--- a/driver/Complements.v
+++ b/driver/Complements.v
@@ -13,23 +13,23 @@
 (** Corollaries of the main semantic preservation theorem. *)
 
 Require Import Classical.
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Values.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Smallstep.
-Require Import Behaviors.
-Require Import Csyntax.
-Require Import Csem.
-Require Import Cstrategy.
-Require Import Clight.
-Require Import Cminor.
-Require Import RTL.
-Require Import Asm.
-Require Import Compiler.
-Require Import Errors.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Values.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
+Require Import compcert.Behaviors.
+Require Import compcert.Csyntax.
+Require Import compcert.Csem.
+Require Import compcert.Cstrategy.
+Require Import compcert.Clight.
+Require Import compcert.Cminor.
+Require Import compcert.RTL.
+Require Import compcert.Asm.
+Require Import compcert.Compiler.
+Require Import compcert.Errors.
 
 (** * Preservation of whole-program behaviors *)
 

--- a/exportclight/Clightdefs.v
+++ b/exportclight/Clightdefs.v
@@ -18,14 +18,14 @@
 Require Export String.
 Require Export List.
 Require Export ZArith.
-Require Export Integers.
-Require Export Floats.
-Require Export AST.
-Require Export Ctypes.
-Require Export Cop.
-Require Export Clight.
-Require Import Maps.
-Require Import Errors.
+Require Export compcert.Integers.
+Require Export compcert.Floats.
+Require Export compcert.AST.
+Require Export compcert.Ctypes.
+Require Export compcert.Cop.
+Require Export compcert.Clight.
+Require Import compcert.Maps.
+Require Import compcert.Errors.
 
 Definition tvoid := Tvoid.
 Definition tschar := Tint I8 Signed noattr.

--- a/extraction/extraction.v
+++ b/extraction/extraction.v
@@ -10,27 +10,27 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Coqlib.
-Require Wfsimpl.
-Require DecidableClass Decidableplus.
-Require AST.
-Require Iteration.
-Require Floats.
-Require SelectLong.
-Require Selection.
-Require RTLgen.
-Require Inlining.
-Require ValueDomain.
-Require Tailcall.
-Require Allocation.
-Require Bounds.
-Require Ctypes.
-Require Csyntax.
-Require Ctyping.
-Require Clight.
-Require Compiler.
-Require Parser.
-Require Initializers.
+Require compcert.Coqlib.
+Require compcert.Wfsimpl.
+Require DecidableClass compcert.Decidableplus.
+Require compcert.AST.
+Require compcert.Iteration.
+Require compcert.Floats.
+Require compcert.SelectLong.
+Require compcert.Selection.
+Require compcert.RTLgen.
+Require compcert.Inlining.
+Require compcert.ValueDomain.
+Require compcert.Tailcall.
+Require compcert.Allocation.
+Require compcert.Bounds.
+Require compcert.Ctypes.
+Require compcert.Csyntax.
+Require compcert.Ctyping.
+Require compcert.Clight.
+Require compcert.Compiler.
+Require compcert.Parser.
+Require compcert.Initializers.
 Require Int31.
 
 (* Standard lib *)

--- a/flocq/Appli/Fappli_IEEE.v
+++ b/flocq/Appli/Fappli_IEEE.v
@@ -18,15 +18,15 @@ COPYING file for more details.
 *)
 
 (** * IEEE-754 arithmetic *)
-Require Import Fcore.
-Require Import Fcore_digits.
-Require Import Fcalc_digits.
-Require Import Fcalc_round.
-Require Import Fcalc_bracket.
-Require Import Fcalc_ops.
-Require Import Fcalc_div.
-Require Import Fcalc_sqrt.
-Require Import Fprop_relative.
+Require Import flocq.Core.Fcore.
+Require Import flocq.Core.Fcore_digits.
+Require Import flocq.Calc.Fcalc_digits.
+Require Import flocq.Calc.Fcalc_round.
+Require Import flocq.Calc.Fcalc_bracket.
+Require Import flocq.Calc.Fcalc_ops.
+Require Import flocq.Calc.Fcalc_div.
+Require Import flocq.Calc.Fcalc_sqrt.
+Require Import flocq.Prop.Fprop_relative.
 
 Section AnyRadix.
 

--- a/flocq/Appli/Fappli_IEEE_bits.v
+++ b/flocq/Appli/Fappli_IEEE_bits.v
@@ -18,10 +18,10 @@ COPYING file for more details.
 *)
 
 (** * IEEE-754 encoding of binary floating-point data *)
-Require Import Fcore.
-Require Import Fcore_digits.
-Require Import Fcalc_digits.
-Require Import Fappli_IEEE.
+Require Import flocq.Core.Fcore.
+Require Import flocq.Core.Fcore_digits.
+Require Import flocq.Calc.Fcalc_digits.
+Require Import flocq.Appli.Fappli_IEEE.
 
 Section Binary_Bits.
 

--- a/flocq/Appli/Fappli_double_round.v
+++ b/flocq/Appli/Fappli_double_round.v
@@ -1,10 +1,10 @@
 (** * Conditions for innocuous double rounding. *)
 
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_generic_fmt.
-Require Import Fcalc_ops.
-Require Import Fcore_ulp.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_generic_fmt.
+Require Import flocq.Calc.Fcalc_ops.
+Require Import flocq.Core.Fcore_ulp.
 
 Require Import Psatz.
 
@@ -659,7 +659,7 @@ Qed.
 
 Section Double_round_mult_FLX.
 
-Require Import Fcore_FLX.
+Require Import flocq.Core.Fcore_FLX.
 
 Variable prec : Z.
 Variable prec' : Z.
@@ -685,8 +685,8 @@ End Double_round_mult_FLX.
 
 Section Double_round_mult_FLT.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FLT.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FLT.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -718,7 +718,7 @@ End Double_round_mult_FLT.
 
 Section Double_round_mult_FTZ.
 
-Require Import Fcore_FTZ.
+Require Import flocq.Core.Fcore_FTZ.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -1611,7 +1611,7 @@ Qed.
 
 Section Double_round_plus_FLX.
 
-Require Import Fcore_FLX.
+Require Import flocq.Core.Fcore_FLX.
 
 Variable prec : Z.
 Variable prec' : Z.
@@ -1667,8 +1667,8 @@ End Double_round_plus_FLX.
 
 Section Double_round_plus_FLT.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FLT.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FLT.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -1739,8 +1739,8 @@ End Double_round_plus_FLT.
 
 Section Double_round_plus_FTZ.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FTZ.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FTZ.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -2325,7 +2325,7 @@ Qed.
 
 Section Double_round_plus_beta_ge_3_FLX.
 
-Require Import Fcore_FLX.
+Require Import flocq.Core.Fcore_FLX.
 
 Variable prec : Z.
 Variable prec' : Z.
@@ -2385,8 +2385,8 @@ End Double_round_plus_beta_ge_3_FLX.
 
 Section Double_round_plus_beta_ge_3_FLT.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FLT.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FLT.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -2461,8 +2461,8 @@ End Double_round_plus_beta_ge_3_FLT.
 
 Section Double_round_plus_beta_ge_3_FTZ.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FTZ.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FTZ.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -2880,7 +2880,7 @@ Qed.
 
 Section Double_round_sqrt_FLX.
 
-Require Import Fcore_FLX.
+Require Import flocq.Core.Fcore_FLX.
 
 Variable prec : Z.
 Variable prec' : Z.
@@ -2917,8 +2917,8 @@ End Double_round_sqrt_FLX.
 
 Section Double_round_sqrt_FLT.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FLT.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FLT.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -2972,8 +2972,8 @@ End Double_round_sqrt_FLT.
 
 Section Double_round_sqrt_FTZ.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FTZ.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FTZ.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -3318,7 +3318,7 @@ Qed.
 
 Section Double_round_sqrt_beta_ge_4_FLX.
 
-Require Import Fcore_FLX.
+Require Import flocq.Core.Fcore_FLX.
 
 Variable prec : Z.
 Variable prec' : Z.
@@ -3357,8 +3357,8 @@ End Double_round_sqrt_beta_ge_4_FLX.
 
 Section Double_round_sqrt_beta_ge_4_FLT.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FLT.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FLT.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -3414,8 +3414,8 @@ End Double_round_sqrt_beta_ge_4_FLT.
 
 Section Double_round_sqrt_beta_ge_4_FTZ.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FTZ.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FTZ.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -4401,7 +4401,7 @@ Qed.
 
 Section Double_round_div_FLX.
 
-Require Import Fcore_FLX.
+Require Import flocq.Core.Fcore_FLX.
 
 Variable prec : Z.
 Variable prec' : Z.
@@ -4445,8 +4445,8 @@ End Double_round_div_FLX.
 
 Section Double_round_div_FLT.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FLT.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FLT.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.
@@ -4515,8 +4515,8 @@ End Double_round_div_FLT.
 
 Section Double_round_div_FTZ.
 
-Require Import Fcore_FLX.
-Require Import Fcore_FTZ.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FTZ.
 
 Variable emin prec : Z.
 Variable emin' prec' : Z.

--- a/flocq/Appli/Fappli_rnd_odd.v
+++ b/flocq/Appli/Fappli_rnd_odd.v
@@ -21,8 +21,8 @@ COPYING file for more details.
       between rnd_NE and double rounding with rnd_odd and then rnd_NE *)
 
 Require Import Reals Psatz.
-Require Import Fcore.
-Require Import Fcalc_ops.
+Require Import flocq.Core.Fcore.
+Require Import flocq.Calc.Fcalc_ops.
 
 Definition Zrnd_odd x :=  match Req_EM_T x (Z2R (Zfloor x))  with
   | left _   => Zfloor x

--- a/flocq/Calc/Fcalc_bracket.v
+++ b/flocq/Calc/Fcalc_bracket.v
@@ -19,9 +19,9 @@ COPYING file for more details.
 
 (** * Locations: where a real number is positioned with respect to its rounded-down value in an arbitrary format. *)
 
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_float_prop.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_float_prop.
 
 Section Fcalc_bracket.
 

--- a/flocq/Calc/Fcalc_digits.v
+++ b/flocq/Calc/Fcalc_digits.v
@@ -19,10 +19,10 @@ COPYING file for more details.
 
 (** * Functions for computing the number of digits of integers and related theorems. *)
 
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_float_prop.
-Require Import Fcore_digits.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_float_prop.
+Require Import flocq.Core.Fcore_digits.
 
 Section Fcalc_digits.
 

--- a/flocq/Calc/Fcalc_div.v
+++ b/flocq/Calc/Fcalc_div.v
@@ -19,12 +19,12 @@ COPYING file for more details.
 
 (** * Helper function and theorem for computing the rounded quotient of two floating-point numbers. *)
 
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_float_prop.
-Require Import Fcore_digits.
-Require Import Fcalc_bracket.
-Require Import Fcalc_digits.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_float_prop.
+Require Import flocq.Core.Fcore_digits.
+Require Import flocq.Calc.Fcalc_bracket.
+Require Import flocq.Calc.Fcalc_digits.
 
 Section Fcalc_div.
 

--- a/flocq/Calc/Fcalc_ops.v
+++ b/flocq/Calc/Fcalc_ops.v
@@ -18,9 +18,9 @@ COPYING file for more details.
 *)
 
 (** Basic operations on floats: alignment, addition, multiplication *)
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_float_prop.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_float_prop.
 
 Section Float_ops.
 

--- a/flocq/Calc/Fcalc_round.v
+++ b/flocq/Calc/Fcalc_round.v
@@ -19,10 +19,10 @@ COPYING file for more details.
 
 (** * Helper function for computing the rounded value of a real number. *)
 
-Require Import Fcore.
-Require Import Fcore_digits.
-Require Import Fcalc_bracket.
-Require Import Fcalc_digits.
+Require Import flocq.Core.Fcore.
+Require Import flocq.Core.Fcore_digits.
+Require Import flocq.Calc.Fcalc_bracket.
+Require Import flocq.Calc.Fcalc_digits.
 
 Section Fcalc_round.
 

--- a/flocq/Calc/Fcalc_sqrt.v
+++ b/flocq/Calc/Fcalc_sqrt.v
@@ -19,12 +19,12 @@ COPYING file for more details.
 
 (** * Helper functions and theorems for computing the rounded square root of a floating-point number. *)
 
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_digits.
-Require Import Fcore_float_prop.
-Require Import Fcalc_bracket.
-Require Import Fcalc_digits.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_digits.
+Require Import flocq.Core.Fcore_float_prop.
+Require Import flocq.Calc.Fcalc_bracket.
+Require Import flocq.Calc.Fcalc_digits.
 
 Section Fcalc_sqrt.
 

--- a/flocq/Core/Fcore.v
+++ b/flocq/Core/Fcore.v
@@ -18,13 +18,13 @@ COPYING file for more details.
 *)
 
 (** To ease the import *)
-Require Export Fcore_Raux.
-Require Export Fcore_defs.
-Require Export Fcore_float_prop.
-Require Export Fcore_rnd.
-Require Export Fcore_generic_fmt.
-Require Export Fcore_rnd_ne.
-Require Export Fcore_FIX.
-Require Export Fcore_FLX.
-Require Export Fcore_FLT.
-Require Export Fcore_ulp.
+Require Export flocq.Core.Fcore_Raux.
+Require Export flocq.Core.Fcore_defs.
+Require Export flocq.Core.Fcore_float_prop.
+Require Export flocq.Core.Fcore_rnd.
+Require Export flocq.Core.Fcore_generic_fmt.
+Require Export flocq.Core.Fcore_rnd_ne.
+Require Export flocq.Core.Fcore_FIX.
+Require Export flocq.Core.Fcore_FLX.
+Require Export flocq.Core.Fcore_FLT.
+Require Export flocq.Core.Fcore_ulp.

--- a/flocq/Core/Fcore_FIX.v
+++ b/flocq/Core/Fcore_FIX.v
@@ -18,12 +18,12 @@ COPYING file for more details.
 *)
 
 (** * Fixed-point format *)
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_rnd.
-Require Import Fcore_generic_fmt.
-Require Import Fcore_ulp.
-Require Import Fcore_rnd_ne.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_rnd.
+Require Import flocq.Core.Fcore_generic_fmt.
+Require Import flocq.Core.Fcore_ulp.
+Require Import flocq.Core.Fcore_rnd_ne.
 
 Section RND_FIX.
 

--- a/flocq/Core/Fcore_FLT.v
+++ b/flocq/Core/Fcore_FLT.v
@@ -18,15 +18,15 @@ COPYING file for more details.
 *)
 
 (** * Floating-point format with gradual underflow *)
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_rnd.
-Require Import Fcore_generic_fmt.
-Require Import Fcore_float_prop.
-Require Import Fcore_FLX.
-Require Import Fcore_FIX.
-Require Import Fcore_ulp.
-Require Import Fcore_rnd_ne.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_rnd.
+Require Import flocq.Core.Fcore_generic_fmt.
+Require Import flocq.Core.Fcore_float_prop.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FIX.
+Require Import flocq.Core.Fcore_ulp.
+Require Import flocq.Core.Fcore_rnd_ne.
 
 Section RND_FLT.
 

--- a/flocq/Core/Fcore_FLX.v
+++ b/flocq/Core/Fcore_FLX.v
@@ -18,14 +18,14 @@ COPYING file for more details.
 *)
 
 (** * Floating-point format without underflow *)
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_rnd.
-Require Import Fcore_generic_fmt.
-Require Import Fcore_float_prop.
-Require Import Fcore_FIX.
-Require Import Fcore_ulp.
-Require Import Fcore_rnd_ne.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_rnd.
+Require Import flocq.Core.Fcore_generic_fmt.
+Require Import flocq.Core.Fcore_float_prop.
+Require Import flocq.Core.Fcore_FIX.
+Require Import flocq.Core.Fcore_ulp.
+Require Import flocq.Core.Fcore_rnd_ne.
 
 Section RND_FLX.
 

--- a/flocq/Core/Fcore_FTZ.v
+++ b/flocq/Core/Fcore_FTZ.v
@@ -18,13 +18,13 @@ COPYING file for more details.
 *)
 
 (** * Floating-point format with abrupt underflow *)
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_rnd.
-Require Import Fcore_generic_fmt.
-Require Import Fcore_float_prop.
-Require Import Fcore_ulp.
-Require Import Fcore_FLX.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_rnd.
+Require Import flocq.Core.Fcore_generic_fmt.
+Require Import flocq.Core.Fcore_float_prop.
+Require Import flocq.Core.Fcore_ulp.
+Require Import flocq.Core.Fcore_FLX.
 
 Section RND_FTZ.
 

--- a/flocq/Core/Fcore_Raux.v
+++ b/flocq/Core/Fcore_Raux.v
@@ -20,7 +20,7 @@ COPYING file for more details.
 (** * Missing definitions/lemmas *)
 Require Export Reals.
 Require Export ZArith.
-Require Export Fcore_Zaux.
+Require Export flocq.Core.Fcore_Zaux.
 
 Section Rmissing.
 

--- a/flocq/Core/Fcore_defs.v
+++ b/flocq/Core/Fcore_defs.v
@@ -18,7 +18,7 @@ COPYING file for more details.
 *)
 
 (** * Basic definitions: float and rounding property *)
-Require Import Fcore_Raux.
+Require Import flocq.Core.Fcore_Raux.
 
 Section Def.
 

--- a/flocq/Core/Fcore_digits.v
+++ b/flocq/Core/Fcore_digits.v
@@ -19,7 +19,7 @@ COPYING file for more details.
 
 Require Import ZArith.
 Require Import Zquot.
-Require Import Fcore_Zaux.
+Require Import flocq.Core.Fcore_Zaux.
 
 (** Number of bits (radix 2) of a positive integer.
 

--- a/flocq/Core/Fcore_float_prop.v
+++ b/flocq/Core/Fcore_float_prop.v
@@ -18,8 +18,8 @@ COPYING file for more details.
 *)
 
 (** * Basic properties of floating-point formats: lemmas about mantissa, exponent... *)
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
 
 Section Float_prop.
 

--- a/flocq/Core/Fcore_generic_fmt.v
+++ b/flocq/Core/Fcore_generic_fmt.v
@@ -18,10 +18,10 @@ COPYING file for more details.
 *)
 
 (** * What is a real number belonging to a format, and many properties. *)
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_rnd.
-Require Import Fcore_float_prop.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_rnd.
+Require Import flocq.Core.Fcore_float_prop.
 
 Section Generic.
 

--- a/flocq/Core/Fcore_rnd.v
+++ b/flocq/Core/Fcore_rnd.v
@@ -18,8 +18,8 @@ COPYING file for more details.
 *)
 
 (** * Roundings: properties and/or functions *)
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
 
 Section RND_prop.
 

--- a/flocq/Core/Fcore_rnd_ne.v
+++ b/flocq/Core/Fcore_rnd_ne.v
@@ -18,12 +18,12 @@ COPYING file for more details.
 *)
 
 (** * Rounding to nearest, ties to even: existence, unicity... *)
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_rnd.
-Require Import Fcore_generic_fmt.
-Require Import Fcore_float_prop.
-Require Import Fcore_ulp.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_rnd.
+Require Import flocq.Core.Fcore_generic_fmt.
+Require Import flocq.Core.Fcore_float_prop.
+Require Import flocq.Core.Fcore_ulp.
 
 Notation ZnearestE := (Znearest (fun x => negb (Zeven x))).
 

--- a/flocq/Core/Fcore_ulp.v
+++ b/flocq/Core/Fcore_ulp.v
@@ -19,11 +19,11 @@ COPYING file for more details.
 
 (** * Unit in the Last Place: our definition using fexp and its properties, successor and predecessor *)
 Require Import Reals Psatz.
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_rnd.
-Require Import Fcore_generic_fmt.
-Require Import Fcore_float_prop.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_rnd.
+Require Import flocq.Core.Fcore_generic_fmt.
+Require Import flocq.Core.Fcore_float_prop.
 
 Section Fcore_ulp.
 

--- a/flocq/Prop/Fprop_Sterbenz.v
+++ b/flocq/Prop/Fprop_Sterbenz.v
@@ -19,10 +19,10 @@ COPYING file for more details.
 
 (** * Sterbenz conditions for exact subtraction *)
 
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_generic_fmt.
-Require Import Fcalc_ops.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_generic_fmt.
+Require Import flocq.Calc.Fcalc_ops.
 
 Section Fprop_Sterbenz.
 

--- a/flocq/Prop/Fprop_div_sqrt_error.v
+++ b/flocq/Prop/Fprop_div_sqrt_error.v
@@ -18,9 +18,9 @@ COPYING file for more details.
 *)
 
 (** * Remainder of the division and square root are in the FLX format *)
-Require Import Fcore.
-Require Import Fcalc_ops.
-Require Import Fprop_relative.
+Require Import flocq.Core.Fcore.
+Require Import flocq.Calc.Fcalc_ops.
+Require Import flocq.Prop.Fprop_relative.
 
 Section Fprop_divsqrt_error.
 

--- a/flocq/Prop/Fprop_mult_error.v
+++ b/flocq/Prop/Fprop_mult_error.v
@@ -18,8 +18,8 @@ COPYING file for more details.
 *)
 
 (** * Error of the multiplication is in the FLX/FLT format *)
-Require Import Fcore.
-Require Import Fcalc_ops.
+Require Import flocq.Core.Fcore.
+Require Import flocq.Calc.Fcalc_ops.
 
 Section Fprop_mult_error.
 

--- a/flocq/Prop/Fprop_plus_error.v
+++ b/flocq/Prop/Fprop_plus_error.v
@@ -19,14 +19,14 @@ COPYING file for more details.
 
 (** * Error of the rounded-to-nearest addition is representable. *)
 
-Require Import Fcore_Raux.
-Require Import Fcore_defs.
-Require Import Fcore_float_prop.
-Require Import Fcore_generic_fmt.
-Require Import Fcore_FIX.
-Require Import Fcore_FLX.
-Require Import Fcore_FLT.
-Require Import Fcalc_ops.
+Require Import flocq.Core.Fcore_Raux.
+Require Import flocq.Core.Fcore_defs.
+Require Import flocq.Core.Fcore_float_prop.
+Require Import flocq.Core.Fcore_generic_fmt.
+Require Import flocq.Core.Fcore_FIX.
+Require Import flocq.Core.Fcore_FLX.
+Require Import flocq.Core.Fcore_FLT.
+Require Import flocq.Calc.Fcalc_ops.
 
 
 Section Fprop_plus_error.

--- a/flocq/Prop/Fprop_relative.v
+++ b/flocq/Prop/Fprop_relative.v
@@ -18,7 +18,7 @@ COPYING file for more details.
 *)
 
 (** * Relative error of the roundings *)
-Require Import Fcore.
+Require Import flocq.Core.Fcore.
 
 Section Fprop_relative.
 

--- a/lib/BoolEqual.v
+++ b/lib/BoolEqual.v
@@ -54,7 +54,7 @@ The present tactics also have some restrictions:
 - They probably do not work for mutually-defined inductive types.
 *)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 
 Module BE.
 

--- a/lib/Decidableplus.v
+++ b/lib/Decidableplus.v
@@ -20,7 +20,7 @@
   universal and existential quantification over finite types. *)
 
 Require Export DecidableClass.
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 
 Ltac decide_goal := eapply Decidable_sound; reflexivity.
 

--- a/lib/FSetAVLplus.v
+++ b/lib/FSetAVLplus.v
@@ -19,7 +19,7 @@
 
 Require Import FSetInterface.
 Require FSetAVL.
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 
 Module Make(X: OrderedType).
 

--- a/lib/Fappli_IEEE_extra.v
+++ b/lib/Fappli_IEEE_extra.v
@@ -20,15 +20,15 @@
 Require Import Psatz.
 Require Import Bool.
 Require Import Eqdep_dec.
-Require Import Fcore.
-Require Import Fcore_digits.
-Require Import Fcalc_digits.
-Require Import Fcalc_ops.
-Require Import Fcalc_round.
-Require Import Fcalc_bracket.
-Require Import Fprop_Sterbenz.
-Require Import Fappli_IEEE.
-Require Import Fappli_rnd_odd.
+Require Import flocq.Core.Fcore.
+Require Import flocq.Core.Fcore_digits.
+Require Import flocq.Calc.Fcalc_digits.
+Require Import flocq.Calc.Fcalc_ops.
+Require Import flocq.Calc.Fcalc_round.
+Require Import flocq.Calc.Fcalc_bracket.
+Require Import flocq.Prop.Fprop_Sterbenz.
+Require Import flocq.Appli.Fappli_IEEE.
+Require Import flocq.Appli.Fappli_rnd_odd.
 
 Local Open Scope Z_scope.
 

--- a/lib/Floats.v
+++ b/lib/Floats.v
@@ -16,14 +16,14 @@
 
 (** Formalization of floating-point numbers, using the Flocq library. *)
 
-Require Import Coqlib.
-Require Import Integers.
-Require Import Fappli_IEEE.
-Require Import Fappli_IEEE_bits.
-Require Import Fappli_IEEE_extra.
-Require Import Fcore.
+Require Import compcert.Coqlib.
+Require Import compcert.Integers.
+Require Import flocq.Appli.Fappli_IEEE.
+Require Import flocq.Appli.Fappli_IEEE_bits.
+Require Import compcert.Fappli_IEEE_extra.
+Require Import flocq.Core.Fcore.
 Require Import Program.
-Require Archi.
+Require compcert.Archi.
 
 Close Scope R_scope.
 

--- a/lib/Heaps.v
+++ b/lib/Heaps.v
@@ -21,9 +21,9 @@
     (If an element is already in a heap, inserting it again does nothing.)
 *)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 Require Import FSets.
-Require Import Ordered.
+Require Import compcert.Ordered.
 
 (* To avoid useless definitions of inductors in extracted code. *)
 Local Unset Elimination Schemes.

--- a/lib/Integers.v
+++ b/lib/Integers.v
@@ -16,8 +16,8 @@
 (** Formalizations of machine integers modulo $2^N$ #2<sup>N</sup>#. *)
 
 Require Import Eqdep_dec Zquot Zwf.
-Require Import Coqlib.
-Require Archi.
+Require Import compcert.Coqlib.
+Require compcert.Archi.
 
 (** * Comparisons *)
 

--- a/lib/Intv.v
+++ b/lib/Intv.v
@@ -15,7 +15,7 @@
 
 (** Definitions and theorems about semi-open integer intervals *)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 Require Import Zwf.
 Require Coq.Program.Wf.
 Require Recdef.

--- a/lib/IntvSets.v
+++ b/lib/IntvSets.v
@@ -15,7 +15,7 @@
 
 (** Finite sets of integer intervals *)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 
 Module ISet.
 

--- a/lib/Iteration.v
+++ b/lib/Iteration.v
@@ -15,9 +15,9 @@
 
 (** Bounded and unbounded iterators *)
 
-Require Import Axioms.
-Require Import Coqlib.
-Require Import Wfsimpl.
+Require Import compcert.Axioms.
+Require Import compcert.Coqlib.
+Require Import compcert.Wfsimpl.
 
 (** This modules defines several Coq encodings of a general "while" loop.
   The loop is presented in functional style as the iteration

--- a/lib/Lattice.v
+++ b/lib/Lattice.v
@@ -16,8 +16,8 @@
 
 (** Constructions of semi-lattices. *)
 
-Require Import Coqlib.
-Require Import Maps.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
 Require Import FSets.
 
 (* To avoid useless definitions of inductors in extracted code. *)

--- a/lib/Maps.v
+++ b/lib/Maps.v
@@ -33,7 +33,7 @@
 *)
 
 Require Import Equivalence EquivDec.
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 
 (* To avoid useless definitions of inductors in extracted code. *)
 Local Unset Elimination Schemes.

--- a/lib/Ordered.v
+++ b/lib/Ordered.v
@@ -18,9 +18,9 @@
   for finite sets and the [FMap] functors for finite maps. *)
 
 Require Import FSets.
-Require Import Coqlib.
-Require Import Maps.
-Require Import Integers.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.Integers.
 
 (** The ordered type of positive numbers *)
 

--- a/lib/Parmov.v
+++ b/lib/Parmov.v
@@ -53,8 +53,8 @@
 *)
 
 Require Import Relations.
-Require Import Axioms.
-Require Import Coqlib.
+Require Import compcert.Axioms.
+Require Import compcert.Coqlib.
 Require Recdef.
 
 Section PARMOV.

--- a/lib/Postorder.v
+++ b/lib/Postorder.v
@@ -18,9 +18,9 @@
 Require Import Wellfounded.
 Require Import Permutation.
 Require Import Mergesort.
-Require Import Coqlib.
-Require Import Maps.
-Require Import Iteration.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.Iteration.
 
 (** The graph is presented as a finite map from nodes (of type [positive])
   to the lists of their successors. *)

--- a/lib/UnionFind.v
+++ b/lib/UnionFind.v
@@ -16,7 +16,7 @@
 (** A persistent union-find data structure. *)
 
 Require Coq.Program.Wf.
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 
 Open Scope nat_scope.
 Set Implicit Arguments.

--- a/lib/Wfsimpl.v
+++ b/lib/Wfsimpl.v
@@ -17,7 +17,7 @@
   interface to the [Wf] module of Coq's standard library, where the functions
   to be defined have non-dependent types, and function extensionality is assumed. *)
 
-Require Import Axioms.
+Require Import compcert.Axioms.
 Require Import Init.Wf.
 Require Import Wf_nat.
 

--- a/powerpc/Archi.v
+++ b/powerpc/Archi.v
@@ -17,8 +17,8 @@
 (** Architecture-dependent parameters for PowerPC *)
 
 Require Import ZArith.
-Require Import Fappli_IEEE.
-Require Import Fappli_IEEE_bits.
+Require Import flocq.Appli.Fappli_IEEE.
+Require Import flocq.Appli.Fappli_IEEE_bits.
 
 Definition ptr64 := false.
 

--- a/powerpc/Asm.v
+++ b/powerpc/Asm.v
@@ -12,19 +12,19 @@
 
 (** Abstract syntax and semantics for PowerPC assembly language *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Smallstep.
-Require Import Locations.
-Require Import Stacklayout.
-Require Import Conventions.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
+Require Import compcert.Locations.
+Require Import compcert.Stacklayout.
+Require Import compcert.Conventions.
 
 (** * Abstract syntax *)
 

--- a/powerpc/Asmgen.v
+++ b/powerpc/Asmgen.v
@@ -12,15 +12,15 @@
 
 (** Translation from Mach to PPC. *)
 
-Require Import Coqlib.
-Require Import Errors.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Op.
-Require Import Locations.
-Require Import Mach.
-Require Import Asm.
+Require Import compcert.Coqlib.
+Require Import compcert.Errors.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Op.
+Require Import compcert.Locations.
+Require Import compcert.Mach.
+Require Import compcert.Asm.
 
 Local Open Scope string_scope.
 Local Open Scope error_monad_scope.

--- a/powerpc/Asmgenproof.v
+++ b/powerpc/Asmgenproof.v
@@ -12,11 +12,11 @@
 
 (** Correctness proof for PPC generation: main proof. *)
 
-Require Import Coqlib Errors.
-Require Import Integers Floats AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Op Locations Mach Conventions Asm.
-Require Import Asmgen Asmgenproof0 Asmgenproof1.
+Require Import compcert.Coqlib compcert.Errors.
+Require Import compcert.Integers compcert.Floats compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Locations compcert.Mach compcert.Conventions compcert.Asm.
+Require Import compcert.Asmgen compcert.Asmgenproof0 compcert.Asmgenproof1.
 
 Local Transparent Archi.ptr64.
 

--- a/powerpc/Asmgenproof1.v
+++ b/powerpc/Asmgenproof1.v
@@ -12,22 +12,22 @@
 
 (** Correctness proof for PPC generation: auxiliary results. *)
 
-Require Import Coqlib.
-Require Import Errors.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Op.
-Require Import Locations.
-Require Import Mach.
-Require Import Asm.
-Require Import Asmgen.
-Require Import Conventions.
-Require Import Asmgenproof0.
+Require Import compcert.Coqlib.
+Require Import compcert.Errors.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Op.
+Require Import compcert.Locations.
+Require Import compcert.Mach.
+Require Import compcert.Asm.
+Require Import compcert.Asmgen.
+Require Import compcert.Conventions.
+Require Import compcert.Asmgenproof0.
 
 Local Transparent Archi.ptr64.
 

--- a/powerpc/CombineOp.v
+++ b/powerpc/CombineOp.v
@@ -13,11 +13,11 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Op.
-Require Import CSEdomain.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Op.
+Require Import compcert.CSEdomain.
 
 Section COMBINE.
 

--- a/powerpc/CombineOpproof.v
+++ b/powerpc/CombineOpproof.v
@@ -13,16 +13,16 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Values.
-Require Import Memory.
-Require Import Op.
-Require Import Registers.
-Require Import RTL.
-Require Import CSEdomain.
-Require Import CombineOp.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.RTL.
+Require Import compcert.CSEdomain.
+Require Import compcert.CombineOp.
 
 Section COMBINE.
 

--- a/powerpc/ConstpropOp.vp
+++ b/powerpc/ConstpropOp.vp
@@ -13,10 +13,10 @@
 (** Strength reduction for operators and conditions.
     This is the machine-dependent part of [Constprop]. *)
 
-Require Import Coqlib Compopts.
-Require Import AST Integers Floats.
-Require Import Op Registers.
-Require Import ValueDomain.
+Require Import compcert.Coqlib Compopts.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.Registers.
+Require Import compcert.ValueDomain.
 
 (** * Converting known values to constants *)
 

--- a/powerpc/ConstpropOp.vp
+++ b/powerpc/ConstpropOp.vp
@@ -13,7 +13,7 @@
 (** Strength reduction for operators and conditions.
     This is the machine-dependent part of [Constprop]. *)
 
-Require Import compcert.Coqlib Compopts.
+Require Import compcert.Coqlib compcert.Compopts.
 Require Import compcert.AST compcert.Integers compcert.Floats.
 Require Import compcert.Op compcert.Registers.
 Require Import compcert.ValueDomain.

--- a/powerpc/ConstpropOpproof.v
+++ b/powerpc/ConstpropOpproof.v
@@ -12,7 +12,7 @@
 
 (** Correctness proof for operator strength reduction. *)
 
-Require Import compcert.Coqlib Compopts.
+Require Import compcert.Coqlib compcert.Compopts.
 Require Import compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
 Require Import compcert.Op compcert.Registers compcert.RTL compcert.ValueDomain.
 Require Import compcert.ConstpropOp.

--- a/powerpc/ConstpropOpproof.v
+++ b/powerpc/ConstpropOpproof.v
@@ -12,10 +12,10 @@
 
 (** Correctness proof for operator strength reduction. *)
 
-Require Import Coqlib Compopts.
-Require Import Integers Floats Values Memory Globalenvs Events.
-Require Import Op Registers RTL ValueDomain.
-Require Import ConstpropOp.
+Require Import compcert.Coqlib Compopts.
+Require Import compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Op compcert.Registers compcert.RTL compcert.ValueDomain.
+Require Import compcert.ConstpropOp.
 
 Local Transparent Archi.ptr64.
 

--- a/powerpc/Conventions1.v
+++ b/powerpc/Conventions1.v
@@ -13,12 +13,12 @@
 (** Function calling conventions and other conventions regarding the use of
     machine registers and stack slots. *)
 
-Require Import Coqlib.
-Require Import Decidableplus.
-Require Import AST.
-Require Import Events.
-Require Import Locations.
-Require Archi.
+Require Import compcert.Coqlib.
+Require Import compcert.Decidableplus.
+Require Import compcert.AST.
+Require Import compcert.Events.
+Require Import compcert.Locations.
+Require compcert.Archi.
 
 (** * Classification of machine registers *)
 

--- a/powerpc/Machregs.v
+++ b/powerpc/Machregs.v
@@ -11,11 +11,11 @@
 (* *********************************************************************)
 
 Require Import String.
-Require Import Coqlib.
-Require Import Decidableplus.
-Require Import Maps.
-Require Import AST.
-Require Import Op.
+Require Import compcert.Coqlib.
+Require Import compcert.Decidableplus.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Op.
 
 (** ** Machine registers *)
 

--- a/powerpc/NeedOp.v
+++ b/powerpc/NeedOp.v
@@ -1,13 +1,13 @@
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Op.
-Require Import NeedDomain.
-Require Import RTL.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Op.
+Require Import compcert.NeedDomain.
+Require Import compcert.RTL.
 
 (** Neededness analysis for PowerPC operators *)
 

--- a/powerpc/Op.v
+++ b/powerpc/Op.v
@@ -24,15 +24,15 @@
   syntax and dynamic semantics of the Cminor language.
 *)
 
-Require Import BoolEqual.
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Events.
+Require Import compcert.BoolEqual.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Events.
 
 Set Implicit Arguments.
 

--- a/powerpc/SelectLong.vp
+++ b/powerpc/SelectLong.vp
@@ -12,11 +12,11 @@
 
 (** Instruction selection for 64-bit integer operations *)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 Require Import Compopts.
-Require Import AST Integers Floats.
-Require Import Op CminorSel.
-Require Import SelectOp SplitLong.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SplitLong.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope string_scope.

--- a/powerpc/SelectLong.vp
+++ b/powerpc/SelectLong.vp
@@ -13,7 +13,7 @@
 (** Instruction selection for 64-bit integer operations *)
 
 Require Import compcert.Coqlib.
-Require Import Compopts.
+Require Import compcert.Compopts.
 Require Import compcert.AST compcert.Integers compcert.Floats.
 Require Import compcert.Op compcert.CminorSel.
 Require Import compcert.SelectOp compcert.SplitLong.

--- a/powerpc/SelectLongproof.v
+++ b/powerpc/SelectLongproof.v
@@ -12,12 +12,12 @@
 
 (** Correctness of instruction selection for 64-bit integer operations *)
 
-Require Import String Coqlib Maps Integers Floats Errors.
-Require Archi.
-Require Import AST Values Memory Globalenvs Events.
-Require Import Cminor Op CminorSel.
-Require Import SelectOp SelectOpproof SplitLong SplitLongproof.
-Require Import SelectLong.
+Require Import String compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Errors.
+Require compcert.Archi.
+Require Import compcert.AST compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Cminor compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SelectOpproof compcert.SplitLong compcert.SplitLongproof.
+Require Import compcert.SelectLong.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope string_scope.

--- a/powerpc/SelectOp.vp
+++ b/powerpc/SelectOp.vp
@@ -37,7 +37,7 @@
 *)
 
 Require Import compcert.Coqlib.
-Require Import Compopts.
+Require Import compcert.Compopts.
 Require Import compcert.AST.
 Require Import compcert.Integers.
 Require Import compcert.Floats.

--- a/powerpc/SelectOp.vp
+++ b/powerpc/SelectOp.vp
@@ -36,13 +36,13 @@
   module [Selection] implements the actual instruction selection pass.
 *)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 Require Import Compopts.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Op.
-Require Import CminorSel.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Op.
+Require Import compcert.CminorSel.
 
 Local Open Scope cminorsel_scope.
 

--- a/powerpc/SelectOpproof.v
+++ b/powerpc/SelectOpproof.v
@@ -12,19 +12,19 @@
 
 (** Correctness of instruction selection for operators *)
 
-Require Import Coqlib.
-Require Import Maps.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
 Require Import Compopts.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Cminor.
-Require Import Op.
-Require Import CminorSel.
-Require Import SelectOp.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Cminor.
+Require Import compcert.Op.
+Require Import compcert.CminorSel.
+Require Import compcert.SelectOp.
 
 Local Open Scope cminorsel_scope.
 Local Transparent Archi.ptr64.

--- a/powerpc/SelectOpproof.v
+++ b/powerpc/SelectOpproof.v
@@ -14,7 +14,7 @@
 
 Require Import compcert.Coqlib.
 Require Import compcert.Maps.
-Require Import Compopts.
+Require Import compcert.Compopts.
 Require Import compcert.AST.
 Require Import compcert.Integers.
 Require Import compcert.Floats.

--- a/powerpc/Stacklayout.v
+++ b/powerpc/Stacklayout.v
@@ -12,9 +12,9 @@
 
 (** Machine- and ABI-dependent layout information for activation records. *)
 
-Require Import Coqlib.
-Require Import Memory Separation.
-Require Import Bounds.
+Require Import compcert.Coqlib.
+Require Import compcert.Memory compcert.Separation.
+Require Import compcert.Bounds.
 
 (** In the PowerPC/EABI application binary interface,
   the general shape of activation records is as follows,

--- a/powerpc/ValueAOp.v
+++ b/powerpc/ValueAOp.v
@@ -11,7 +11,7 @@
 (* *********************************************************************)
 
 Require Import compcert.Coqlib.
-Require Import Compopts.
+Require Import compcert.Compopts.
 Require Import compcert.AST.
 Require Import compcert.Integers.
 Require Import compcert.Floats.

--- a/powerpc/ValueAOp.v
+++ b/powerpc/ValueAOp.v
@@ -10,17 +10,17 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 Require Import Compopts.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Op.
-Require Import ValueDomain.
-Require Import RTL.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Op.
+Require Import compcert.ValueDomain.
+Require Import compcert.RTL.
 
 (** Value analysis for PowerPC operators *)
 

--- a/riscV/Archi.v
+++ b/riscV/Archi.v
@@ -17,8 +17,8 @@
 (** Architecture-dependent parameters for RISC-V *)
 
 Require Import ZArith.
-Require Import Fappli_IEEE.
-Require Import Fappli_IEEE_bits.
+Require Import flocq.Appli.Fappli_IEEE.
+Require Import flocq.Appli.Fappli_IEEE_bits.
 
 Parameter ptr64 : bool.
 

--- a/riscV/Asm.v
+++ b/riscV/Asm.v
@@ -17,19 +17,19 @@
 
 (** Abstract syntax and semantics for RISC-V assembly language. *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Events.
-Require Import Globalenvs.
-Require Import Smallstep.
-Require Import Locations.
-Require Stacklayout.
-Require Import Conventions.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Events.
+Require Import compcert.Globalenvs.
+Require Import compcert.Smallstep.
+Require Import compcert.Locations.
+Require compcert.Stacklayout.
+Require Import compcert.Conventions.
 
 (** * Abstract syntax *)
 
@@ -963,7 +963,7 @@ Definition exec_instr (f: function) (i: instruction) (rs: regset) (m: mem) : out
   | Pbuiltin ef args res =>
       Stuck (**r treated specially below *)
 
-  (** The following instructions and directives are not generated directly by Asmgen,
+  (** The following instructions and directives are not generated directly by compcert.Asmgen.
       so we do not model them. *)
   | Pfence
 
@@ -989,7 +989,7 @@ Definition exec_instr (f: function) (i: instruction) (rs: regset) (m: mem) : out
   end.
 
 (** Translation of the LTL/Linear/Mach view of machine registers to
-  the RISC-V view.  Note that no LTL register maps to [X31].  This
+  the RISC-V view.  Note that no compcert.LTL register maps to [X31].  This
   register is reserved as temporary, to be used by the generated RV32G
   code.  *)
 

--- a/riscV/Asmgen.v
+++ b/riscV/Asmgen.v
@@ -17,10 +17,10 @@
 
 (** Translation from Mach to RISC-V assembly language *)
 
-Require Archi.
-Require Import Coqlib Errors.
-Require Import AST Integers Floats Memdata.
-Require Import Op Locations Mach Asm.
+Require compcert.Archi.
+Require Import compcert.Coqlib compcert.Errors.
+Require Import compcert.AST compcert.Integers compcert.Floats compcert.Memdata.
+Require Import compcert.Op compcert.Locations compcert.Mach compcert.Asm.
 
 Local Open Scope string_scope.
 Local Open Scope error_monad_scope.

--- a/riscV/Asmgenproof.v
+++ b/riscV/Asmgenproof.v
@@ -12,11 +12,11 @@
 
 (** Correctness proof for RISC-V generation: main proof. *)
 
-Require Import Coqlib Errors.
-Require Import Integers Floats AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Op Locations Mach Conventions Asm.
-Require Import Asmgen Asmgenproof0 Asmgenproof1.
+Require Import compcert.Coqlib compcert.Errors.
+Require Import compcert.Integers compcert.Floats compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Locations compcert.Mach compcert.Conventions compcert.Asm.
+Require Import compcert.Asmgen compcert.Asmgenproof0 compcert.Asmgenproof1.
 
 Definition match_prog (p: Mach.program) (tp: Asm.program) :=
   match_program (fun _ f tf => transf_fundef f = OK tf) eq p tp.

--- a/riscV/Asmgenproof1.v
+++ b/riscV/Asmgenproof1.v
@@ -15,10 +15,10 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import Coqlib Errors Maps.
-Require Import AST Integers Floats Values Memory Globalenvs.
-Require Import Op Locations Mach Conventions.
-Require Import Asm Asmgen Asmgenproof0.
+Require Import compcert.Coqlib compcert.Errors compcert.Maps.
+Require Import compcert.AST compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs.
+Require Import compcert.Op compcert.Locations compcert.Mach compcert.Conventions.
+Require Import compcert.Asm compcert.Asmgen compcert.Asmgenproof0.
 
 (** Decomposition of integer constants. *)
 

--- a/riscV/CombineOp.v
+++ b/riscV/CombineOp.v
@@ -13,11 +13,11 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Op.
-Require Import CSEdomain.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Op.
+Require Import compcert.CSEdomain.
 
 Section COMBINE.
 

--- a/riscV/CombineOpproof.v
+++ b/riscV/CombineOpproof.v
@@ -13,16 +13,16 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Values.
-Require Import Memory.
-Require Import Op.
-Require Import Registers.
-Require Import RTL.
-Require Import CSEdomain.
-Require Import CombineOp.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Op.
+Require Import compcert.Registers.
+Require Import compcert.RTL.
+Require Import compcert.CSEdomain.
+Require Import compcert.CombineOp.
 
 Section COMBINE.
 

--- a/riscV/ConstpropOp.vp
+++ b/riscV/ConstpropOp.vp
@@ -13,11 +13,11 @@
 (** Strength reduction for operators and conditions.
     This is the machine-dependent part of [Constprop]. *)
 
-Require Archi.
-Require Import Coqlib Compopts.
-Require Import AST Integers Floats.
-Require Import Op Registers.
-Require Import ValueDomain.
+Require compcert.Archi.
+Require Import compcert.Coqlib Compopts.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.Registers.
+Require Import compcert.ValueDomain.
 
 (** * Converting known values to constants *)
 

--- a/riscV/ConstpropOp.vp
+++ b/riscV/ConstpropOp.vp
@@ -14,7 +14,7 @@
     This is the machine-dependent part of [Constprop]. *)
 
 Require compcert.Archi.
-Require Import compcert.Coqlib Compopts.
+Require Import compcert.Coqlib compcert.Compopts.
 Require Import compcert.AST compcert.Integers compcert.Floats.
 Require Import compcert.Op compcert.Registers.
 Require Import compcert.ValueDomain.

--- a/riscV/ConstpropOpproof.v
+++ b/riscV/ConstpropOpproof.v
@@ -12,7 +12,7 @@
 
 (** Correctness proof for operator strength reduction. *)
 
-Require Import compcert.Coqlib Compopts.
+Require Import compcert.Coqlib compcert.Compopts.
 Require Import compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
 Require Import compcert.Op compcert.Registers compcert.RTL compcert.ValueDomain.
 Require Import compcert.ConstpropOp.

--- a/riscV/ConstpropOpproof.v
+++ b/riscV/ConstpropOpproof.v
@@ -12,10 +12,10 @@
 
 (** Correctness proof for operator strength reduction. *)
 
-Require Import Coqlib Compopts.
-Require Import Integers Floats Values Memory Globalenvs Events.
-Require Import Op Registers RTL ValueDomain.
-Require Import ConstpropOp.
+Require Import compcert.Coqlib Compopts.
+Require Import compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Op compcert.Registers compcert.RTL compcert.ValueDomain.
+Require Import compcert.ConstpropOp.
 
 Section STRENGTH_REDUCTION.
 

--- a/riscV/Conventions1.v
+++ b/riscV/Conventions1.v
@@ -18,8 +18,8 @@
 (** Function calling conventions and other conventions regarding the use of
     machine registers and stack slots. *)
 
-Require Import Coqlib Decidableplus.
-Require Import AST Machregs Locations.
+Require Import compcert.Coqlib compcert.Decidableplus.
+Require Import compcert.AST compcert.Machregs compcert.Locations.
 
 (** * Classification of machine registers *)
 

--- a/riscV/Machregs.v
+++ b/riscV/Machregs.v
@@ -16,12 +16,12 @@
 (* *********************************************************************)
 
 Require Import String.
-Require Import Coqlib.
-Require Import Decidableplus.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Op.
+Require Import compcert.Coqlib.
+Require Import compcert.Decidableplus.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Op.
 
 (** ** Machine registers *)
 

--- a/riscV/NeedOp.v
+++ b/riscV/NeedOp.v
@@ -15,11 +15,11 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import Coqlib.
-Require Import AST Integers Floats.
-Require Import Values Memory Globalenvs.
-Require Import Op RTL.
-Require Import NeedDomain.
+Require Import compcert.Coqlib.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs.
+Require Import compcert.Op compcert.RTL.
+Require Import compcert.NeedDomain.
 
 (** Neededness analysis for RISC-V operators *)
 

--- a/riscV/Op.v
+++ b/riscV/Op.v
@@ -29,9 +29,9 @@
   syntax and dynamic semantics of the Cminor language.
 *)
 
-Require Import BoolEqual Coqlib.
-Require Import AST Integers Floats.
-Require Import Values Memory Globalenvs Events.
+Require Import compcert.BoolEqual compcert.Coqlib.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
 
 Set Implicit Arguments.
 

--- a/riscV/SelectLong.vp
+++ b/riscV/SelectLong.vp
@@ -17,11 +17,11 @@
 
 (** Instruction selection for 64-bit integer operations *)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 Require Import Compopts.
-Require Import AST Integers Floats.
-Require Import Op CminorSel.
-Require Import SelectOp SplitLong.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SplitLong.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope string_scope.

--- a/riscV/SelectLong.vp
+++ b/riscV/SelectLong.vp
@@ -18,7 +18,7 @@
 (** Instruction selection for 64-bit integer operations *)
 
 Require Import compcert.Coqlib.
-Require Import Compopts.
+Require Import compcert.Compopts.
 Require Import compcert.AST compcert.Integers compcert.Floats.
 Require Import compcert.Op compcert.CminorSel.
 Require Import compcert.SelectOp compcert.SplitLong.

--- a/riscV/SelectLongproof.v
+++ b/riscV/SelectLongproof.v
@@ -17,12 +17,12 @@
 
 (** Correctness of instruction selection for 64-bit integer operations *)
 
-Require Import String Coqlib Maps Integers Floats Errors.
-Require Archi.
-Require Import AST Values Memory Globalenvs Events.
-Require Import Cminor Op CminorSel.
-Require Import SelectOp SelectOpproof SplitLong SplitLongproof.
-Require Import SelectLong.
+Require Import String compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Errors.
+Require compcert.Archi.
+Require Import compcert.AST compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Cminor compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SelectOpproof compcert.SplitLong compcert.SplitLongproof.
+Require Import compcert.SelectLong.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope string_scope.

--- a/riscV/SelectOp.vp
+++ b/riscV/SelectOp.vp
@@ -43,7 +43,7 @@
 
 Require compcert.Archi.
 Require Import compcert.Coqlib.
-Require Import Compopts.
+Require Import compcert.Compopts.
 Require Import compcert.AST.
 Require Import compcert.Integers.
 Require Import compcert.Floats.

--- a/riscV/SelectOp.vp
+++ b/riscV/SelectOp.vp
@@ -41,14 +41,14 @@
   module [Selection] implements the actual instruction selection pass.
 *)
 
-Require Archi.
-Require Import Coqlib.
+Require compcert.Archi.
+Require Import compcert.Coqlib.
 Require Import Compopts.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Op.
-Require Import CminorSel.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Op.
+Require Import compcert.CminorSel.
 
 Local Open Scope cminorsel_scope.
 

--- a/riscV/SelectOpproof.v
+++ b/riscV/SelectOpproof.v
@@ -17,18 +17,18 @@
 
 (** Correctness of instruction selection for operators *)
 
-Require Import Coqlib.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Cminor.
-Require Import Op.
-Require Import CminorSel.
-Require Import SelectOp.
+Require Import compcert.Coqlib.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Cminor.
+Require Import compcert.Op.
+Require Import compcert.CminorSel.
+Require Import compcert.SelectOp.
 
 Local Open Scope cminorsel_scope.
 

--- a/riscV/Stacklayout.v
+++ b/riscV/Stacklayout.v
@@ -12,9 +12,9 @@
 
 (** Machine- and ABI-dependent layout information for activation records. *)
 
-Require Import Coqlib.
-Require Import AST Memory Separation.
-Require Import Bounds.
+Require Import compcert.Coqlib.
+Require Import compcert.AST compcert.Memory compcert.Separation.
+Require Import compcert.Bounds.
 
 Local Open Scope sep_scope.
 

--- a/riscV/ValueAOp.v
+++ b/riscV/ValueAOp.v
@@ -10,9 +10,9 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import Coqlib Compopts.
-Require Import AST Integers Floats Values Memory Globalenvs.
-Require Import Op RTL ValueDomain.
+Require Import compcert.Coqlib Compopts.
+Require Import compcert.AST compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs.
+Require Import compcert.Op compcert.RTL compcert.ValueDomain.
 
 (** Value analysis for RISC V operators *)
 

--- a/riscV/ValueAOp.v
+++ b/riscV/ValueAOp.v
@@ -10,7 +10,7 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import compcert.Coqlib Compopts.
+Require Import compcert.Coqlib compcert.Compopts.
 Require Import compcert.AST compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs.
 Require Import compcert.Op compcert.RTL compcert.ValueDomain.
 

--- a/riscV/extractionMachdep.v
+++ b/riscV/extractionMachdep.v
@@ -12,7 +12,7 @@
 
 (* Additional extraction directives specific to the RISC-V port *)
 
-Require Archi Asm.
+Require compcert.Archi compcert.Asm.
 
 (* Archi *)
 

--- a/x86/Asm.v
+++ b/x86/Asm.v
@@ -12,9 +12,9 @@
 
 (** Abstract syntax and semantics for IA32 assembly language *)
 
-Require Import Coqlib Maps.
-Require Import AST Integers Floats Values Memory Events Globalenvs Smallstep.
-Require Import Locations Stacklayout Conventions.
+Require Import compcert.Coqlib compcert.Maps.
+Require Import compcert.AST compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Locations compcert.Stacklayout compcert.Conventions.
 
 (** * Abstract syntax *)
 

--- a/x86/Asmgen.v
+++ b/x86/Asmgen.v
@@ -12,9 +12,9 @@
 
 (** Translation from Mach to IA32 assembly language *)
 
-Require Import Coqlib Errors.
-Require Import AST Integers Floats Memdata.
-Require Import Op Locations Mach Asm.
+Require Import compcert.Coqlib compcert.Errors.
+Require Import compcert.AST compcert.Integers compcert.Floats compcert.Memdata.
+Require Import compcert.Op compcert.Locations compcert.Mach compcert.Asm.
 
 Local Open Scope string_scope.
 Local Open Scope error_monad_scope.

--- a/x86/Asmgenproof.v
+++ b/x86/Asmgenproof.v
@@ -12,11 +12,11 @@
 
 (** Correctness proof for x86-64 generation: main proof. *)
 
-Require Import Coqlib Errors.
-Require Import Integers Floats AST Linking.
-Require Import Values Memory Events Globalenvs Smallstep.
-Require Import Op Locations Mach Conventions Asm.
-Require Import Asmgen Asmgenproof0 Asmgenproof1.
+Require Import compcert.Coqlib compcert.Errors.
+Require Import compcert.Integers compcert.Floats compcert.AST compcert.Linking.
+Require Import compcert.Values compcert.Memory compcert.Events compcert.Globalenvs compcert.Smallstep.
+Require Import compcert.Op compcert.Locations compcert.Mach compcert.Conventions compcert.Asm.
+Require Import compcert.Asmgen compcert.Asmgenproof0 compcert.Asmgenproof1.
 
 Definition match_prog (p: Mach.program) (tp: Asm.program) :=
   match_program (fun _ f tf => transf_fundef f = OK tf) eq p tp.

--- a/x86/Asmgenproof1.v
+++ b/x86/Asmgenproof1.v
@@ -12,10 +12,10 @@
 
 (** Correctness proof for x86-64 generation: auxiliary results. *)
 
-Require Import Coqlib.
-Require Import AST Errors Integers Floats Values Memory Globalenvs.
-Require Import Op Locations Conventions Mach Asm.
-Require Import Asmgen Asmgenproof0.
+Require Import compcert.Coqlib.
+Require Import compcert.AST compcert.Errors compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs.
+Require Import compcert.Op compcert.Locations compcert.Conventions compcert.Mach compcert.Asm.
+Require Import compcert.Asmgen compcert.Asmgenproof0.
 
 Local Open Scope error_monad_scope.
 

--- a/x86/CombineOp.v
+++ b/x86/CombineOp.v
@@ -13,9 +13,9 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
-Require Import Coqlib.
-Require Import AST Integers.
-Require Import Op CSEdomain.
+Require Import compcert.Coqlib.
+Require Import compcert.AST compcert.Integers.
+Require Import compcert.Op compcert.CSEdomain.
 
 Definition valnum := positive.
 

--- a/x86/CombineOpproof.v
+++ b/x86/CombineOpproof.v
@@ -13,10 +13,10 @@
 (** Recognition of combined operations, addressing modes and conditions
   during the [CSE] phase. *)
 
-Require Import Coqlib.
-Require Import Integers Values Memory.
-Require Import Op RTL CSEdomain.
-Require Import CombineOp.
+Require Import compcert.Coqlib.
+Require Import compcert.Integers compcert.Values compcert.Memory.
+Require Import compcert.Op compcert.RTL compcert.CSEdomain.
+Require Import compcert.CombineOp.
 
 Section COMBINE.
 

--- a/x86/ConstpropOp.vp
+++ b/x86/ConstpropOp.vp
@@ -13,10 +13,10 @@
 (** Strength reduction for operators and conditions.
     This is the machine-dependent part of [Constprop]. *)
 
-Require Import Coqlib Compopts.
-Require Import AST Integers Floats.
-Require Import Op Registers.
-Require Import ValueDomain.
+Require Import compcert.Coqlib Compopts.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.Registers.
+Require Import compcert.ValueDomain.
 
 (** * Converting known values to constants *)
 

--- a/x86/ConstpropOp.vp
+++ b/x86/ConstpropOp.vp
@@ -13,7 +13,7 @@
 (** Strength reduction for operators and conditions.
     This is the machine-dependent part of [Constprop]. *)
 
-Require Import compcert.Coqlib Compopts.
+Require Import compcert.Coqlib compcert.Compopts.
 Require Import compcert.AST compcert.Integers compcert.Floats.
 Require Import compcert.Op compcert.Registers.
 Require Import compcert.ValueDomain.

--- a/x86/ConstpropOpproof.v
+++ b/x86/ConstpropOpproof.v
@@ -12,7 +12,7 @@
 
 (** Correctness proof for operator strength reduction. *)
 
-Require Import compcert.Coqlib Compopts.
+Require Import compcert.Coqlib compcert.Compopts.
 Require Import compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
 Require Import compcert.Op compcert.Registers compcert.RTL compcert.ValueDomain.
 Require Import compcert.ConstpropOp.

--- a/x86/ConstpropOpproof.v
+++ b/x86/ConstpropOpproof.v
@@ -12,10 +12,10 @@
 
 (** Correctness proof for operator strength reduction. *)
 
-Require Import Coqlib Compopts.
-Require Import Integers Floats Values Memory Globalenvs Events.
-Require Import Op Registers RTL ValueDomain.
-Require Import ConstpropOp.
+Require Import compcert.Coqlib Compopts.
+Require Import compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Op compcert.Registers compcert.RTL compcert.ValueDomain.
+Require Import compcert.ConstpropOp.
 
 Section STRENGTH_REDUCTION.
 

--- a/x86/Conventions1.v
+++ b/x86/Conventions1.v
@@ -13,8 +13,8 @@
 (** Function calling conventions and other conventions regarding the use of
     machine registers and stack slots. *)
 
-Require Import Coqlib Decidableplus.
-Require Import AST Machregs Locations.
+Require Import compcert.Coqlib compcert.Decidableplus.
+Require Import compcert.AST compcert.Machregs compcert.Locations.
 
 (** * Classification of machine registers *)
 

--- a/x86/Machregs.v
+++ b/x86/Machregs.v
@@ -11,12 +11,12 @@
 (* *********************************************************************)
 
 Require Import String.
-Require Import Coqlib.
-Require Import Decidableplus.
-Require Import Maps.
-Require Import AST.
-Require Import Integers.
-Require Import Op.
+Require Import compcert.Coqlib.
+Require Import compcert.Decidableplus.
+Require Import compcert.Maps.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Op.
 
 (** ** Machine registers *)
 

--- a/x86/NeedOp.v
+++ b/x86/NeedOp.v
@@ -12,9 +12,9 @@
 
 (** Neededness analysis for x86_64 operators *)
 
-Require Import Coqlib.
-Require Import AST Integers Floats Values Memory Globalenvs.
-Require Import Op NeedDomain RTL.
+Require Import compcert.Coqlib.
+Require Import compcert.AST compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs.
+Require Import compcert.Op compcert.NeedDomain compcert.RTL.
 
 Definition op1 (nv: nval) := nv :: nil.
 Definition op2 (nv: nval) := nv :: nv :: nil.

--- a/x86/Op.v
+++ b/x86/Op.v
@@ -23,15 +23,15 @@
   For a processor-independent set of operations, see the abstract
   syntax and dynamic semantics of the Cminor language.
 *)
-Require Import BoolEqual.
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Events.
+Require Import compcert.BoolEqual.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Events.
 
 Set Implicit Arguments.
 

--- a/x86/SelectLong.vp
+++ b/x86/SelectLong.vp
@@ -12,11 +12,11 @@
 
 (** Instruction selection for 64-bit integer operations *)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 Require Import Compopts.
-Require Import AST Integers Floats.
-Require Import Op CminorSel.
-Require Import SelectOp SplitLong.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SplitLong.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope string_scope.

--- a/x86/SelectLong.vp
+++ b/x86/SelectLong.vp
@@ -13,7 +13,7 @@
 (** Instruction selection for 64-bit integer operations *)
 
 Require Import compcert.Coqlib.
-Require Import Compopts.
+Require Import compcert.Compopts.
 Require Import compcert.AST compcert.Integers compcert.Floats.
 Require Import compcert.Op compcert.CminorSel.
 Require Import compcert.SelectOp compcert.SplitLong.

--- a/x86/SelectLongproof.v
+++ b/x86/SelectLongproof.v
@@ -12,12 +12,12 @@
 
 (** Correctness of instruction selection for 64-bit integer operations *)
 
-Require Import String Coqlib Maps Integers Floats Errors.
-Require Archi.
-Require Import AST Values Memory Globalenvs Events.
-Require Import Cminor Op CminorSel.
-Require Import SelectOp SelectOpproof SplitLong SplitLongproof.
-Require Import SelectLong.
+Require Import String compcert.Coqlib compcert.Maps compcert.Integers compcert.Floats compcert.Errors.
+Require compcert.Archi.
+Require Import compcert.AST compcert.Values compcert.Memory compcert.Globalenvs compcert.Events.
+Require Import compcert.Cminor compcert.Op compcert.CminorSel.
+Require Import compcert.SelectOp compcert.SelectOpproof compcert.SplitLong compcert.SplitLongproof.
+Require Import compcert.SelectLong.
 
 Local Open Scope cminorsel_scope.
 Local Open Scope string_scope.

--- a/x86/SelectOp.vp
+++ b/x86/SelectOp.vp
@@ -37,7 +37,7 @@
 *)
 
 Require Import compcert.Coqlib.
-Require Import Compopts.
+Require Import compcert.Compopts.
 Require Import compcert.AST compcert.Integers compcert.Floats.
 Require Import compcert.Op compcert.CminorSel.
 

--- a/x86/SelectOp.vp
+++ b/x86/SelectOp.vp
@@ -36,10 +36,10 @@
   module [Selection] implements the actual instruction selection pass.
 *)
 
-Require Import Coqlib.
+Require Import compcert.Coqlib.
 Require Import Compopts.
-Require Import AST Integers Floats.
-Require Import Op CminorSel.
+Require Import compcert.AST compcert.Integers compcert.Floats.
+Require Import compcert.Op compcert.CminorSel.
 
 Local Open Scope cminorsel_scope.
 

--- a/x86/SelectOpproof.v
+++ b/x86/SelectOpproof.v
@@ -12,17 +12,17 @@
 
 (** Correctness of instruction selection for operators *)
 
-Require Import Coqlib.
-Require Import AST.
-Require Import Integers.
-Require Import Floats.
-Require Import Values.
-Require Import Memory.
-Require Import Globalenvs.
-Require Import Cminor.
-Require Import Op.
-Require Import CminorSel.
-Require Import SelectOp.
+Require Import compcert.Coqlib.
+Require Import compcert.AST.
+Require Import compcert.Integers.
+Require Import compcert.Floats.
+Require Import compcert.Values.
+Require Import compcert.Memory.
+Require Import compcert.Globalenvs.
+Require Import compcert.Cminor.
+Require Import compcert.Op.
+Require Import compcert.CminorSel.
+Require Import compcert.SelectOp.
 
 Local Open Scope cminorsel_scope.
 

--- a/x86/Stacklayout.v
+++ b/x86/Stacklayout.v
@@ -12,9 +12,9 @@
 
 (** Machine- and ABI-dependent layout information for activation records. *)
 
-Require Import Coqlib.
-Require Import AST Memory Separation.
-Require Import Bounds.
+Require Import compcert.Coqlib.
+Require Import compcert.AST compcert.Memory compcert.Separation.
+Require Import compcert.Bounds.
 
 Local Open Scope sep_scope.
 

--- a/x86/ValueAOp.v
+++ b/x86/ValueAOp.v
@@ -10,9 +10,9 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import Coqlib Compopts.
-Require Import AST Integers Floats Values Memory Globalenvs.
-Require Import Op RTL ValueDomain.
+Require Import compcert.Coqlib Compopts.
+Require Import compcert.AST compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs.
+Require Import compcert.Op compcert.RTL compcert.ValueDomain.
 
 (** Value analysis for x86_64 operators *)
 

--- a/x86/ValueAOp.v
+++ b/x86/ValueAOp.v
@@ -10,7 +10,7 @@
 (*                                                                     *)
 (* *********************************************************************)
 
-Require Import compcert.Coqlib Compopts.
+Require Import compcert.Coqlib compcert.Compopts.
 Require Import compcert.AST compcert.Integers compcert.Floats compcert.Values compcert.Memory compcert.Globalenvs.
 Require Import compcert.Op compcert.RTL compcert.ValueDomain.
 

--- a/x86/extractionMachdep.v
+++ b/x86/extractionMachdep.v
@@ -12,7 +12,7 @@
 
 (* Additional extraction directives specific to the x86-64 port *)
 
-Require SelectOp ConstpropOp.
+Require compcert.SelectOp compcert.ConstpropOp.
 
 (* SelectOp *)
 

--- a/x86_32/Archi.v
+++ b/x86_32/Archi.v
@@ -17,8 +17,8 @@
 (** Architecture-dependent parameters for x86 in 32-bit mode *)
 
 Require Import ZArith.
-Require Import Fappli_IEEE.
-Require Import Fappli_IEEE_bits.
+Require Import flocq.Appli.Fappli_IEEE.
+Require Import flocq.Appli.Fappli_IEEE_bits.
 
 Definition ptr64 := false.
 

--- a/x86_64/Archi.v
+++ b/x86_64/Archi.v
@@ -17,8 +17,8 @@
 (** Architecture-dependent parameters for x86 in 64-bit mode *)
 
 Require Import ZArith.
-Require Import Fappli_IEEE.
-Require Import Fappli_IEEE_bits.
+Require Import flocq.Appli.Fappli_IEEE.
+Require Import flocq.Appli.Fappli_IEEE_bits.
 
 Definition ptr64 := true.
 


### PR DESCRIPTION
Use -Q instead of -R for the include's in order to avoid polluting the global namespace as outlined in issue #199. Note that the -Q option is used for all modules with compcert except for flocq.

In order to test this one needs to apply the patch attached from the [menhir issue](https://gitlab.inria.fr/fpottier/menhir/issues/1). Thus this cannot be merged before the patch is applied to menhir or something similar is implemented.