### PR TITLE
Define macros with CompCert's version number

### DIFF
--- a/driver/Frontend.ml
+++ b/driver/Frontend.ml
@@ -11,6 +11,7 @@
 (*                                                                     *)
 (* *********************************************************************)
 
+open Printf
 open Clflags
 open Commandline
 open Driveraux
@@ -35,7 +36,7 @@ let v_number =
 (* Predefined macros: version numbers, C11 features *)
 
 let predefined_macros =
-  Printf.([
+  let macros = [  
     "-D__COMPCERT__";
     sprintf "-D__COMPCERT_MAJOR__=%d" v_major;    
     sprintf "-D__COMPCERT_MINOR__=%d" v_minor;    
@@ -46,7 +47,10 @@ let predefined_macros =
     "-D__STDC_NO_COMPLEX__";
     "-D__STDC_NO_THREADS__";
     "-D__STDC_NO_VLA__"
-  ])
+  ] in
+  if Version.buildnr = ""
+  then macros
+  else sprintf "-D__COMPCERT_BUILDNR__=%s" Version.buildnr :: macros
 
 (* From C to preprocessed C *)
 

--- a/driver/Frontend.ml
+++ b/driver/Frontend.ml
@@ -17,15 +17,36 @@ open Driveraux
 
 (* Common frontend functions between clightgen and ccomp *)
 
+(* Split the version number into major.minor.patchlevel *)
+
+let re_version = Str.regexp {|\([0-9]+\)\.\([0-9]+\)\(\.\([0-9]+\)\)?|}
+
+let (v_major, v_minor, v_patchlevel) =
+  let get n =
+    try int_of_string (Str.matched_group n Version.version)
+    with Not_found -> 0 in
+  assert (Str.string_match re_version Version.version 0);
+  (get 1, get 2, get 4)
+
+let v_number =
+  assert (v_major < 100 && v_minor < 100 && v_patchlevel < 100);
+  10000 * v_major + 100 * v_minor + v_patchlevel
+
+(* Predefined macros: version numbers, C11 features *)
+
 let predefined_macros =
-  [
+  Printf.([
     "-D__COMPCERT__";
+    sprintf "-D__COMPCERT_MAJOR__=%d" v_major;    
+    sprintf "-D__COMPCERT_MINOR__=%d" v_minor;    
+    sprintf "-D__COMPCERT_PATCHLEVEL__=%d" v_patchlevel;    
+    sprintf "-D__COMPCERT_VERSION__=%d" v_number;    
     "-U__STDC_IEC_559_COMPLEX__";
     "-D__STDC_NO_ATOMICS__";
     "-D__STDC_NO_COMPLEX__";
     "-D__STDC_NO_THREADS__";
     "-D__STDC_NO_VLA__"
-  ]
+  ])
 
 (* From C to preprocessed C *)
 

--- a/driver/Frontend.ml
+++ b/driver/Frontend.ml
@@ -18,20 +18,18 @@ open Driveraux
 
 (* Common frontend functions between clightgen and ccomp *)
 
-(* Split the version number into major.minor.patchlevel *)
+(* Split the version number into major.minor *)
 
-let re_version = Str.regexp {|\([0-9]+\)\.\([0-9]+\)\(\.\([0-9]+\)\)?|}
+let re_version = Str.regexp {|\([0-9]+\)\.\([0-9]+\)|}
 
-let (v_major, v_minor, v_patchlevel) =
-  let get n =
-    try int_of_string (Str.matched_group n Version.version)
-    with Not_found -> 0 in
+let (v_major, v_minor) =
+  let get n = int_of_string (Str.matched_group n Version.version) in
   assert (Str.string_match re_version Version.version 0);
-  (get 1, get 2, get 4)
+  (get 1, get 2)
 
 let v_number =
-  assert (v_major < 100 && v_minor < 100 && v_patchlevel < 100);
-  10000 * v_major + 100 * v_minor + v_patchlevel
+  assert (v_minor < 100);
+  100 * v_major + v_minor
 
 (* Predefined macros: version numbers, C11 features *)
 
@@ -40,7 +38,6 @@ let predefined_macros =
     "-D__COMPCERT__";
     sprintf "-D__COMPCERT_MAJOR__=%d" v_major;    
     sprintf "-D__COMPCERT_MINOR__=%d" v_minor;    
-    sprintf "-D__COMPCERT_PATCHLEVEL__=%d" v_patchlevel;    
     sprintf "-D__COMPCERT_VERSION__=%d" v_number;    
     "-U__STDC_IEC_559_COMPLEX__";
     "-D__STDC_NO_ATOMICS__";


### PR DESCRIPTION
As suggested in #282, it can be useful to `#ifdef` code depending on specific versions of CompCert.

Assuming a version number of the form `MM.mm` ~~or `MM.mm.pp`~~, the following macros are predefined:

`__COMPCERT_MAJOR__=MM`       (the major version number)
`__COMPCERT_MINOR__=mm`       (the minor version number)
~~`__COMPCERT_PATCHLEVEL__=pp`  (the patchlevel, or 0 if none)~~
`__COMPCERT_VERSION__=MMmm` (two decimal digits each, e.g. 305 for version 3.5)

Having 3 macros for MAJOR, MINOR and PATCHLEVEL is what GCC and Clang do.  (Edit: but during the discussion we found PATCHLEVEL useless.)

Having the combined VERSION macro is convenient to write tests such as
```
#if __COMPCERT_VERSION__ >= 302
// use feature introduced in CompCert 3.2
#endif
```
