### PR TITLE
.vo installation also install a VERSION file (VST requirement)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -259,7 +259,7 @@ ifeq ($(INSTALL_COQDEV),true)
           install -d $(COQDEVDIR)/$$d && \
           install -m 0644 $$d/*.vo $(COQDEVDIR)/$$d/; \
 	done
-	cp ./VERSION $(COQDEVDIR)
+	install -m 0644 ./VERSION $(COQDEVDIR)
 	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(COQDEVDIR)/README
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ ifeq ($(INSTALL_COQDEV),true)
           install -d $(COQDEVDIR)/$$d && \
           install -m 0644 $$d/*.vo $(COQDEVDIR)/$$d/; \
 	done
+	cp ./VERSION $(COQDEVDIR)
 	@(echo "To use, pass the following to coq_makefile or add the following to _CoqProject:"; echo "-R $(COQDEVDIR) compcert") > $(COQDEVDIR)/README
 endif
 


### PR DESCRIPTION
VST check compatibility with the `VERSION` of CompCert in their Makefile.
It was not currently provided by the script.