### PR TITLE
[Proposal] Tweak "perm_inv" in extends/inject

### DIFF
--- a/backend/Deadcodeproof.v
+++ b/backend/Deadcodeproof.v
@@ -41,9 +41,6 @@ Record magree (m1 m2: mem) (P: locset) : Prop := mk_magree {
   ma_perm:
     forall b ofs k p,
     Mem.perm m1 b ofs k p -> Mem.perm m2 b ofs k p;
-  ma_perm_inv:
-    forall b ofs k p,
-    Mem.perm m2 b ofs k p -> Mem.perm m1 b ofs k p \/ ~Mem.perm m1 b ofs Max Nonempty;
   ma_memval:
     forall b ofs,
     Mem.perm m1 b ofs Cur Readable ->
@@ -68,7 +65,6 @@ Lemma mextends_agree:
 Proof.
   intros. destruct H. destruct mext_inj. constructor; intros.
 - replace ofs with (ofs + 0) by omega. eapply mi_perm; eauto. auto.
-- eauto.
 - exploit mi_memval; eauto. unfold inject_id; eauto.
   rewrite Z.add_0_r. auto.
 - auto.
@@ -161,8 +157,6 @@ Proof.
   constructor; intros.
 - eapply Mem.perm_storebytes_1; eauto. eapply ma_perm; eauto.
   eapply Mem.perm_storebytes_2; eauto.
-- exploit ma_perm_inv; eauto using Mem.perm_storebytes_2.
-  intuition eauto using Mem.perm_storebytes_1, Mem.perm_storebytes_2.
 - rewrite (Mem.storebytes_mem_contents _ _ _ _ _ H0).
   rewrite (Mem.storebytes_mem_contents _ _ _ _ _ ST2).
   rewrite ! PMap.gsspec. destruct (peq b0 b).
@@ -206,8 +200,6 @@ Lemma magree_storebytes_left:
 Proof.
   intros. constructor; intros.
 - eapply ma_perm; eauto. eapply Mem.perm_storebytes_2; eauto.
-- exploit ma_perm_inv; eauto.
-  intuition eauto using Mem.perm_storebytes_1, Mem.perm_storebytes_2.
 - rewrite (Mem.storebytes_mem_contents _ _ _ _ _ H0).
   rewrite PMap.gsspec. destruct (peq b0 b).
 + subst b0. rewrite Mem.setN_outside. eapply ma_memval; eauto. eapply Mem.perm_storebytes_2; eauto.
@@ -249,11 +241,6 @@ Proof.
   assert (Mem.perm m2 b0 ofs k p). { eapply ma_perm; eauto. eapply Mem.perm_free_3; eauto. }
   exploit Mem.perm_free_inv; eauto. intros [[A B] | A]; auto.
   subst b0. eelim Mem.perm_free_2. eexact H0. eauto. eauto.
-- (* inverse permissions *)
-  exploit ma_perm_inv; eauto using Mem.perm_free_3. intros [A|A].
-  eapply Mem.perm_free_inv in A; eauto. destruct A as [[A B] | A]; auto.
-  subst b0; right; eapply Mem.perm_free_2; eauto.
-  right; intuition eauto using Mem.perm_free_3.
 - (* contents *)
   rewrite (Mem.free_result _ _ _ _ _ H0).
   rewrite (Mem.free_result _ _ _ _ _ FREE).

--- a/backend/Unusedglobproof.v
+++ b/backend/Unusedglobproof.v
@@ -1187,12 +1187,12 @@ Proof.
   exploit (Genv.init_mem_characterization_gen tp); eauto.
   destruct gd as [f|v].
 + intros (P2 & Q2) (P1 & Q1).
-  apply Q2 in H0. destruct H0. subst. replace ofs with 0 by omega.
-  left; apply Mem.perm_cur; auto.
+  apply Q1 in H0. destruct H0. subst. simpl.
+  apply Mem.perm_cur; auto.
 + intros (P2 & Q2 & R2 & S2) (P1 & Q1 & R1 & S1).
-  apply Q2 in H0. destruct H0. subst.
-  left. apply Mem.perm_cur. eapply Mem.perm_implies; eauto.
-  apply P1. omega.
+  apply Q1 in H0. destruct H0. subst. simpl.
+  apply Mem.perm_cur. eapply Mem.perm_implies; eauto.
+  apply P2. omega.
 Qed.
 
 End INIT_MEM.

--- a/backend/ValueDomain.v
+++ b/backend/ValueDomain.v
@@ -4443,7 +4443,7 @@ Proof.
   rewrite Z.add_0_r. split. omega. apply Ptrofs.unsigned_range_2.
 - (* perm inv *)
   intros. exploit inj_of_bc_inv; eauto. intros (A & B & C); subst.
-  rewrite Z.add_0_r in H2. auto.
+  rewrite Z.add_0_r. auto.
 Qed.
 
 Lemma inj_of_bc_preserves_globals:

--- a/common/Separation.v
+++ b/common/Separation.v
@@ -627,9 +627,7 @@ Next Obligation.
 - intros. eapply Mem.valid_block_unchanged_on; eauto.
 - assumption.
 - assumption.
-- intros. destruct (Mem.perm_dec m0 b1 ofs Max Nonempty); auto.
-  eapply mi_perm_inv; eauto.
-  eapply Mem.perm_unchanged_on_2; eauto.
+- intros. eapply Mem.perm_unchanged_on; eauto.
 Qed.
 Next Obligation.
   eapply Mem.valid_block_inject_2; eauto.


### PR DESCRIPTION
The rationale behind this PR is as follows.

- We can think of a memory operation (say, free_weak) that lowers "Cur" permission without changing "Max" permission. (As described in [here](https://hal.inria.fr/hal-00703441/document))
Then, it is desirable to have lemmas like `free_weak_left_extends` and `free_weak_left_inject`, just like `free_left_extends` and `free_left_inject`.
However, such lemmas do not hold currently because of `perm_inv` conditions.
This PR tweaks the conditions so that aforementioned lemmas hold.

- Also, this form looks more like forward-simulation style and (arguably) a little simpler.

This PR compiles with Coq 8.10.1.
It turns out that no single lemma/theorem's statement is changed, except for the unused ones (`perm_extends_inv`/`perm_inject_inv`).
Thanks for reading this!
