### PR TITLE
Unify definitions of agree_callee_save

### DIFF
--- a/backend/Allocproof.v
+++ b/backend/Allocproof.v
@@ -1317,15 +1317,6 @@ Proof.
   eauto.
 Qed.
 
-Definition callee_save_loc (l: loc) :=
-  match l with
-  | R r => is_callee_save r = true
-  | S sl ofs ty => sl <> Outgoing
-  end.
-
-Definition agree_callee_save (ls1 ls2: locset) : Prop :=
-  forall l, callee_save_loc l -> ls1 l = ls2 l.
-
 Lemma return_regs_agree_callee_save:
   forall caller callee,
   agree_callee_save caller (return_regs caller callee).
@@ -1345,7 +1336,7 @@ Proof.
   unfold no_caller_saves, callee_save_loc; intros.
   exploit EqSet.for_all_2; eauto.
   hnf. intros. simpl in H1. rewrite H1. auto.
-  lazy beta. destruct (eloc q). auto. destruct sl; congruence.
+  lazy beta. destruct (eloc q); auto.
 Qed.
 
 Lemma val_hiword_longofwords:

--- a/backend/Conventions.v
+++ b/backend/Conventions.v
@@ -103,3 +103,16 @@ Proof.
   generalize (loc_arguments_bounded _ _ _ H0).
   generalize (typesize_pos ty). omega.
 Qed.
+
+(** * Callee-save registers *)
+
+Definition callee_save_loc (l: loc) :=
+  match l with
+  | R r => is_callee_save r = true
+  | S sl ofs ty => True
+  end.
+
+Hint Unfold callee_save_loc.
+
+Definition agree_callee_save (ls1 ls2: Locmap.t) : Prop :=
+  forall l, callee_save_loc l -> ls1 l = ls2 l.

--- a/backend/Stackingproof.v
+++ b/backend/Stackingproof.v
@@ -573,16 +573,6 @@ Record agree_locs (ls ls0: locset) : Prop :=
        ls (S Incoming ofs ty) = ls0 (S Outgoing ofs ty)
 }.
 
-(** Auxiliary predicate used at call points *)
-
-Definition agree_callee_save (ls ls0: locset) : Prop :=
-  forall l,
-  match l with
-  | R r => is_callee_save r = true
-  | S _ _ _ => True
-  end ->
-  ls l = ls0 l.
-
 (** ** Properties of [agree_regs]. *)
 
 (** Values of registers *)


### PR DESCRIPTION
Allocproof and Stackingproof introduce incompatible definitions of `agree_callee_save`, but it turns out they can be unified with very little effort.

For what it's worth this shows up in my ongoing compositional compilation work where I use `agree_callee_save` to characterize the calling conventions used at module boundary.