### PR TITLE
Synchronize with vendored MenhirLib

### DIFF
--- a/MenhirLib/Alphabet.v
+++ b/MenhirLib/Alphabet.v
@@ -37,7 +37,7 @@ Qed.
 Definition comparableLt {A:Type} (C: Comparable A) : relation A :=
   fun x y => compare x y = Lt.
 
-Instance ComparableLtStrictOrder {A:Type} (C: Comparable A) :
+Global Instance ComparableLtStrictOrder {A:Type} (C: Comparable A) :
   StrictOrder (comparableLt C).
 Proof.
 apply Build_StrictOrder.
@@ -53,7 +53,7 @@ apply compare_trans.
 Qed.
 
 (** nat is comparable. **)
-Program Instance natComparable : Comparable nat :=
+Global Program Instance natComparable : Comparable nat :=
   { compare := Nat.compare }.
 Next Obligation.
 symmetry.
@@ -79,7 +79,7 @@ apply (gt_trans _ _ _ H H0).
 Qed.
 
 (** A pair of comparable is comparable. **)
-Program Instance PairComparable {A:Type} (CA:Comparable A) {B:Type} (CB:Comparable B) :
+Global Program Instance PairComparable {A:Type} (CA:Comparable A) {B:Type} (CB:Comparable B) :
   Comparable (A*B) :=
   { compare := fun x y =>
       let (xa, xb) := x in let (ya, yb) := y in
@@ -134,10 +134,10 @@ destruct H.
 rewrite compare_refl; intuition.
 Qed.
 
-Instance NComparableLeibnizEq : ComparableLeibnizEq natComparable := Nat.compare_eq.
+Global Instance NComparableLeibnizEq : ComparableLeibnizEq natComparable := Nat.compare_eq.
 
 (** A pair of ComparableLeibnizEq is ComparableLeibnizEq **)
-Instance PairComparableLeibnizEq
+Global Instance PairComparableLeibnizEq
   {A:Type} {CA:Comparable A} (UA:ComparableLeibnizEq CA)
   {B:Type} {CB:Comparable B} (UB:ComparableLeibnizEq CB) :
     ComparableLeibnizEq (PairComparable CA CB).
@@ -174,7 +174,7 @@ Class Numbered (A:Type) := {
   inj_bound_spec : forall x, (inj x < Pos.succ inj_bound)%positive
 }.
 
-Program Instance NumberedAlphabet {A:Type} (N:Numbered A) : Alphabet A :=
+Global Program Instance NumberedAlphabet {A:Type} (N:Numbered A) : Alphabet A :=
   { AlphabetComparable := {| compare := fun x y => Pos.compare (inj x) (inj y) |};
     AlphabetFinite :=
       {| all_list := fst (Pos.iter
@@ -224,7 +224,7 @@ Import OrderedType.
 
 Module Type ComparableM.
   Parameter t : Type.
-  Declare Instance tComparable : Comparable t.
+  Global Declare Instance tComparable : Comparable t.
 End ComparableM.
 
 Module OrderedTypeAlt_from_ComparableM (C:ComparableM) <: OrderedTypeAlt.

--- a/MenhirLib/Automaton.v
+++ b/MenhirLib/Automaton.v
@@ -23,10 +23,10 @@ Module Type AutInit.
 
   (** The set of non initial state is considered as an alphabet. **)
   Parameter noninitstate : Type.
-  Declare Instance NonInitStateAlph : Alphabet noninitstate.
+  Global Declare Instance NonInitStateAlph : Alphabet noninitstate.
 
   Parameter initstate : Type.
-  Declare Instance InitStateAlph : Alphabet initstate.
+  Global Declare Instance InitStateAlph : Alphabet initstate.
 
   (** When we are at this state, we know that this symbol is the top of the
      stack. **)
@@ -41,7 +41,7 @@ Module Types(Import Init:AutInit).
     | Init: initstate -> state
     | Ninit: noninitstate -> state.
 
-  Program Instance StateAlph : Alphabet state :=
+  Global Program Instance StateAlph : Alphabet state :=
     { AlphabetComparable := {| compare := fun x y =>
         match x, y return comparison with
           | Init _, Ninit _ => Lt

--- a/MenhirLib/Grammar.v
+++ b/MenhirLib/Grammar.v
@@ -18,8 +18,8 @@ Require Import Alphabet.
 (** The terminal non-terminal alphabets of the grammar. **)
 Module Type Alphs.
   Parameters terminal nonterminal : Type.
-  Declare Instance TerminalAlph: Alphabet terminal.
-  Declare Instance NonTerminalAlph: Alphabet nonterminal.
+  Global Declare Instance TerminalAlph: Alphabet terminal.
+  Global Declare Instance NonTerminalAlph: Alphabet nonterminal.
 End Alphs.
 
 (** Definition of the alphabet of symbols, given the alphabet of terminals
@@ -30,7 +30,7 @@ Module Symbol(Import A:Alphs).
     | T: terminal -> symbol
     | NT: nonterminal -> symbol.
 
-  Program Instance SymbolAlph : Alphabet symbol :=
+  Global Program Instance SymbolAlph : Alphabet symbol :=
     { AlphabetComparable := {| compare := fun x y =>
         match x, y return comparison with
           | T _, NT _ => Gt
@@ -74,7 +74,7 @@ Module Type T.
 
   (** The type of productions identifiers **)
   Parameter production : Type.
-  Declare Instance ProductionAlph : Alphabet production.
+  Global Declare Instance ProductionAlph : Alphabet production.
 
   (** Accessors for productions: left hand side, right hand side,
      and semantic action. The semantic actions are given in the form

--- a/MenhirLib/Validator_classes.v
+++ b/MenhirLib/Validator_classes.v
@@ -19,26 +19,26 @@ Class IsValidator (P : Prop) (b : bool) :=
   is_validator : b = true -> P.
 Global Hint Mode IsValidator + - : typeclass_instances.
 
-Instance is_validator_true : IsValidator True true.
+Global Instance is_validator_true : IsValidator True true.
 Proof. done. Qed.
 
-Instance is_validator_false : IsValidator False false.
+Global Instance is_validator_false : IsValidator False false.
 Proof. done. Qed.
 
-Instance is_validator_eq_true b :
+Global Instance is_validator_eq_true b :
   IsValidator (b = true) b.
 Proof. done. Qed.
 
-Instance is_validator_and P1 b1 P2 b2 `{IsValidator P1 b1} `{IsValidator P2 b2}:
+Global Instance is_validator_and P1 b1 P2 b2 `{IsValidator P1 b1} `{IsValidator P2 b2}:
   IsValidator (P1 /\ P2) (if b1 then b2 else false).
 Proof. by split; destruct b1, b2; apply is_validator. Qed.
 
-Instance is_validator_comparable_leibniz_eq A (C:Comparable A) (x y : A) :
+Global Instance is_validator_comparable_leibniz_eq A (C:Comparable A) (x y : A) :
   ComparableLeibnizEq C ->
   IsValidator (x = y) (compare_eqb x y).
 Proof. intros ??. by apply compare_eqb_iff. Qed.
 
-Instance is_validator_comparable_eq_impl A `(Comparable A) (x y : A) P b :
+Global Instance is_validator_comparable_eq_impl A `(Comparable A) (x y : A) P b :
   IsValidator P b ->
   IsValidator (x = y -> P) (if compare_eqb x y then b else true).
 Proof.

--- a/MenhirLib/Validator_complete.v
+++ b/MenhirLib/Validator_complete.v
@@ -22,12 +22,12 @@ Module Make(Import A:Automaton.T).
 (** We instantiate some sets/map. **)
 Module TerminalComparableM <: ComparableM.
   Definition t := terminal.
-  Instance tComparable : Comparable t := _.
+  Global Instance tComparable : Comparable t := _.
 End TerminalComparableM.
 Module TerminalOrderedType := OrderedType_from_ComparableM TerminalComparableM.
 Module StateProdPosComparableM <: ComparableM.
   Definition t := (state*production*nat)%type.
-  Instance tComparable : Comparable t := _.
+  Global Instance tComparable : Comparable t := _.
 End StateProdPosComparableM.
 Module StateProdPosOrderedType :=
   OrderedType_from_ComparableM StateProdPosComparableM.
@@ -117,7 +117,7 @@ Definition forallb_items items_map (P:state -> production -> nat -> TerminalSet.
 
 (** Typeclass instances for synthetizing the validator. *)
 
-Instance is_validator_subset S1 S2 :
+Global Instance is_validator_subset S1 S2 :
   IsValidator (TerminalSet.Subset S1 S2) (TerminalSet.subset S1 S2).
 Proof. intros ?. by apply TerminalSet.subset_2. Qed.
 
@@ -150,7 +150,7 @@ Global Hint Extern 2 (IsValidator (state_has_future _ _ _ _) _) =>
   validator.
 
   This instance is used for [non_terminal_closed]. *)
-Instance is_validator_forall_lookahead_set lset P b:
+Global Instance is_validator_forall_lookahead_set lset P b:
   (forall lookahead, TerminalSet.In lookahead lset -> IsValidator (P lookahead) b) ->
   IsValidator (forall lookahead, TerminalSet.In lookahead lset -> P lookahead) b.
 Proof. unfold IsValidator. firstorder. Qed.
@@ -237,7 +237,7 @@ Proof.
     eapply Hval2 with (pos := pos); eauto; [].
     revert EQ. unfold future_of_prod=>-> //.
 Qed.
-(* We need a hint for expplicitely instantiating b1 and b2 with lambdas. *)
+(* We need a hint to explicitly instantiate b1 and b2 with lambdas. *)
 Global Hint Extern 0 (IsValidator
                  (forall st prod fut lookahead,
                      state_has_future st prod fut lookahead -> _)
@@ -247,7 +247,7 @@ Global Hint Extern 0 (IsValidator
   : typeclass_instances.
 
 (* Used in [start_future] only. *)
-Instance is_validator_forall_state_has_future im st prod :
+Global Instance is_validator_forall_state_has_future im st prod :
   IsItemsMap im ->
   IsValidator
     (forall look, state_has_future st prod (rev' (prod_rhs_rev prod)) look)

--- a/MenhirLib/Validator_safe.v
+++ b/MenhirLib/Validator_safe.v
@@ -62,7 +62,7 @@ Fixpoint is_prefix (l1 l2:list symbol) :=
   | _::_, [] => false
   end.
 
-Instance prefix_is_validator l1 l2 : IsValidator (prefix l1 l2) (is_prefix l1 l2).
+Global Instance prefix_is_validator l1 l2 : IsValidator (prefix l1 l2) (is_prefix l1 l2).
 Proof.
   revert l2. induction l1 as [|x1 l1 IH]=>l2 Hpref.
   - constructor.
@@ -127,7 +127,7 @@ Fixpoint is_prefix_pred (l1 l2:list (state->bool)) :=
   | _::_, [] => false
   end.
 
-Instance prefix_pred_is_validator l1 l2 :
+Global Instance prefix_pred_is_validator l1 l2 :
   IsValidator (prefix_pred l1 l2) (is_prefix_pred l1 l2).
 Proof.
   revert l2. induction l1 as [|x1 l1 IH]=>l2 Hpref.
@@ -180,7 +180,7 @@ Fixpoint is_state_valid_after_pop (state:state) (to_pop:list symbol) annot :=
   | p::pl, s::sl => is_state_valid_after_pop state sl pl
   end.
 
-Instance impl_is_state_valid_after_pop_is_validator state sl pl P b :
+Global Instance impl_is_state_valid_after_pop_is_validator state sl pl P b :
   IsValidator P b ->
   IsValidator (state_valid_after_pop state sl pl -> P)
               (if is_state_valid_after_pop state sl pl then b else true).


### PR DESCRIPTION
A diff between Compcert's vendored coq-menhirlib and upstream revealed some differences. Most of them correspond to what is covered in #415, but there are also a few other changes.

This should not break compatibility with the versions of Menhir which are already compatible (i.e., from 20190626).