### PR TITLE
Do not use “Require” inside sections

### DIFF
--- a/backend/RTLgenproof.v
+++ b/backend/RTLgenproof.v
@@ -1147,7 +1147,7 @@ Qed.
 Ltac Lt_state :=
   apply lt_state_intro; simpl; try omega.
 
-Require Import Wellfounded.
+Import Wellfounded.
 
 Lemma lt_state_wf:
   well_founded lt_state.

--- a/cfrontend/Cstrategy.v
+++ b/cfrontend/Cstrategy.v
@@ -15,6 +15,7 @@
 
 (** A deterministic evaluation strategy for C. *)
 
+Require Import Classical.
 Require Import Axioms.
 Require Import Coqlib.
 Require Import Errors.
@@ -432,8 +433,6 @@ Lemma plus_safe:
 Proof.
   intros. eapply star_plus_trans; eauto. apply H1. eapply safe_steps; eauto. auto.
 Qed.
-
-Require Import Classical.
 
 Lemma safe_imm_safe:
   forall f C a k e m K,


### PR DESCRIPTION
Who knows what a “Require” within a section means…

This will be deprecated in the next version of Coq.