### PR TITLE
In Coq-MenhirLib: backport upstream changes.

### DIFF
--- a/MenhirLib/Alphabet.v
+++ b/MenhirLib/Alphabet.v
@@ -11,7 +11,8 @@
 (*                                                                          *)
 (****************************************************************************)
 
-From Coq Require Import Omega List Syntax Relations RelationClasses.
+From Coq Require Import Omega List Relations RelationClasses.
+Import ListNotations.
 
 Local Obligation Tactic := intros.
 

--- a/MenhirLib/Grammar.v
+++ b/MenhirLib/Grammar.v
@@ -11,7 +11,8 @@
 (*                                                                          *)
 (****************************************************************************)
 
-From Coq Require Import List Syntax Orders.
+From Coq Require Import List Orders.
+Import ListNotations.
 Require Import Alphabet.
 
 (** The terminal non-terminal alphabets of the grammar. **)

--- a/MenhirLib/Interpreter.v
+++ b/MenhirLib/Interpreter.v
@@ -12,6 +12,7 @@
 (****************************************************************************)
 
 From Coq Require Import List Syntax.
+Import ListNotations.
 From Coq.ssr Require Import ssreflect.
 Require Automaton.
 Require Import Alphabet Grammar Validator_safe.
@@ -82,6 +83,7 @@ Proof. by rewrite /cast -Eqdep_dec.eq_rect_eq_dec. Qed.
 CoInductive buffer : Type :=
   Buf_cons { buf_head : token; buf_tail : buffer }.
 
+Declare Scope buffer_scope.
 Delimit Scope buffer_scope with buf.
 Bind Scope buffer_scope with buffer.
 

--- a/MenhirLib/Interpreter_complete.v
+++ b/MenhirLib/Interpreter_complete.v
@@ -11,7 +11,8 @@
 (*                                                                          *)
 (****************************************************************************)
 
-From Coq Require Import List Syntax Arith.
+From Coq Require Import List Arith.
+Import ListNotations.
 From Coq.ssr Require Import ssreflect.
 Require Import Alphabet Grammar.
 Require Automaton Interpreter Validator_complete.

--- a/MenhirLib/Interpreter_correct.v
+++ b/MenhirLib/Interpreter_correct.v
@@ -11,7 +11,8 @@
 (*                                                                          *)
 (****************************************************************************)
 
-From Coq Require Import List Syntax.
+From Coq Require Import List.
+Import ListNotations.
 Require Import Alphabet.
 Require Grammar Automaton Interpreter.
 From Coq.ssr Require Import ssreflect.

--- a/MenhirLib/Validator_complete.v
+++ b/MenhirLib/Validator_complete.v
@@ -13,6 +13,7 @@
 
 From Coq Require Import List Syntax Derive.
 From Coq.ssr Require Import ssreflect.
+Import ListNotations.
 Require Automaton.
 Require Import Alphabet Validator_classes.
 

--- a/MenhirLib/Validator_safe.v
+++ b/MenhirLib/Validator_safe.v
@@ -12,6 +12,7 @@
 (****************************************************************************)
 
 From Coq Require Import List Syntax Derive.
+Import ListNotations.
 From Coq.ssr Require Import ssreflect.
 Require Automaton.
 Require Import Alphabet Validator_classes.


### PR DESCRIPTION
I.e., import ListNotations wherever it is necessary so that we do not rely on it being exported by Program.

This is the part of #352 which is specific to the MenhirLib directory. There are a few adaptations, but this should not cause incompatibilities with your PR, @llelf.