### PR TITLE
Compatibility with primitive integers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,11 @@ else
 ARCHDIRS=$(ARCH)_$(BITSIZE) $(ARCH)
 endif
 
+ifeq ($(COQ_HAS_PRIMITIVE_INTEGERS),true)
+EXTRACTION31DIRS=extraction_31_63
+else
 EXTRACTION31DIRS=extraction_31_31
+endif
 
 DIRS=lib common $(ARCHDIRS) backend cfrontend driver \
   flocq/Core flocq/Prop flocq/Calc flocq/Appli exportclight \

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,14 @@ else
 ARCHDIRS=$(ARCH)_$(BITSIZE) $(ARCH)
 endif
 
+EXTRACTION31DIRS=extraction_31_31
+
 DIRS=lib common $(ARCHDIRS) backend cfrontend driver \
   flocq/Core flocq/Prop flocq/Calc flocq/Appli exportclight \
+  $(EXTRACTION31DIRS) \
   cparser cparser/MenhirLib
 
-RECDIRS=lib common $(ARCHDIRS) backend cfrontend driver flocq exportclight cparser
+RECDIRS=lib common $(ARCHDIRS) backend cfrontend driver flocq exportclight cparser $(EXTRACTION31DIRS)
 
 COQINCLUDES=$(foreach d, $(RECDIRS), -R $(d) compcert.$(d))
 
@@ -123,6 +126,7 @@ DRIVER=Compopts.v Compiler.v Complements.v
 # All source files
 
 FILES=$(VLIB) $(COMMON) $(BACKEND) $(CFRONTEND) $(DRIVER) $(FLOCQ) \
+  ExtractInt31.v \
   $(PARSERVALIDATOR) $(PARSER)
 
 # Generated source files

--- a/configure
+++ b/configure
@@ -638,6 +638,7 @@ case $arch in
         echo "-R x86_${bitsize} compcert.x86_${bitsize}" >> _CoqProject
         ;;
 esac
+echo "-R extraction_31_31 compcert.extraction_31_31" >> _CoqProject
 
 #
 # Generate Makefile.config

--- a/configure
+++ b/configure
@@ -519,6 +519,13 @@ case "$coq_ver" in
         missingtools=true;;
 esac
 
+case "$coq_ver" in
+  8.10?*)
+    coq_has_primitive_integers=true;;
+  ?*)
+    coq_has_primitive_integers=false;;
+esac
+
 echo "Testing OCaml... " | tr -d '\n'
 ocaml_ver=`ocamlopt -version 2>/dev/null`
 case "$ocaml_ver" in
@@ -638,7 +645,10 @@ case $arch in
         echo "-R x86_${bitsize} compcert.x86_${bitsize}" >> _CoqProject
         ;;
 esac
-echo "-R extraction_31_31 compcert.extraction_31_31" >> _CoqProject
+if $coq_has_primitive_integers
+then echo "-R extraction_31_63 compcert.extraction_31_63" >> _CoqProject
+else echo "-R extraction_31_31 compcert.extraction_31_31" >> _CoqProject
+fi
 
 #
 # Generate Makefile.config
@@ -672,6 +682,7 @@ CC=$cc
 CLIGHTGEN=$clightgen
 CLINKER=$clinker
 CLINKER_OPTIONS=$clinker_options
+COQ_HAS_PRIMITIVE_INTEGERS=$coq_has_primitive_integers
 CPREPRO=$cprepro
 CPREPRO_OPTIONS=$cprepro_options
 ENDIANNESS=$endianness

--- a/cparser/MenhirLib/Alphabet.v
+++ b/cparser/MenhirLib/Alphabet.v
@@ -238,7 +238,7 @@ clear H H0 H1.
 do 2 rewrite <- Zabs2Nat.id_abs.
 f_equal.
 revert l i Heqp.
-assert (Z.abs_nat (phi inj_bound) < Z.abs_nat (2^31)).
+assert (Z.abs_nat (phi inj_bound) < Z.abs_nat (2 ^ Z.of_nat size)).
 apply Zabs_nat_lt, phi_bounded.
 induction (Z.abs_nat (phi inj_bound)); intros.
 inversion Heqp; reflexivity.

--- a/extraction/extraction.v
+++ b/extraction/extraction.v
@@ -34,7 +34,7 @@ Require Clight.
 Require Compiler.
 Require Parser.
 Require Initializers.
-Require Int31.
+Require ExtractInt31.
 
 (* Standard lib *)
 Require Import ExtrOcamlBasic.
@@ -135,15 +135,6 @@ Extract Constant Cabs.cabsloc =>
  }".
 Extract Inlined Constant Cabs.string => "String.t".
 Extract Constant Cabs.char_code => "int64".
-
-(* Int31 *)
-Extract Inductive Int31.digits => "bool" [ "false" "true" ].
-Extract Inductive Int31.int31 => "int" [ "Camlcoq.Int31.constr" ] "Camlcoq.Int31.destr".
-Extract Constant Int31.twice => "Camlcoq.Int31.twice".
-Extract Constant Int31.twice_plus_one => "Camlcoq.Int31.twice_plus_one".
-Extract Constant Int31.compare31 => "Camlcoq.Int31.compare".
-Extract Constant Int31.On => "0".
-Extract Constant Int31.In => "1".
 
 (* Processor-specific extraction directives *)
 

--- a/extraction_31_31/ExtractInt31.v
+++ b/extraction_31_31/ExtractInt31.v
@@ -1,0 +1,12 @@
+(** TODO: add a proper header *)
+From Coq Require Extraction.
+From Coq Require Int31.
+
+(* Int31 *)
+Extract Inductive Int31.digits => "bool" [ "false" "true" ].
+Extract Inductive Int31.int31 => "int" [ "Camlcoq.Int31.constr" ] "Camlcoq.Int31.destr".
+Extract Constant Int31.twice => "Camlcoq.Int31.twice".
+Extract Constant Int31.twice_plus_one => "Camlcoq.Int31.twice_plus_one".
+Extract Constant Int31.compare31 => "Camlcoq.Int31.compare".
+Extract Constant Int31.On => "0".
+Extract Constant Int31.In => "1".

--- a/extraction_31_63/ExtractInt31.v
+++ b/extraction_31_63/ExtractInt31.v
@@ -1,0 +1,10 @@
+(** TODO: add a proper header *)
+From Coq Require Extraction.
+From Coq Require Int31.
+
+(* Emulated Int31 *)
+Extract Constant Int31.twice => "(fun x -> Uint63.of_int (Camlcoq.Int31.twice (snd (Uint63.to_int2 x))))".
+Extract Constant Int31.twice_plus_one => "(fun x -> Uint63.of_int (Camlcoq.Int31.twice_plus_one (snd (Uint63.to_int2 x))))".
+Extract Constant Int31.compare31 => "(fun x y -> Camlcoq.Int31.compare (snd (Uint63.to_int2 x)) (snd (Uint63.to_int2 y)))".
+Extract Constant Int31.On => "Uint63.zero".
+Extract Constant Int31.In => "Uint63.one".

--- a/lib/uint63.ml
+++ b/lib/uint63.ml
@@ -1,0 +1,159 @@
+(* Invariant: the msb should be 0 *)
+type t = Int64.t
+
+let uint_size = 63
+
+let maxuint63 = Int64.of_string "0x7FFFFFFFFFFFFFFF"
+let maxuint31 = Int64.of_string "0x7FFFFFFF"
+
+let zero = Int64.zero
+let one = Int64.one
+
+    (* conversion from an int *)
+let mask63 i = Int64.logand i maxuint63
+let of_int i = Int64.of_int i
+let to_int2 i = (Int64.to_int (Int64.shift_right_logical i 31), Int64.to_int i)
+let of_int64 i = i
+let hash i =
+  let (h,l) = to_int2 i in
+  h * 65599 + l
+
+    (* conversion of an uint63 to a string *)
+let to_string i = Int64.to_string i
+
+let of_string s =
+  let i64 = Int64.of_string s in
+  if Int64.compare Int64.zero i64 <= 0
+      && Int64.compare i64 maxuint63 <= 0
+  then i64
+  else raise (Failure "Int63.of_string")
+
+(* Compiles an unsigned int to OCaml code *)
+let compile i = Printf.sprintf "Uint63.of_int64 (%LiL)" i
+
+    (* comparison *)
+let lt x y =
+  Int64.compare x y < 0
+
+let le x y =
+  Int64.compare x y <= 0
+
+    (* logical shift *)
+let l_sl x y =
+  if le 0L y && lt y 63L then mask63 (Int64.shift_left x (Int64.to_int y)) else 0L
+
+let l_sr x y =
+  if le 0L y && lt y 63L then Int64.shift_right x (Int64.to_int y) else 0L
+
+let l_and x y = Int64.logand x y
+let l_or x y = Int64.logor x y
+let l_xor x y = Int64.logxor x y
+
+    (* addition of int63 *)
+let add x y = mask63 (Int64.add x y)
+
+    (* subtraction *)
+let sub x y = mask63 (Int64.sub x y)
+
+    (* multiplication *)
+let mul x y = mask63 (Int64.mul x y)
+
+    (* division *)
+let div x y =
+  if y = 0L then 0L else Int64.div x y
+
+    (* modulo *)
+let rem x y =
+  if y = 0L then 0L else Int64.rem x y
+
+let addmuldiv p x y =
+  l_or (l_sl x p) (l_sr y (Int64.sub (of_int uint_size) p))
+
+(* A few helper functions on 128 bits *)
+let lt128 xh xl yh yl =
+  lt xh yh || (xh = yh && lt xl yl)
+
+let le128 xh xl yh yl =
+  lt xh yh || (xh = yh && le xl yl)
+
+    (* division of two numbers by one *)
+let div21 xh xl y =
+  let maskh = ref zero in
+  let maskl = ref one in
+  let dh = ref zero in
+  let dl = ref y in
+  let cmp = ref true in
+  while le zero !dh && !cmp do
+    cmp := lt128 !dh !dl xh xl;
+    (* We don't use addmuldiv below to avoid checks on 1 *)
+    dh := l_or (l_sl !dh one) (l_sr !dl (of_int (uint_size - 1)));
+    dl := l_sl !dl one;
+    maskh := l_or (l_sl !maskh one) (l_sr !maskl (of_int (uint_size - 1)));
+    maskl := l_sl !maskl one
+  done; (* mask = 2^N, d = 2^N * d, d >= x *)
+  let remh = ref xh in
+  let reml = ref xl in
+  let quotient = ref zero in
+  while not (Int64.equal (l_or !maskh !maskl) zero) do
+    if le128 !dh !dl !remh !reml then begin (* if rem >= d, add one bit and subtract d *)
+      quotient := l_or !quotient !maskl;
+      remh := if lt !reml !dl then sub (sub !remh !dh) one else sub !remh !dh;
+      reml := sub !reml !dl
+    end;
+    maskl := l_or (l_sr !maskl one) (l_sl !maskh (of_int (uint_size - 1)));
+    maskh := l_sr !maskh one;
+    dl := l_or (l_sr !dl one) (l_sl !dh (of_int (uint_size - 1)));
+    dh := l_sr !dh one
+  done;
+  !quotient, !reml
+
+
+     (* exact multiplication *)
+let mulc x y =
+  let lx = ref (Int64.logand x maxuint31) in
+  let ly = ref (Int64.logand y maxuint31) in
+  let hx = Int64.shift_right x 31 in
+  let hy = Int64.shift_right y 31 in
+  let hr = ref (Int64.mul hx hy) in
+  let lr = ref (Int64.logor (Int64.mul !lx !ly) (Int64.shift_left !hr 62)) in
+  hr := (Int64.shift_right_logical !hr 1);
+  lx := Int64.mul !lx hy;
+  ly := Int64.mul hx !ly;
+  hr := Int64.logor !hr (Int64.add (Int64.shift_right !lx 32) (Int64.shift_right !ly 32));
+  lr := Int64.add !lr (Int64.shift_left !lx 31);
+  hr := Int64.add !hr (Int64.shift_right_logical !lr 63);
+  lr := Int64.add (Int64.shift_left !ly 31) (mask63 !lr);
+  hr := Int64.add !hr (Int64.shift_right_logical !lr 63);
+  if Int64.logand !lr Int64.min_int <> 0L
+  then (Int64.sub !hr 1L, mask63 !lr)
+  else (!hr, !lr)
+
+let equal x y = mask63 x = mask63 y
+
+let compare x y = Int64.compare x y
+
+(* Number of leading zeroes *)
+let head0 x =
+  let r = ref 0 in
+  let x = ref x in
+  if Int64.logand !x 0x7FFFFFFF00000000L = 0L then r := !r + 31
+  else x := Int64.shift_right !x 31;
+  if Int64.logand !x 0xFFFF0000L = 0L then (x := Int64.shift_left !x 16; r := !r + 16);
+  if Int64.logand !x 0xFF000000L = 0L then (x := Int64.shift_left !x 8; r := !r + 8);
+  if Int64.logand !x 0xF0000000L = 0L then (x := Int64.shift_left !x 4; r := !r + 4);
+  if Int64.logand !x 0xC0000000L = 0L then (x := Int64.shift_left !x 2; r := !r + 2);
+  if Int64.logand !x 0x80000000L = 0L then (x := Int64.shift_left !x 1; r := !r + 1);
+  if Int64.logand !x 0x80000000L = 0L then (               r := !r + 1);
+  Int64.of_int !r
+
+(* Number of trailing zeroes *)
+let tail0 x =
+  let r = ref 0 in
+  let x = ref x in
+  if Int64.logand !x 0xFFFFFFFFL = 0L then (x := Int64.shift_right !x 32; r := !r + 32);
+  if Int64.logand !x 0xFFFFL = 0L then (x := Int64.shift_right !x 16; r := !r + 16);
+  if Int64.logand !x 0xFFL = 0L   then (x := Int64.shift_right !x 8;  r := !r + 8);
+  if Int64.logand !x 0xFL = 0L    then (x := Int64.shift_right !x 4;  r := !r + 4);
+  if Int64.logand !x 0x3L = 0L    then (x := Int64.shift_right !x 2;  r := !r + 2);
+  if Int64.logand !x 0x1L = 0L    then (                r := !r + 1);
+  Int64.of_int !r

--- a/lib/uint63.mli
+++ b/lib/uint63.mli
@@ -1,0 +1,70 @@
+type t
+
+val uint_size : int
+
+val maxuint31 : t
+
+(* conversion to int *)
+val of_int : int -> t
+
+val to_int2 : t -> int * int
+
+(* msb, lsb *)
+val of_int64 : Int64.t -> t
+
+val hash : t -> int
+
+(* convertion to a string *)
+val to_string : t -> string
+
+val of_string : string -> t
+
+val compile : t -> string
+
+(* constants *)
+val zero : t
+
+val one : t
+
+(* logical operations *)
+val l_sl : t -> t -> t
+
+val l_sr : t -> t -> t
+
+val l_and : t -> t -> t
+
+val l_xor : t -> t -> t
+
+val l_or : t -> t -> t
+
+(* Arithmetic operations *)
+val add : t -> t -> t
+
+val sub : t -> t -> t
+
+val mul : t -> t -> t
+
+val div : t -> t -> t
+
+val rem : t -> t -> t
+
+(* Specific arithmetic operations *)
+val mulc : t -> t -> t * t
+
+val addmuldiv : t -> t -> t -> t
+
+val div21 : t -> t -> t -> t * t
+
+(* comparison *)
+val lt : t -> t -> bool
+
+val equal : t -> t -> bool
+
+val le : t -> t -> bool
+
+val compare : t -> t -> int
+
+(* head and tail *)
+val head0 : t -> t
+
+val tail0 : t -> t


### PR DESCRIPTION
Dear CompCert developers,

Coq will soon have primitive integers (i.e., 63-bits machine arithmetic as part of the logic); see https://github.com/coq/coq/pull/6914 for details. This subsumes and replaces the 31-bit integers facility.

CompCert — and more specifically its parser — is one of the rare users of these legacy 31-bit integers. The Coq backend of menhir has been updated (thanks to Jacques-Henri) to generate code that is compatible with both old and new versions of Coq.

Coq with primitive integers provides a few compatibility modules to emulate the old 31-bit integers. Unfortunately, the extraction of old and new 31-bit integers is slightly different. Therefore, to make CompCert compatible with present and future versions of Coq, this PR does the following changes :
    - the extraction declarations that are specific to the 31-bit machine integers are moved to a dedicated module `ExtractInt31`;
    - there are two implementations of this module: one as before, an other for emulated integers using 63-bit primitive integers;
    - at configure-time, one of these modules is selected, based on the version of Coq;
    - the OCaml library includes a module `Uint63`, derived from the one of Coq, that implements the primitive operations.
    

