### PR TITLE
Makefile.menhir: specify menhirLib.cmxa instead of menhirLib.cmx.

### DIFF
--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -41,7 +41,7 @@ MENHIR_FLAGS = -v --no-stdlib -la 1
 # Using Menhir in --table mode requires MenhirLib.
 
 ifeq ($(MENHIR_TABLE),true)
-  MENHIR_LIBS = menhirLib.cmx
+  MENHIR_LIBS = menhirLib.cmxa
 else
   MENHIR_LIBS =
 endif


### PR DESCRIPTION
This should allow CompCert to compile with Menhir 20200123 and newer.