### PR TITLE
Minor simplifications in two proofs.

### DIFF
--- a/backend/Unusedglobproof.v
+++ b/backend/Unusedglobproof.v
@@ -1373,9 +1373,9 @@ Proof.
   * apply Y with id; auto.
   * exists gd1; auto.
   * exists gd2; auto.
-  * eapply used_not_defined_2 in GD1; eauto. eapply used_not_defined_2 in GD2; eauto.
+  * eapply used_not_defined_2 in GD1; [ | eauto | congruence ].
+    eapply used_not_defined_2 in GD2; [ | eauto | congruence ].
     tauto.
-    congruence.
   }
   destruct E as [g LD].
   left. unfold prog_defs_names; simpl.

--- a/lib/Heaps.v
+++ b/lib/Heaps.v
@@ -432,7 +432,7 @@ Lemma lt_heap_In:
 Proof.
   induction h; simpl; intros.
   contradiction.
-  intuition. apply le_lt_trans with x0; auto. red. left. apply E.eq_sym; auto.
+  intuition. apply le_lt_trans with x0; auto. red. left. assumption.
 Qed.
 
 Lemma findMax_max:


### PR DESCRIPTION
Preparation for [Coq PR 9725](https://github.com/coq/coq/pull/9725) that may make `eauto` stronger.

Currently, the proof in `Unusedglobproof.v` relies on a *failure* of a call to `eauto`. This PR removes this call.