### PR TITLE
Revised handling of data sections

### DIFF
--- a/aarch64/TargetPrinter.ml
+++ b/aarch64/TargetPrinter.ml
@@ -226,7 +226,7 @@ module MacOS_System : SYSTEM =
       | Section_data i | Section_small_data i ->
           variable_section ~sec:".data" i
       | Section_const i  | Section_small_const i ->
-          variable_section ~sec:".section	__DATA,__CONST" i
+          variable_section ~sec:".const" ~reloc:".const_data" i
       | Section_string -> ".const"
       | Section_literal -> ".const"
       | Section_jumptable -> ".text"

--- a/aarch64/TargetPrinter.ml
+++ b/aarch64/TargetPrinter.ml
@@ -162,9 +162,9 @@ module ELF_System : SYSTEM =
     let name_of_section = function
       | Section_text         -> ".text"
       | Section_data i | Section_small_data i ->
-          if i then ".data" else common_section ()
+          variable_section ~sec:".data" ~bss:".bss" i
       | Section_const i | Section_small_const i ->
-          if i || (not !Clflags.option_fcommon) then ".section	.rodata" else "COMM"
+          variable_section ~sec:".section	.rodata" i
       | Section_string       -> ".section	.rodata"
       | Section_literal      -> ".section	.rodata"
       | Section_jumptable    -> ".section	.rodata"
@@ -224,9 +224,9 @@ module MacOS_System : SYSTEM =
     let name_of_section = function
       | Section_text -> ".text"
       | Section_data i | Section_small_data i ->
-          if i || (not !Clflags.option_fcommon) then ".data" else "COMM"
+          variable_section ~sec:".data" i
       | Section_const i  | Section_small_const i ->
-          if i || (not !Clflags.option_fcommon) then ".section	__DATA,__CONST" else "COMM"
+          variable_section ~sec:".section	__DATA,__CONST" i
       | Section_string -> ".const"
       | Section_literal -> ".const"
       | Section_jumptable -> ".text"

--- a/arm/TargetPrinter.ml
+++ b/arm/TargetPrinter.ml
@@ -148,9 +148,9 @@ struct
   let name_of_section = function
     | Section_text -> ".text"
     | Section_data i | Section_small_data i ->
-      if i then ".data" else common_section ()
+        variable_section ~sec:".data" ~bss:".bss" i
     | Section_const i | Section_small_const i ->
-      if i || (not !Clflags.option_fcommon) then ".section	.rodata" else "COMM"
+        variable_section ~sec:".section	.rodata" i
     | Section_string -> ".section	.rodata"
     | Section_literal -> ".text"
     | Section_jumptable -> ".text"

--- a/backend/JsonAST.ml
+++ b/backend/JsonAST.ml
@@ -21,14 +21,22 @@ open Sections
 let pp_storage pp static =
   pp_jstring pp (if static then "Static" else "Extern")
 
+let pp_init pp init =
+  pp_jstring pp
+    (match init with
+      | Uninit -> "Uninit"
+      | Init -> "Init"
+      | Init_reloc -> "Init_reloc")
+
 let pp_section pp sec =
   let pp_simple name =
     pp_jsingle_object pp "Section Name" pp_jstring name
   and pp_complex name init =
     pp_jobject_start pp;
     pp_jmember ~first:true pp "Section Name" pp_jstring name;
-    pp_jmember pp "Init" pp_jbool init;
+    pp_jmember pp "Init" pp_init init;
     pp_jobject_end pp in
+
   match sec with
   | Section_text -> pp_simple "Text"
   | Section_data init -> pp_complex "Data" init

--- a/backend/PrintAsm.ml
+++ b/backend/PrintAsm.ml
@@ -121,7 +121,7 @@ module Printer(Target:TARGET) =
           let sec =
             match C2C.atom_sections name with
             | [s] -> s
-            |  _  -> Section_data true
+            |  _  -> Section_data Init
           and align =
             match C2C.atom_alignof name with
             | Some a -> a

--- a/backend/PrintAsmaux.ml
+++ b/backend/PrintAsmaux.ml
@@ -303,11 +303,16 @@ let print_version_and_options oc comment =
     fprintf oc " %s" Commandline.argv.(i)
   done;
   fprintf oc "\n"
-(** Get the name of the common section if it is used otherwise the given section
-    name, with bss as default *)
 
-let common_section ?(sec = ".bss") () =
-  if !Clflags.option_fcommon then
-    "COMM"
-  else
-    sec
+(** Determine the name of the section to use for a variable.
+    [i] says whether the variable is initialized (true) or not (false).
+    [sec] is the name of the section to use if initialized or if
+    no other cases apply.
+    [bss] is the name of the section to use if uninitialized and
+    common declarations are not used.  If not provided, [sec] is used.
+*)
+
+let variable_section ~sec ?bss i =
+  if i then sec
+  else if !Clflags.option_fcommon then "COMM"
+  else match bss with None -> sec | Some b -> b

--- a/backend/PrintAsmaux.ml
+++ b/backend/PrintAsmaux.ml
@@ -312,12 +312,17 @@ let print_version_and_options oc comment =
     containing relocations.  If not provided, [sec] is used.
   - [bss] is the name of the section to use if uninitialized and
     common declarations are not used.  If not provided, [sec] is used.
+  - [common] says whether common declarations can be used for uninitialized
+    variables.  It defaults to the status of the [-fcommon] / [-fno-common]
+    command-line option.  Passing [~common:false] is needed when
+    common declarations cannot be used at all, for example in the context of
+    small data areas.
 *)
 
-let variable_section ~sec ?bss ?reloc i =
+let variable_section ~sec ?bss ?reloc ?(common = !Clflags.option_fcommon) i =
   match i with
   | Uninit ->
-      if !Clflags.option_fcommon
+      if common
       then "COMM"
       else begin match bss with Some s -> s | None -> sec end
   | Init -> sec

--- a/cfrontend/C2C.ml
+++ b/cfrontend/C2C.ml
@@ -1333,8 +1333,13 @@ let convertGlobvar loc env (sto, id, ty, optinit) =
         if sto = C.Storage_extern then [] else [AST.Init_space sz]
     | Some i ->
         convertInitializer env ty i in
+  let initialized =
+    if optinit = None then Sections.Uninit else
+    if List.exists (function AST.Init_addrof _ -> true | _ -> false) init'
+    then Sections.Init_reloc
+    else Sections.Init in
   let (section, access) =
-    Sections.for_variable env loc id' ty (optinit <> None) in
+    Sections.for_variable env loc id' ty initialized in
   if Z.gt sz (Z.of_uint64 0xFFFF_FFFFL) then
     error "'%s' is too big (%s bytes)"
                    id.name (Z.to_string sz);

--- a/common/Sections.mli
+++ b/common/Sections.mli
@@ -16,12 +16,17 @@
 
 (* Handling of linker sections *)
 
+type initialized =
+  | Uninit       (* uninitialized data area *)
+  | Init         (* initialized with fixed, non-relocatable data *)
+  | Init_reloc   (* initialized with relocatable data (symbol addresses) *)
+
 type section_name =
   | Section_text
-  | Section_data of bool          (* true = init data, false = uninit data *)
-  | Section_small_data of bool
-  | Section_const of bool
-  | Section_small_const of bool
+  | Section_data of initialized
+  | Section_small_data of initialized
+  | Section_const of initialized
+  | Section_small_const of initialized
   | Section_string
   | Section_literal
   | Section_jumptable
@@ -46,7 +51,7 @@ val define_section:
          -> ?writable:bool -> ?executable:bool -> ?access:access_mode -> unit -> unit
 val use_section_for: AST.ident -> string -> bool
 
-val for_variable: Env.t -> C.location -> AST.ident -> C.typ -> bool ->
+val for_variable: Env.t -> C.location -> AST.ident -> C.typ -> initialized ->
                                           section_name * access_mode
 val for_function: Env.t -> C.location -> AST.ident -> C.attributes -> section_name list
 val for_stringlit: unit -> section_name

--- a/powerpc/TargetPrinter.ml
+++ b/powerpc/TargetPrinter.ml
@@ -212,8 +212,10 @@ module Diab_System : SYSTEM =
 
     let name_of_section = function
       | Section_text -> ".text"
-      | Section_data i -> variable_section ~sec:".data" ~bss:".bss" i
-      | Section_small_data i -> variable_section ~sec:".sdata" ~bss:".sbss" i
+      | Section_data i ->
+          variable_section ~sec:".data" ~bss:".bss" i
+      | Section_small_data i ->
+          variable_section ~sec:".sdata" ~bss:".sbss" ~common:false i
       | Section_const _ -> ".text"
       | Section_small_const _ -> ".sdata2"
       | Section_string -> ".text"

--- a/powerpc/TargetPrinter.ml
+++ b/powerpc/TargetPrinter.ml
@@ -118,22 +118,16 @@ module Linux_System : SYSTEM =
     let name_of_section = function
       | Section_text -> ".text"
       | Section_data i ->
-          if i then
-            ".data"
-          else
-            common_section ~sec:".section	.bss" ()
+          variable_section ~sec:".data" ~bss:".section	.bss" i
       | Section_small_data i ->
-          if i then
-            ".section	.sdata,\"aw\",@progbits"
-          else
-            common_section ~sec:".section	.sbss,\"aw\",@nobits" ()
+          variable_section
+            ~sec:".section	.sdata,\"aw\",@progbits"
+            ~bss:".section	.sbss,\"aw\",@nobits"
+            i
       | Section_const i ->
-          if i || (not !Clflags.option_fcommon) then ".rodata" else "COMM"
+          variable_section ~sec:".rodata" i
       | Section_small_const i ->
-          if i || (not !Clflags.option_fcommon) then
-            ".section	.sdata2,\"a\",@progbits"
-          else
-            "COMM"
+          variable_section ~sec:".section	.sdata2,\"a\",@progbits" i
       | Section_string -> ".rodata"
       | Section_literal -> ".section	.rodata.cst8,\"aM\",@progbits,8"
       | Section_jumptable -> ".text"
@@ -218,7 +212,7 @@ module Diab_System : SYSTEM =
 
     let name_of_section = function
       | Section_text -> ".text"
-      | Section_data i -> if i then ".data" else common_section ()
+      | Section_data i -> variable_section ~sec:".data" ~bss:".bss" i
       | Section_small_data i -> if i then ".sdata" else ".sbss"
       | Section_const _ -> ".text"
       | Section_small_const _ -> ".sdata2"

--- a/powerpc/TargetPrinter.ml
+++ b/powerpc/TargetPrinter.ml
@@ -213,7 +213,7 @@ module Diab_System : SYSTEM =
     let name_of_section = function
       | Section_text -> ".text"
       | Section_data i -> variable_section ~sec:".data" ~bss:".bss" i
-      | Section_small_data i -> if i then ".sdata" else ".sbss"
+      | Section_small_data i -> variable_section ~sec:".sdata" ~bss:".sbss" i
       | Section_const _ -> ".text"
       | Section_small_const _ -> ".sdata2"
       | Section_string -> ".text"

--- a/riscV/TargetPrinter.ml
+++ b/riscV/TargetPrinter.ml
@@ -108,9 +108,9 @@ module Target : TARGET =
     let name_of_section = function
       | Section_text         -> ".text"
       | Section_data i | Section_small_data i ->
-          if i then ".data" else common_section ()
+          variable_section ~sec:".data" ~bss:".bss" i
       | Section_const i | Section_small_const i ->
-          if i || (not !Clflags.option_fcommon) then ".section	.rodata" else "COMM"
+          variable_section ~sec:".section	.rodata" i
       | Section_string       -> ".section	.rodata"
       | Section_literal      -> ".section	.rodata"
       | Section_jumptable    -> ".section	.rodata"

--- a/x86/TargetPrinter.ml
+++ b/x86/TargetPrinter.ml
@@ -194,9 +194,9 @@ module MacOS_System : SYSTEM =
       | Section_data i | Section_small_data i ->
           variable_section ~sec:".data" i
       | Section_const i  | Section_small_const i ->
-          variable_section ~sec:".const" i
+          variable_section ~sec:".const" ~reloc:".const_data" i
       | Section_string -> ".const"
-      | Section_literal -> ".literal8"
+      | Section_literal -> ".const"
       | Section_jumptable -> ".text"
       | Section_user(s, wr, ex) ->
           sprintf ".section	\"%s\", %s, %s"
@@ -914,8 +914,7 @@ module Target(System: SYSTEM):TARGET =
 
     let print_epilogue oc =
       if !need_masks then begin
-        section oc (Section_const true);
-        (* not Section_literal because not 8-bytes *)
+        section oc Section_literal;
         print_align oc 16;
         fprintf oc "%a:	.quad   0x8000000000000000, 0\n"
           raw_symbol "__negd_mask";

--- a/x86/TargetPrinter.ml
+++ b/x86/TargetPrinter.ml
@@ -134,9 +134,9 @@ module ELF_System : SYSTEM =
     let name_of_section = function
       | Section_text -> ".text"
       | Section_data i | Section_small_data i ->
-          if i then ".data" else common_section ()
+          variable_section ~sec:".data" ~bss:".bss" i
       | Section_const i | Section_small_const i ->
-          if i || (not !Clflags.option_fcommon) then ".section	.rodata" else "COMM"
+          variable_section ~sec:".section	.rodata" i
       | Section_string -> ".section	.rodata"
       | Section_literal -> ".section	.rodata.cst8,\"aM\",@progbits,8"
       | Section_jumptable -> ".text"
@@ -192,9 +192,9 @@ module MacOS_System : SYSTEM =
     let name_of_section = function
       | Section_text -> ".text"
       | Section_data i | Section_small_data i ->
-          if i || (not !Clflags.option_fcommon) then ".data" else "COMM"
+          variable_section ~sec:".data" i
       | Section_const i  | Section_small_const i ->
-          if i || (not !Clflags.option_fcommon) then ".const" else "COMM"
+          variable_section ~sec:".const" i
       | Section_string -> ".const"
       | Section_literal -> ".literal8"
       | Section_jumptable -> ".text"
@@ -254,9 +254,9 @@ module Cygwin_System : SYSTEM =
     let name_of_section = function
       | Section_text -> ".text"
       | Section_data i | Section_small_data i ->
-          if i then ".data" else common_section ()
+          variable_section ~sec:".data" ~bss:".bss" i
       | Section_const i | Section_small_const i ->
-          if i || (not !Clflags.option_fcommon) then ".section	.rdata,\"dr\"" else "COMM"
+          variable_section ~sec:".section	.rdata,\"dr\"" i
       | Section_string -> ".section	.rdata,\"dr\""
       | Section_literal -> ".section	.rdata,\"dr\""
       | Section_jumptable -> ".text"


### PR DESCRIPTION
To determine the linker section where to put a global variable, CompCert used to distinguish whether the variable is initialized or not.  Uninitialized variables typically go i the `.bss` or the special `COMM` section, while initialized variables typically go in `.data` or `.const`. depending on whether they are declared `const`.

When producing PIE or PIC code (like CompCert does on macOS today), a problematic situation arises: a `const` variable initialized with the address of a variable or function, e.g.
```
  extern char x, y;
  char * const tbl[] = { &x, &y };
```
Even though `tbl` is declared `const`, it should not go in a read-only section like `.const`, because its initial contents need relocation at program start-up.

This PR addresses this issue via a finer classification of global variables:
- uninitialized variables, which can go in COMM if supported;
- variables initialized with fixed, numeric quantities, which can go in a readonly section if `const`;
- variables initialized with symbol addresses which may need relocation and can go in a special "const_data" read-write section.

The selection of the appropriate section for a variable is done mainly in the auxiliary function `PrintAsmaux.variable_section`, generalizing and subsuming the previous `PrintAsmaux.common_section`.

Currently, only macOS (x86_64 and AArch64) uses a "const_data" section for the problematic case.  Other ports produce non-relocatable code, so the problematic case requires no relocation, and all initialized `const` global variables still go in read-only sections.

On a related note: on macOS, this PR uses `.const` instead of `.literal8` for literals, as not all literals have size 8.
