### PR TITLE
Improve behavior of configure script in case of configuration errors

### DIFF
--- a/configure
+++ b/configure
@@ -86,6 +86,10 @@ Options:
   -ignore-coq-version  Accept to use experimental or unsupported versions of Coq
 '
 
+#
+# Remove Leftover Makefile.config (if any)  (GPR#244)
+#
+rm -f Makefile.config
 
 #
 # Parse Command-Line Arguments

--- a/configure
+++ b/configure
@@ -29,6 +29,10 @@ responsefile="gnu"
 ignore_coq_version=false
 
 usage='Usage: ./configure [options] target
+For help on options and targets, do: ./configure -help
+'
+
+help='Usage: ./configure [options] target
 
 Supported targets:
   ppc-eabi             (PowerPC, EABI with GNU/Unix tools)
@@ -119,6 +123,12 @@ while : ; do
         ignore_coq_version=true;;
     -install-coqdev|--install-coqdev|-install-coq-dev|--install-coq-dev)
         install_coqdev=true;;
+    -help|--help)
+        echo "$help"; exit 0;;
+    -*)
+        echo "Error: unknown option '$1'." 1>&2
+        echo "$usage" 1>&2
+        exit 2;;
     *)
         if test -n "$target"; then echo "$usage" 1>&2; exit 2; fi
         target="$1";;


### PR DESCRIPTION
* As suggested in #244: remove leftover Makefile.config before configuration, so that if an error occurs during configuration, there is no Makefile.config file and `make` will fail.

* Configuration errors are hard to read because the full "usage" text is so long that the actual error message scrolls off the screen.  Instead, print a  short (3-line) error message, with a suggestion to do `./configure -help`.

* Print a clearer error message for unknown options (arguments starting with `-`).
