### PR TITLE
Fix #304 Changes in configure broke Windows build

### DIFF
--- a/configure
+++ b/configure
@@ -560,7 +560,7 @@ case "$menhir_ver" in
   20[0-9][0-9][0-9][0-9][0-9][0-9])
       if test "$menhir_ver" -ge $MENHIR_REQUIRED; then
           echo "version $menhir_ver -- good!"
-          menhir_include_dir=`menhir --suggest-menhirLib`
+          menhir_include_dir=$(menhir --suggest-menhirLib | tr -d '\r' | tr '\\' '/')
           if test -z "$menhir_include_dir"; then
               echo "Error: cannot determine the location of the Menhir API library."
               echo "This can be due to an incorrect Menhir package."


### PR DESCRIPTION
This PR fixes issue #304, that is the build of CompCert on Windows (for inclusion of CompCert as optional addon in the Coq Windows Installer).