### PR TITLE
Branchless implementation of cmplu_gen, cmpl_gen and intuoffloat

### DIFF
--- a/backend/SplitLong.vp
+++ b/backend/SplitLong.vp
@@ -285,9 +285,10 @@ Definition cmpl_ne_zero (e: expr) :=
 
 Definition cmplu_gen (ch cl: comparison) (e1 e2: expr) :=
   splitlong2 e1 e2 (fun h1 l1 h2 l2 =>
-    Econdition (CEcond (Ccomp Ceq) (h1:::h2:::Enil))
-               (Eop (Ocmp (Ccompu cl)) (l1:::l2:::Enil))
-               (Eop (Ocmp (Ccompu ch)) (h1:::h2:::Enil))).
+    (Eop (Osel (Ccomp Ceq) Tint)
+              ((Eop (Ocmp (Ccompu cl)) (l1:::l2:::Enil)) :::
+               (Eop (Ocmp (Ccompu ch)) (h1:::h2:::Enil)) :::
+               (h1:::h2:::Enil)))).
 
 Definition cmplu (c: comparison) (e1 e2: expr) :=
   match c with
@@ -307,9 +308,10 @@ Definition cmplu (c: comparison) (e1 e2: expr) :=
 
 Definition cmpl_gen (ch cl: comparison) (e1 e2: expr) :=
   splitlong2 e1 e2 (fun h1 l1 h2 l2 =>
-    Econdition (CEcond (Ccomp Ceq) (h1:::h2:::Enil))
-               (Eop (Ocmp (Ccompu cl)) (l1:::l2:::Enil))
-               (Eop (Ocmp (Ccomp ch)) (h1:::h2:::Enil))).
+    (Eop (Osel (Ccomp Ceq) Tint)
+              ((Eop (Ocmp (Ccompu cl)) (l1:::l2:::Enil)) :::
+               (Eop (Ocmp (Ccomp ch)) (h1:::h2:::Enil)) :::
+               (h1:::h2:::Enil)))).
 
 Definition cmpl (c: comparison) (e1 e2: expr) :=
   match c with

--- a/backend/SplitLongproof.v
+++ b/backend/SplitLongproof.v
@@ -986,8 +986,10 @@ Lemma eval_cmplu_gen:
                   else Int.cmpu ch (Int64.hiword x) (Int64.hiword y))).
 Proof.
   intros. unfold cmplu_gen. eapply eval_splitlong2_strict; eauto. intros.
-  econstructor. econstructor. EvalOp. simpl. eauto.
-  destruct (Int.eq (Int64.hiword x) (Int64.hiword y)); EvalOp.
+  repeat econstructor; EvalOp; simpl.
+  destruct (Int.eq (Int64.hiword x) (Int64.hiword y)).
+  - destruct (Int.cmpu cl (Int64.loword x) (Int64.loword y)); EvalOp.
+  - destruct (Int.cmpu ch (Int64.hiword x) (Int64.hiword y)); EvalOp.
 Qed.
 
 Remark int64_eq_xor:
@@ -1045,8 +1047,10 @@ Lemma eval_cmpl_gen:
                   else Int.cmp ch (Int64.hiword x) (Int64.hiword y))).
 Proof.
   intros. unfold cmpl_gen. eapply eval_splitlong2_strict; eauto. intros.
-  econstructor. econstructor. EvalOp. simpl. eauto.
-  destruct (Int.eq (Int64.hiword x) (Int64.hiword y)); EvalOp.
+  repeat econstructor; EvalOp; simpl.
+  destruct (Int.eq (Int64.hiword x) (Int64.hiword y)).
+  - destruct (Int.cmpu cl (Int64.loword x) (Int64.loword y)); EvalOp.
+  - destruct (Int.cmp ch (Int64.hiword x) (Int64.hiword y)); EvalOp.
 Qed.
 
 Remark decompose_cmpl_lt_zero:

--- a/backend/ValueDomain.v
+++ b/backend/ValueDomain.v
@@ -2174,17 +2174,17 @@ Definition intoffloat (x: aval) :=
   | F f =>
       match Float.to_int f with
       | Some i => I i
-      | None => if va_strict tt then Vbot else ntop
+      | None => ntop
       end
   | _ => ntop1 x
   end.
 
 Lemma intoffloat_sound:
-  forall v x w, vmatch v x -> Val.intoffloat v = Some w -> vmatch w (intoffloat x).
+  forall v x w, vmatch v x -> Val.maketotal (Val.intoffloat v) = w -> vmatch w (intoffloat x).
 Proof.
-  unfold Val.intoffloat; intros. destruct v; try discriminate.
-  destruct (Float.to_int f) as [i|] eqn:E; simpl in H0; inv H0.
-  inv H; simpl; auto with va. rewrite E; constructor.
+  unfold Val.intoffloat; intros. 
+  inv H; try constructor; simpl;
+    destruct (Float.to_int f) as [i|] eqn:E; constructor.
 Qed.
 
 Definition intuoffloat (x: aval) :=

--- a/x86/Asmgenproof1.v
+++ b/x86/Asmgenproof1.v
@@ -1431,8 +1431,6 @@ Transparent destroyed_by_op.
   rewrite Pregmap.gss. rewrite <- EV; auto.
   intros; Simplifs.
   TranslOp. rewrite nextinstr_inv; auto with asmgen. rewrite Pregmap.gss; auto. rewrite <- EV; auto.
-(* intoffloat *)
-  apply SAME. TranslOp. rewrite H0; auto.
 (* floatofint *)
   apply SAME. TranslOp. rewrite H0; auto.
 (* intofsingle *)

--- a/x86/Op.v
+++ b/x86/Op.v
@@ -400,7 +400,7 @@ Definition eval_operation
   | Odivfs, v1::v2::nil => Some(Val.divfs v1 v2)
   | Osingleoffloat, v1::nil => Some(Val.singleoffloat v1)
   | Ofloatofsingle, v1::nil => Some(Val.floatofsingle v1)
-  | Ointoffloat, v1::nil => Val.intoffloat v1
+  | Ointoffloat, v1::nil => Some (Val.maketotal (Val.intoffloat v1))
   | Ofloatofint, v1::nil => Val.floatofint v1
   | Ointofsingle, v1::nil => Val.intofsingle v1
   | Osingleofint, v1::nil => Val.singleofint v1
@@ -730,7 +730,7 @@ Proof with (try exact I; try reflexivity).
   destruct v0; destruct v1...
   destruct v0...
   destruct v0...
-  destruct v0; simpl in H0; inv H0. destruct (Float.to_int f); inv H2...
+  destruct v0; simpl... destruct (Float.to_int f); simpl; auto.
   destruct v0; simpl in H0; inv H0...
   destruct v0; simpl in H0; inv H0. destruct (Float32.to_int f); inv H2...
   destruct v0; simpl in H0; inv H0...
@@ -1298,8 +1298,7 @@ Proof.
   inv H4; inv H2; simpl; auto.
   inv H4; simpl; auto.
   inv H4; simpl; auto.
-  inv H4; simpl in H1; inv H1. simpl. destruct (Float.to_int f0); simpl in H2; inv H2.
-  exists (Vint i); auto.
+  inv H4; simpl; auto. destruct (Float.to_int f0); simpl; auto.
   inv H4; simpl in H1; inv H1. simpl. TrivialExists.
   inv H4; simpl in H1; inv H1. simpl. destruct (Float32.to_int f0); simpl in H2; inv H2.
   exists (Vint i); auto.

--- a/x86/SelectOp.vp
+++ b/x86/SelectOp.vp
@@ -500,9 +500,11 @@ Nondetfunction floatofint (e: expr) :=
 Definition intuoffloat (e: expr) :=
   Elet e
     (Elet (Eop (Ofloatconst (Float.of_intu Float.ox8000_0000)) Enil)
-      (Econdition (CEcond (Ccompf Clt) (Eletvar 1 ::: Eletvar 0 ::: Enil))
-        (intoffloat (Eletvar 1))
-        (addimm Float.ox8000_0000 (intoffloat (subf (Eletvar 1) (Eletvar 0))))))%nat.
+      (Eop (Osel (Ccompf Clt) Tint)
+        ((intoffloat (Eletvar 1)) :::
+         (addimm Float.ox8000_0000 (intoffloat (subf (Eletvar 1) (Eletvar 0)))) :::
+         Eletvar 1 ::: Eletvar 0 ::: Enil)))%nat. 
+
 
 Nondetfunction floatofintu (e: expr) :=
   match e with


### PR DESCRIPTION
The new implementation of these functions, along with the new implementation of unsigned int32 to float conversion, should remove every introduction of branching during the selection pass.
Proving the correctness of `intuoffloat` required to change the semantics of `Ointoffloat` in x86/Op.v