### PR TITLE
solve Menhir compatibility with 20180530

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ COQDEP="$(COQBIN)coqdep" $(COQINCLUDES)
 COQDOC="$(COQBIN)coqdoc"
 COQEXEC="$(COQBIN)coqtop" $(COQINCLUDES) -batch -load-vernac-source
 COQCHK="$(COQBIN)coqchk" $(COQINCLUDES)
-MENHIR=menhir
+MENHIR=menhir $(MENHIR_SWITCH)
 CP=cp
 
 VPATH=$(DIRS)

--- a/configure
+++ b/configure
@@ -540,6 +540,7 @@ else
 fi
 
 MENHIR_REQUIRED=20161201
+MENHIR_SWITCH=20180530
 echo "Testing Menhir... " | tr -d '\n'
 menhir_ver=`menhir --version 2>/dev/null | sed -n -e 's/^.*version \([0-9]*\).*$/\1/p'`
 case "$menhir_ver" in
@@ -547,6 +548,12 @@ case "$menhir_ver" in
       if test "$menhir_ver" -ge $MENHIR_REQUIRED; then
           echo "version $menhir_ver -- good!"
           menhir_includes="-I `menhir --suggest-menhirLib`"
+          if test "$menhir_ver" -ge $MENHIR_SWITCH; then
+            echo "version >= $MENHIR_SWITCH: activating --coq-lib-no-path"
+            menhir_compatibility=true
+          else
+            menhir_compatibility=false
+          fi
         else
           echo "version $menhir_ver -- UNSUPPORTED"
           echo "Error: CompCert requires Menhir version $MENHIR_REQUIRED or later."
@@ -637,6 +644,16 @@ OCAML_OPT_COMP=$ocaml_opt_comp
 MENHIR_INCLUDES=$menhir_includes
 COMPFLAGS=-bin-annot
 EOF
+
+if test "$menhir_compatibility" = true; then
+cat >> Makefile.config <<EOF
+MENHIR_SWITCH=--coq-lib-no-path
+EOF
+else
+cat >> Makefile.config <<EOF
+MENHIR_SWITCH=
+EOF
+fi
 
 if test "$target" != "manual"; then
 cat >> Makefile.config <<EOF
@@ -809,4 +826,3 @@ EOF
 fi
 
 fi
-


### PR DESCRIPTION
> New command line option `--coq-lib-no-path` to suppress the above behavior
and retain the previous (now-deprecated) behavior, that is, produce
unqualified references the modules in Menhir's support library.

Thus this pull request adds a version check in `configure` to enable the option `--coq-lib-no-path` if `menhir` is of version greater or equal to 20180530.

As this is a depreciated behavior, I am aware this is more of a fix and this should be properly updated in the future. But as is, Compcert will simply not build with the current version of menhir provided by opam.

Another solution would be to limit the version of menhir at 20180528 maximum.