### PR TITLE
Import prim token notations before using them

### DIFF
--- a/backend/Allocation.v
+++ b/backend/Allocation.v
@@ -12,6 +12,7 @@
 
 (** Register allocation by external oracle and a posteriori validation. *)
 
+Require Import Coq.Strings.String.
 Require Import FSets FSetAVLplus.
 Require Import Coqlib Ordered Maps Errors Integers Floats.
 Require Import AST Lattice Kildall Memdata.

--- a/backend/CSE.v
+++ b/backend/CSE.v
@@ -13,6 +13,7 @@
 (** Common subexpression elimination over RTL.  This optimization
   proceeds by value numbering over extended basic blocks. *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib Maps Errors Integers Floats Lattice Kildall.
 Require Import AST Linking.
 Require Import Values Memory.

--- a/backend/Deadcode.v
+++ b/backend/Deadcode.v
@@ -12,6 +12,7 @@
 
 (** Elimination of unneeded computations over RTL. *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib Maps Errors Integers Floats Lattice Kildall.
 Require Import AST Linking.
 Require Import Memory Registers Op RTL.

--- a/backend/Debugvar.v
+++ b/backend/Debugvar.v
@@ -13,6 +13,7 @@
 (** Computation of live ranges for local variables that carry
     debugging information. *)
 
+Require Import Coq.Strings.String.
 Require Import Axioms Coqlib Maps Iteration Errors.
 Require Import Integers Floats AST.
 Require Import Machregs Locations Conventions Linear.

--- a/backend/Inlining.v
+++ b/backend/Inlining.v
@@ -12,6 +12,7 @@
 
 (** RTL function inlining *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib Wfsimpl Maps Errors Integers.
 Require Import AST Linking.
 Require Import Op Registers RTL.

--- a/backend/Linearize.v
+++ b/backend/Linearize.v
@@ -12,6 +12,7 @@
 
 (** Linearization of the control-flow graph: translation from LTL to Linear *)
 
+Require Import Coq.Strings.String.
 Require Import FSets FSetAVL.
 Require Import Coqlib Maps Ordered Errors Lattice Kildall.
 Require Import AST Op Locations LTL Linear.

--- a/backend/RTLgen.v
+++ b/backend/RTLgen.v
@@ -12,6 +12,7 @@
 
 (** Translation from CminorSel to RTL. *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib.
 Require Errors.
 Require Import Maps.

--- a/backend/RTLtyping.v
+++ b/backend/RTLtyping.v
@@ -12,6 +12,7 @@
 
 (** Typing rules and a type inference algorithm for RTL. *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib.
 Require Import Errors.
 Require Import Unityping.

--- a/backend/Selection.v
+++ b/backend/Selection.v
@@ -22,6 +22,7 @@
   Instruction selection proceeds by bottom-up rewriting over expressions.
   The source language is Cminor and the target language is CminorSel. *)
 
+Require Import Coq.Strings.String.
 Require String.
 Require Import Coqlib Maps.
 Require Import AST Errors Integers Globalenvs Switch.

--- a/backend/SplitLong.vp
+++ b/backend/SplitLong.vp
@@ -12,7 +12,7 @@
 
 (** Instruction selection for 64-bit integer operations *)
 
-Require String.
+Require Import Coq.Strings.String.
 Require Import Coqlib.
 Require Import AST Integers Floats.
 Require Import Op CminorSel.

--- a/backend/Stacking.v
+++ b/backend/Stacking.v
@@ -12,6 +12,7 @@
 
 (** Layout of activation records; translation from Linear to Mach. *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib Errors.
 Require Import Integers AST.
 Require Import Op Locations Linear Mach.

--- a/backend/Unusedglob.v
+++ b/backend/Unusedglob.v
@@ -12,6 +12,7 @@
 
 (** Elimination of unreferenced static definitions *)
 
+Require Import Coq.Strings.String.
 Require Import FSets Coqlib Maps Ordered Iteration Errors.
 Require Import AST Linking.
 Require Import Op Registers RTL.

--- a/cfrontend/Cminorgen.v
+++ b/cfrontend/Cminorgen.v
@@ -12,6 +12,7 @@
 
 (** Translation from Csharpminor to Cminor. *)
 
+Require Import Coq.Strings.String.
 Require Import FSets FSetAVL Orders Mergesort.
 Require Import Coqlib Maps Ordered Errors Integers Floats.
 Require Import AST Linking.

--- a/cfrontend/Cshmgen.v
+++ b/cfrontend/Cshmgen.v
@@ -20,6 +20,7 @@
    Csharpminor's simpler control structures.
 *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib Maps Errors Integers Floats.
 Require Import AST Linking.
 Require Import Ctypes Cop Clight Cminor Csharpminor.

--- a/cfrontend/Ctypes.v
+++ b/cfrontend/Ctypes.v
@@ -15,6 +15,7 @@
 
 (** Type expressions for the Compcert C and Clight languages *)
 
+Require Import Coq.Strings.String.
 Require Import Axioms Coqlib Maps Errors.
 Require Import AST Linking.
 Require Archi.

--- a/cfrontend/Initializers.v
+++ b/cfrontend/Initializers.v
@@ -12,6 +12,7 @@
 
 (** Compile-time evaluation of initializers for global C variables. *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib Maps Errors.
 Require Import Integers Floats Values AST Memory Globalenvs.
 Require Import Ctypes Cop Csyntax.

--- a/cfrontend/SimplExpr.v
+++ b/cfrontend/SimplExpr.v
@@ -13,6 +13,7 @@
 (** Translation from Compcert C to Clight.
     Side effects are pulled out of Compcert C expressions. *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib.
 Require Import Errors.
 Require Import Integers.
@@ -26,6 +27,7 @@ Require Import Csyntax.
 Require Import Clight.
 
 Local Open Scope string_scope.
+Local Open Scope list_scope.
 
 (** State and error monad for generating fresh identifiers. *)
 

--- a/cfrontend/SimplLocals.v
+++ b/cfrontend/SimplLocals.v
@@ -13,6 +13,7 @@
 (** Pulling local scalar variables whose address is not taken
   into temporary variables. *)
 
+Require Import Coq.Strings.String.
 Require Import FSets.
 Require FSetAVL.
 Require Import Coqlib Ordered Errors.
@@ -22,6 +23,7 @@ Require Compopts.
 
 Open Scope error_monad_scope.
 Open Scope string_scope.
+Open Scope list_scope.
 
 Module VSet := FSetAVL.Make(OrderedPositive).
 

--- a/common/Unityping.v
+++ b/common/Unityping.v
@@ -15,6 +15,7 @@
 
 (* A solver for unification constraints. *)
 
+Require Import Coq.Strings.String.
 Require Import Recdef Coqlib Maps Errors.
 
 Local Open Scope nat_scope.

--- a/x86/Asmgen.v
+++ b/x86/Asmgen.v
@@ -12,6 +12,7 @@
 
 (** Translation from Mach to IA32 assembly language *)
 
+Require Import Coq.Strings.String.
 Require Import Coqlib Errors.
 Require Import AST Integers Floats Memdata.
 Require Import Op Locations Mach Asm.


### PR DESCRIPTION
This is required for compatibility with
https://github.com/coq/coq/pull/8064, where prim token notations no longer
follow `Require`, but instead follow `Import`.

c.f. https://github.com/coq/coq/pull/8064#issuecomment-415493362

Most changes were made via
https://gist.github.com/JasonGross/5d4558edf8f5c2c548a3d96c17820169#file-fix-py
The changes to `backend/SplitLong.vp` were made manually, and the scope
opening in `cfrontend/SimplExpr.v` and `cfrontend/SimplLocals.v` were
also done manually.