### PR TITLE
Simplify two scripts in Zbits

### DIFF
--- a/lib/Zbits.v
+++ b/lib/Zbits.v
@@ -266,7 +266,7 @@ Qed.
 Remark Ztestbit_shiftin_base:
   forall b x, Z.testbit (Zshiftin b x) 0 = b.
 Proof.
-  intros. rewrite Ztestbit_shiftin. apply zeq_true. omega.
+  intros. rewrite Ztestbit_shiftin; reflexivity.
 Qed.
 
 Remark Ztestbit_shiftin_succ:
@@ -316,7 +316,7 @@ Qed.
 Remark Ztestbit_base:
   forall x, Z.testbit x 0 = Z.odd x.
 Proof.
-  intros. rewrite Ztestbit_eq. apply zeq_true. omega.
+  intros. rewrite Ztestbit_eq; reflexivity.
 Qed.
 
 Remark Ztestbit_succ:


### PR DESCRIPTION
Previous scripts where relying on the order in which `apply`'s HO
unification performs reductions, for a goal that could be solved by
`reflexivity`.

For more context, I discovered this while working with Matthieu on porting `apply` to the "evarconv" unification engine (https://github.com/coq/coq/pull/991).

The patch has been tested on Coq's master.