### PR TITLE
Adapt to coq/coq#13837 ("apply with" does not rename arguments)

### DIFF
--- a/cfrontend/Ctyping.v
+++ b/cfrontend/Ctyping.v
@@ -2120,12 +2120,12 @@ Lemma wt_find_label:
   wt_stmt ge e f.(fn_return) s' /\ wt_stmt_cont e f k'.
 Proof.
   intros lbl e f s0 WTS0. pattern s0.
-  apply (wt_stmt_ind2 ge e f.(fn_return)) with
-    (P0 := fun ls => wt_lblstmts ge e f.(fn_return) ls ->
+  apply (wt_stmt_ind2 ge e f.(fn_return) _
+    (fun ls => wt_lblstmts ge e f.(fn_return) ls ->
            forall k s' k',
            find_label_ls lbl ls k = Some (s', k') ->
            wt_stmt_cont e f k ->
-           wt_stmt ge e f.(fn_return) s' /\ wt_stmt_cont e f k');
+           wt_stmt ge e f.(fn_return) s' /\ wt_stmt_cont e f k'));
   simpl; intros; try discriminate.
   + destruct (find_label lbl s1 (Kseq s2 k)) as [[sx kx] | ] eqn:F.
     inv H3. eauto with ty.

--- a/common/Smallstep.v
+++ b/common/Smallstep.v
@@ -960,7 +960,7 @@ Qed.
 
 Lemma forward_simulation_determ: forward_simulation L1 L2.
 Proof.
-  apply Forward_simulation with (order0 := lex_ord order lt) (match_states0 := match_states_later);
+  apply @Forward_simulation with (order := lex_ord order lt) (match_states := match_states_later);
   constructor.
 - apply wf_lex_ord. apply wf_order. apply lt_wf.
 - intros. exploit match_initial_states; eauto. intros (i & s2 & A & B).


### PR DESCRIPTION
Should be backwards compatible.