### PR TITLE
Do not rely on a failure of automatic proof search

### DIFF
--- a/lib/IntvSets.v
+++ b/lib/IntvSets.v
@@ -102,7 +102,7 @@ Proof.
   simpl. rewrite IHok. tauto.
   destruct (zlt h0 l).
   simpl. tauto.
-  rewrite IHok. intuition.
+  rewrite IHok. intuition idtac.
   assert (l0 <= x < h0 \/ l <= x < h) by xomega. tauto.
   left; xomega.
   left; xomega.


### PR DESCRIPTION
I would like to make “intuition” a bit stronger, in a way that would break this proof script.

See https://github.com/coq/coq/pull/11018 for details.