### PR TITLE
Support __builtin_constant_p 

### DIFF
--- a/cparser/Elab.ml
+++ b/cparser/Elab.ml
@@ -1809,6 +1809,16 @@ let elab_expr ctx loc env a =
           (print_typ env) ty (print_typ env) ty'  (print_typ env) ty'  (print_typ env) ty;
       { edesc = ECall(ident, [b2; b3]); etyp = ty },env
 
+  | CALL(VARIABLE "__builtin_constant_p", al) ->
+      begin match al with
+      | [a1] ->
+          let b1,env = elab env a1 in
+          let v = if Ceval.is_constant_expr env b1 then 1L else 0L in
+          intconst v IInt, env
+      | _ ->
+          fatal_error "'__builtin_constant_p' expects one argument"
+      end
+
   | CALL((VARIABLE "__builtin_sel" as a0), al) ->
       begin match al with
       | [a1; a2; a3] ->


### PR DESCRIPTION
 `__builtin_constant_p(EXP)` evaluates to 1 if the argument is a constant expression, 0 otherwise.

CompCert's notion of constant expression follows strictly ISO C 99, section 6.6.  There are some differences with GCC and Clang:
* The address of an object with static storage duration is a constant for ISO C 99 and for CompCert, but not for GCC nor Clang.  Example:
```
static int x;
__builtin_constant_p(&x);  // 1 with CompCert, 0 with GCC and Clang
```
* Variables of `const` scalar types are constants for GCC with optimization level > 0 and for Clang regardless of optimization.  They are not constant for CompCert.  Example:
```
const float pi = 3.14159;
__builtin_constant_p(pi / 4.0);  // 0 with CompCert, 1 with GCC (-O) and Clang
```
* Parameters of inline functions are not constants for CompCert but are constants for GCC and Clang with optimization level > 0 if the actual argument is a constant.  Example:
```
static inline int f(int x)
{
  return __builtin_constant_p(x + 2);
}
int main()
{
  return f(42); // 0 with CompCert, 1 with GCC -O and Clang -O
}
```
Hence, the implementation of `__builtin_constant_p` proposed in this PR is not an exact replacement for that of GCC or Clang, but I hope it is close enough to be useful.  It is also better specified (by reference to ISO C 99 section 6.6, not by reference to what the optimizer is doing).

Closes: #366
