### PR TITLE
Use Z.log2 instead of the deprecated log_inf

### DIFF
--- a/lib/Coqlib.v
+++ b/lib/Coqlib.v
@@ -183,6 +183,12 @@ Hint Resolve Ple_refl Plt_Ple Ple_succ Plt_strict: coqlib.
 Ltac xomega := unfold Plt, Ple in *; zify; omega.
 Ltac xomegaContradiction := exfalso; xomega.
 
+Lemma Psize_Zlog2 (p: positive) :
+  Zpos (Pos.size p) = Z.succ (Z.log2 (Zpos p)).
+Proof.
+  destruct p; simpl; rewrite ?Pos.add_1_r; reflexivity.
+Qed.
+
 (** Peano recursion over positive numbers. *)
 
 Section POSITIVE_ITERATION.

--- a/lib/Floats.v
+++ b/lib/Floats.v
@@ -118,7 +118,7 @@ Proof.
   simpl. rewrite Z.ltb_lt in *.
   assert (H : forall x, Digits.digits2_pos x = Pos.size x).
   { induction x; simpl; auto; rewrite IHx; zify; omega. }
-  rewrite H, Psize_log_inf, <- Zlog2_log_inf in *. clear H.
+  rewrite H, Psize_Zlog2 in *; clear H.
   change (Z.pos (Pos.lor p 2251799813685248)) with (Z.lor (Z.pos p) 2251799813685248%Z).
   rewrite Z.log2_lor by (zify; omega).
   now apply Z.max_case.
@@ -921,7 +921,7 @@ Proof.
   simpl. rewrite Z.ltb_lt in *.
   assert (H : forall x, Digits.digits2_pos x = Pos.size x).
   { induction x; simpl; auto; rewrite IHx; zify; omega. }
-  rewrite H, Psize_log_inf, <- Zlog2_log_inf in *. clear H.
+  rewrite H, Psize_Zlog2 in *. clear H.
   change (Z.pos (Pos.lor p 4194304)) with (Z.lor (Z.pos p) 4194304%Z).
   rewrite Z.log2_lor by (zify; omega).
   now apply Z.max_case.


### PR DESCRIPTION
Function `log_inf` from the `Zlogarithm` module has been deprecated for a few years. It will be removed from the standard library (see https://github.com/coq/coq/pull/9811).