### PR TITLE
Add `-main` option to specify entrypoint function in interpreter mode

### DIFF
--- a/cfrontend/C2C.ml
+++ b/cfrontend/C2C.ml
@@ -1495,7 +1495,7 @@ let convertProgram p =
         let p' =
           { prog_defs = gl2;
             prog_public = public_globals gl2;
-            prog_main = intern_string "main";
+            prog_main = intern_string !Clflags.main_function_name;
             prog_types = typs;
             prog_comp_env = ce } in
         Diagnostics.check_errors ();

--- a/driver/Clflags.ml
+++ b/driver/Clflags.ml
@@ -67,3 +67,4 @@ let option_small_const = ref (!option_small_data)
 let option_timings = ref false
 let stdlib_path = ref Configuration.stdlib_path
 let use_standard_headers =  ref Configuration.has_standard_headers
+let main_function_name = ref "main"

--- a/driver/Driver.ml
+++ b/driver/Driver.ml
@@ -233,6 +233,7 @@ Code generation options: (use -fno-<opt> to turn off -f<opt>)
   -trace         Have the interpreter produce a detailed trace of reductions
   -random        Randomize execution order
   -all           Simulate all possible execution orders
+  -main <name>   Start executing at function <name> instead of main()
 |}
 
 let print_usage_and_exit () =
@@ -355,7 +356,8 @@ let cmdline_actions =
   Exact "-quiet", Unit (fun () -> Interp.trace := 0);
   Exact "-trace", Unit (fun () -> Interp.trace := 2);
   Exact "-random", Unit (fun () -> Interp.mode := Interp.Random);
-  Exact "-all", Unit (fun () -> Interp.mode := Interp.All)
+  Exact "-all", Unit (fun () -> Interp.mode := Interp.All);
+  Exact "-main", String (fun s -> main_function_name := s)
  ]
 (* Optimization options *)
 (* -f options: come in -f and -fno- variants *)


### PR DESCRIPTION
As suggested by a user.  When running unit tests with the CompCert reference interpreter, it's nice to be able to start execution at a given test function instead of having to write a `main` function.  

This PR adds a `-main` command-line option to give the name of the entry point function.  The default is still `main`.  Frama-C has a similar option.

The function specified with `-main` is called with no arguments.  If its return type is `int`, its return value is the exit status of the program.  Otherwise, its return value is ignored and the program exits with status 0.
