### PR TITLE
An improved PTree data structure

### DIFF
--- a/backend/CSEdomain.v
+++ b/backend/CSEdomain.v
@@ -140,7 +140,7 @@ Proof.
 - split; simpl; intros.
   + contradiction.
   + rewrite PTree.gempty in H; discriminate.
-  + rewrite PMap.gi in H; contradiction.
+  + contradiction.
 - contradiction.
 - rewrite PTree.gempty in H; discriminate.
 Qed.

--- a/backend/ValueDomain.v
+++ b/backend/ValueDomain.v
@@ -3438,7 +3438,7 @@ Lemma ablock_init_sound:
   forall m b p, smatch m b p -> bmatch m b (ablock_init p).
 Proof.
   intros; split; auto; intros.
-  unfold ablock_load, ablock_init; simpl. rewrite ZTree.gempty.
+  unfold ablock_load, ablock_init; simpl.
   eapply vnormalize_cast; eauto. eapply H; eauto.
 Qed.
 
@@ -4558,7 +4558,7 @@ Lemma ematch_init:
   ematch (init_regs vl rl) (einit_regs rl).
 Proof.
   induction rl; simpl; intros.
-- red; intros. rewrite Regmap.gi. simpl AE.get. rewrite PTree.gempty.
+- red; intros. rewrite Regmap.gi. simpl.
   constructor.
 - destruct vl as [ | v1 vs ].
   + assert (ematch (init_regs nil rl) (einit_regs rl)).

--- a/cfrontend/Cminorgenproof.v
+++ b/cfrontend/Cminorgenproof.v
@@ -875,7 +875,6 @@ Proof.
   intros. apply Mem.perm_implies with Freeable; auto with mem. eapply Mem.perm_alloc_2; eauto.
   instantiate (1 := f1). red; intros. eelim Mem.fresh_block_alloc; eauto.
   eapply Mem.valid_block_inject_2; eauto.
-  intros. apply PTree.gempty.
   eapply match_callstack_alloc_right; eauto.
   intros. destruct (In_dec peq id (map fst vars)).
   apply cenv_remove_gss; auto.

--- a/cfrontend/SimplExprproof.v
+++ b/cfrontend/SimplExprproof.v
@@ -893,13 +893,9 @@ Qed.
 Lemma static_bool_val_sound:
   forall v t m b, bool_val v t Mem.empty = Some b -> bool_val v t m = Some b.
 Proof.
-  assert (A: forall b ofs, Mem.weak_valid_pointer Mem.empty b ofs = false).
-  { unfold Mem.weak_valid_pointer, Mem.valid_pointer, proj_sumbool; intros.
-    rewrite ! pred_dec_false by (apply Mem.perm_empty). auto. }  
   intros until b; unfold bool_val.
-  destruct (classify_bool t); destruct v; destruct Archi.ptr64 eqn:SF; auto.
-- rewrite A; congruence.
-- simpl; rewrite A; congruence.
+  destruct (classify_bool t); destruct v; destruct Archi.ptr64 eqn:SF; auto;
+  simpl; congruence.
 Qed.
 
 Lemma step_makeif:

--- a/cfrontend/SimplLocalsproof.v
+++ b/cfrontend/SimplLocalsproof.v
@@ -935,7 +935,6 @@ Proof.
   (* local var, lifted *)
   destruct R as [U V]. exploit H2; eauto. intros [chunk X].
   eapply match_var_lifted with (v := Vundef) (tv := Vundef); eauto.
-  rewrite U; apply PTree.gempty.
   eapply alloc_variables_initial_value; eauto.
   red. unfold empty_env; intros. rewrite PTree.gempty in H4; congruence.
   apply create_undef_temps_charact with ty.

--- a/common/Globalenvs.v
+++ b/common/Globalenvs.v
@@ -265,15 +265,6 @@ Qed.
 
 Program Definition empty_genv (pub: list ident): t :=
   @mkgenv pub (PTree.empty _) (PTree.empty _) 1%positive _ _ _.
-Next Obligation.
-  rewrite PTree.gempty in H. discriminate.
-Qed.
-Next Obligation.
-  rewrite PTree.gempty in H. discriminate.
-Qed.
-Next Obligation.
-  rewrite PTree.gempty in H. discriminate.
-Qed.
 
 Definition globalenv (p: program F V) :=
   add_globals (empty_genv p.(prog_public)) p.(prog_defs).

--- a/common/Memory.v
+++ b/common/Memory.v
@@ -346,15 +346,6 @@ Program Definition empty: mem :=
   mkmem (PMap.init (ZMap.init Undef))
         (PMap.init (fun ofs k => None))
         1%positive _ _ _.
-Next Obligation.
-  repeat rewrite PMap.gi. red; auto.
-Qed.
-Next Obligation.
-  rewrite PMap.gi. auto.
-Qed.
-Next Obligation.
-  rewrite PMap.gi. auto.
-Qed.
 
 (** Allocation of a fresh block with the given bounds.  Return an updated
   memory state and the address of the fresh block, which initially contains
@@ -631,7 +622,7 @@ Proof. reflexivity. Qed.
 
 Theorem perm_empty: forall b ofs k p, ~perm empty b ofs k p.
 Proof.
-  intros. unfold perm, empty; simpl. rewrite PMap.gi. simpl. tauto.
+  intros. unfold perm, empty; simpl. tauto.
 Qed.
 
 Theorem valid_access_empty: forall chunk b ofs p, ~valid_access empty chunk b ofs p.

--- a/lib/Lattice.v
+++ b/lib/Lattice.v
@@ -3,6 +3,7 @@
 (*              The Compcert verified compiler                         *)
 (*                                                                     *)
 (*          Xavier Leroy, INRIA Paris-Rocquencourt                     *)
+(*          Andrew W. Appel, Princeton University                      *)
 (*                                                                     *)
 (*  Copyright Institut National de Recherche en Informatique et en     *)
 (*  Automatique.  All rights reserved.  This file is distributed       *)
@@ -140,7 +141,7 @@ Definition bot : t := PTree.empty _.
 
 Lemma get_bot: forall p, get p bot = L.bot.
 Proof.
-  unfold bot, get; intros; simpl. rewrite PTree.gempty. auto.
+  intros; reflexivity.
 Qed.
 
 Lemma ge_bot: forall x, ge x bot.
@@ -148,13 +149,7 @@ Proof.
   unfold ge; intros. rewrite get_bot. apply L.ge_bot.
 Qed.
 
-(** A [combine] operation over the type [PTree.t L.t] that attempts
-  to share its result with its arguments. *)
-
-Section COMBINE.
-
-Variable f: option L.t -> option L.t -> option L.t.
-Hypothesis f_none_none: f None None = None.
+(** Equivalence modulo L.eq *)
 
 Definition opt_eq (ox oy: option L.t) : Prop :=
   match ox, oy with
@@ -194,182 +189,231 @@ Proof.
   auto.
 Qed.
 
-Definition tree_eq (m1 m2: PTree.t L.t) : Prop :=
-  forall i, opt_eq (PTree.get i m1) (PTree.get i m2).
+Local Hint Resolve opt_beq_correct opt_eq_refl opt_eq_sym : combine.
 
-Lemma tree_eq_refl: forall m, tree_eq m m.
-Proof. intros; red; intros; apply opt_eq_refl. Qed.
+(** A [map_filter] operation over the type [PTree.t L.t] that attempts
+  to share its result with its arguments. *)
 
-Lemma tree_eq_sym: forall m1 m2, tree_eq m1 m2 -> tree_eq m2 m1.
-Proof. intros; red; intros; apply opt_eq_sym; auto. Qed.
+Section MAP_FILTER.
 
-Lemma tree_eq_trans: forall m1 m2 m3, tree_eq m1 m2 -> tree_eq m2 m3 -> tree_eq m1 m3.
-Proof. intros; red; intros; apply opt_eq_trans with (PTree.get i m2); auto. Qed.
+Variable f: option L.t -> option L.t.
+Hypothesis f_None: f None = None.
 
-Lemma tree_eq_node:
-  forall l1 o1 r1 l2 o2 r2,
-  tree_eq l1 l2 -> tree_eq r1 r2 -> opt_eq o1 o2 ->
-  tree_eq (PTree.Node l1 o1 r1) (PTree.Node l2 o2 r2).
-Proof.
-  intros; red; intros. destruct i; simpl; auto.
-Qed.
+Inductive changed: Type := Unchanged | Chempty | Changed (m: PTree.tree' L.t).
 
-Lemma tree_eq_node':
-  forall l1 o1 r1 l2 o2 r2,
-  tree_eq l1 l2 -> tree_eq r1 r2 -> opt_eq o1 o2 ->
-  tree_eq (PTree.Node l1 o1 r1) (PTree.Node' l2 o2 r2).
-Proof.
-  intros; red; intros. rewrite PTree.gnode'. apply tree_eq_node; auto.
-Qed.
+(** This is like [Node] but uses [Chempty] and [Changed] instead of [Empty] and [Nodes]. *)
 
-Lemma tree_eq_node'':
-  forall l1 o1 r1 l2 o2 r2,
-  tree_eq l1 l2 -> tree_eq r1 r2 -> opt_eq o1 o2 ->
-  tree_eq (PTree.Node' l1 o1 r1) (PTree.Node' l2 o2 r2).
-Proof.
-  intros; red; intros. repeat rewrite PTree.gnode'. apply tree_eq_node; auto.
-Qed.
-
-Hint Resolve opt_beq_correct opt_eq_refl opt_eq_sym
-             tree_eq_refl tree_eq_sym
-             tree_eq_node tree_eq_node' tree_eq_node'' : combine.
-
-Inductive changed: Type := Unchanged | Changed (m: PTree.t L.t).
-
-Fixpoint combine_l (m : PTree.t L.t) {struct m} : changed :=
-  match m with
-  | PTree.Leaf =>
-      Unchanged
-  | PTree.Node l o r =>
-      let o' := f o None in
-      match combine_l l, combine_l r with
-      | Unchanged, Unchanged => if opt_beq o' o then Unchanged else Changed (PTree.Node' l o' r)
-      | Unchanged, Changed r' => Changed (PTree.Node' l o' r')
-      | Changed l', Unchanged => Changed (PTree.Node' l' o' r)
-      | Changed l', Changed r' => Changed (PTree.Node' l' o' r')
-      end
+Definition Node1 (l: PTree.t L.t) (o: option L.t) (r: PTree.t L.t) : changed := 
+  match l,o,r with
+  | PTree.Empty, None, PTree.Empty => Chempty
+  | PTree.Empty, None, PTree.Nodes r' => Changed (PTree.Node001 r')
+  | PTree.Empty, Some x, PTree.Empty => Changed (PTree.Node010 x)
+  | PTree.Empty, Some x, PTree.Nodes r' => Changed (PTree.Node011 x r')
+  | PTree.Nodes l', None, PTree.Empty => Changed (PTree.Node100 l')
+  | PTree.Nodes l', None, PTree.Nodes r' => Changed (PTree.Node101 l' r')
+  | PTree.Nodes l', Some x, PTree.Empty => Changed (PTree.Node110 l' x)
+  | PTree.Nodes l', Some x, PTree.Nodes r' => Changed (PTree.Node111 l' x r')
   end.
 
-Lemma combine_l_eq:
-  forall m,
-  tree_eq (match combine_l m with Unchanged => m | Changed m' => m' end)
-          (PTree.xcombine_l f m).
-Proof.
-  induction m; simpl.
-  auto with combine.
-  destruct (combine_l m1) as [ | l']; destruct (combine_l m2) as [ | r'];
-  auto with combine.
-  case_eq (opt_beq (f o None) o); auto with combine.
-Qed.
-
-Fixpoint combine_r (m : PTree.t L.t) {struct m} : changed :=
-  match m with
-  | PTree.Leaf =>
-      Unchanged
-  | PTree.Node l o r =>
-      let o' := f None o in
-      match combine_r l, combine_r r with
-      | Unchanged, Unchanged => if opt_beq o' o then Unchanged else Changed (PTree.Node' l o' r)
-      | Unchanged, Changed r' => Changed (PTree.Node' l o' r')
-      | Changed l', Unchanged => Changed (PTree.Node' l' o' r)
-      | Changed l', Changed r' => Changed (PTree.Node' l' o' r')
-      end
+Definition Node_share1 (l1: PTree.t L.t) (lres: changed) (o1: option L.t)
+                       (r1: PTree.t L.t) (rres: changed) : changed :=
+  let o' := f o1 in
+  match lres, rres with
+  | Unchanged, Unchanged =>
+      if opt_beq o' o1 then Unchanged else Node1 l1 o' r1
+  | Unchanged, Chempty => Node1 l1 o' PTree.Empty
+  | Chempty, Unchanged => Node1 PTree.Empty o' r1
+  | Unchanged, Changed r' => Node1 l1 o' (PTree.Nodes r')
+  | Changed l', Unchanged => Node1 (PTree.Nodes l') o' r1
+  | Chempty, Chempty => Node1 PTree.Empty o' PTree.Empty
+  | Chempty, Changed r' => Node1 PTree.Empty o' (PTree.Nodes r')
+  | Changed l', Chempty => Node1 (PTree.Nodes l') o' PTree.Empty
+  | Changed l', Changed r' => Node1 (PTree.Nodes l') o' (PTree.Nodes r')
   end.
 
-Lemma combine_r_eq:
-  forall m,
-  tree_eq (match combine_r m with Unchanged => m | Changed m' => m' end)
-          (PTree.xcombine_r f m).
+Definition map_filter :=
+  Eval cbv beta iota delta [Node_share1 Node1] in
+  PTree.tree_rec Unchanged Node_share1.
+
+Remark gNode1: forall l o r m i,
+  match Node1 l o r with Unchanged => m | Chempty => PTree.Empty | Changed m' => PTree.Nodes m' end ! i
+  = match i with xH => o | xO j => l!j | xI j => r!j end.
 Proof.
-  induction m; simpl.
-  auto with combine.
-  destruct (combine_r m1) as [ | l']; destruct (combine_r m2) as [ | r'];
-  auto with combine.
-  case_eq (opt_beq (f None o) o); auto with combine.
+  intros. destruct l, o, r, i; reflexivity.
 Qed.
+
+Lemma gmap_filter: forall m i,
+  opt_eq (match map_filter m with Unchanged => m | Chempty => PTree.Empty | Changed m' => PTree.Nodes m' end ! i)
+         (f m!i).
+Proof.
+  change map_filter with (PTree.tree_rec Unchanged Node_share1).
+  induction m using PTree.tree_ind; intros.
+- simpl. rewrite f_None; auto.
+- rename m1 into l; rename m2 into r. rewrite PTree.unroll_tree_rec by auto.
+  destruct (PTree.tree_rec Unchanged Node_share1 l) as [ | | l'];
+  destruct (PTree.tree_rec Unchanged Node_share1 r) as [ | | r'];
+  unfold Node_share1; rewrite ? gNode1, ? PTree.gNode;
+  try (destruct i; now auto with combine).
+  destruct (opt_beq (f o) o) eqn:BEQ.
+  * rewrite PTree.gNode; destruct i; auto with combine.
+  * rewrite gNode1. destruct i; auto with combine.
+Qed.
+
+End MAP_FILTER.
+
+(** A [combine] operation over the type [PTree.t L.t] that attempts
+  to share its result with its arguments. *)
+
+Section COMBINE.
+
+Variable f: option L.t -> option L.t -> option L.t.
+Hypothesis f_none_none: f None None = None.
 
 Inductive changed2 : Type :=
   | Same
   | Same1
   | Same2
-  | CC(m: PTree.t L.t).
+  | CC0
+  | CC (m: PTree.tree' L.t).
 
-Fixpoint xcombine (m1 m2 : PTree.t L.t) {struct m1} : changed2 :=
-    match m1, m2 with
-    | PTree.Leaf, PTree.Leaf =>
-        Same
-    | PTree.Leaf, _ =>
-        match combine_r m2 with
-        | Unchanged => Same2
-        | Changed m => CC m
-        end
-    | _, PTree.Leaf =>
-        match combine_l m1 with
-        | Unchanged => Same1
-        | Changed m => CC m
-        end
-    | PTree.Node l1 o1 r1, PTree.Node l2 o2 r2 =>
-        let o := f o1 o2 in
-        match xcombine l1 l2, xcombine r1 r2 with
-        | Same, Same =>
-            match opt_beq o o1, opt_beq o o2 with
-            | true, true => Same
-            | true, false => Same1
-            | false, true => Same2
-            | false, false => CC(PTree.Node' l1 o r1)
-            end
-        | Same1, Same | Same, Same1 | Same1, Same1 =>
-            if opt_beq o o1 then Same1 else CC(PTree.Node' l1 o r1)
-        | Same2, Same | Same, Same2 | Same2, Same2 =>
-            if opt_beq o o2 then Same2 else CC(PTree.Node' l2 o r2)
-        | Same1, Same2 => CC(PTree.Node' l1 o r2)
-        | (Same|Same1), CC r => CC(PTree.Node' l1 o r)
-        | Same2, Same1 => CC(PTree.Node' l2 o r1)
-        | Same2, CC r => CC(PTree.Node' l2 o r)
-        | CC l, (Same|Same1) => CC(PTree.Node' l o r1)
-        | CC l, Same2 => CC(PTree.Node' l o r2)
-        | CC l, CC r => CC(PTree.Node' l o r)
-        end
-    end.
-
-Lemma xcombine_eq:
-  forall m1 m2,
-  match xcombine m1 m2 with
-  | Same => tree_eq m1 (PTree.combine f m1 m2) /\ tree_eq m2 (PTree.combine f m1 m2)
-  | Same1 => tree_eq m1 (PTree.combine f m1 m2)
-  | Same2 => tree_eq m2 (PTree.combine f m1 m2)
-  | CC m => tree_eq m (PTree.combine f m1 m2)
+Definition Node2 (l: PTree.t L.t) (o: option L.t) (r: PTree.t L.t) : changed2 := 
+  match l,o,r with
+  | PTree.Empty, None, PTree.Empty => CC0
+  | PTree.Empty, None, PTree.Nodes r' => CC (PTree.Node001 r')
+  | PTree.Empty, Some x, PTree.Empty => CC (PTree.Node010 x)
+  | PTree.Empty, Some x, PTree.Nodes r' => CC (PTree.Node011 x r')
+  | PTree.Nodes l', None, PTree.Empty => CC (PTree.Node100 l')
+  | PTree.Nodes l', None, PTree.Nodes r' => CC (PTree.Node101 l' r')
+  | PTree.Nodes l', Some x, PTree.Empty => CC (PTree.Node110 l' x)
+  | PTree.Nodes l', Some x, PTree.Nodes r' => CC (PTree.Node111 l' x r')
   end.
+
+Definition Node_share2
+             (l1: PTree.t L.t) (o1: option L.t) (r1: PTree.t L.t)
+             (l2: PTree.t L.t) (o2: option L.t) (r2: PTree.t L.t)
+             (lres: changed2) (rres: changed2) : changed2 :=
+  let o := f o1 o2 in
+  match lres, rres with
+  | Same, Same =>
+      match opt_beq o o1, opt_beq o o2 with
+      | true, true => Same
+      | true, false => Same1
+      | false, true => Same2
+      | false, false => Node2 l1 o r1
+      end
+  | Same, Same1
+  | Same1, Same
+  | Same1, Same1 =>
+      if opt_beq o o1 then Same1 else Node2 l1 o r1
+  | Same, Same2
+  | Same2, Same
+  | Same2, Same2 =>
+      if opt_beq o o2 then Same2 else Node2 l2 o r2
+  | Same, CC0 => Node2 l1 o PTree.Empty
+  | Same, CC m2 => Node2 l1 o (PTree.Nodes m2)
+  | Same1, Same2 => Node2 l1 o r2
+  | Same1, CC0 => Node2 l1 o PTree.Empty
+  | Same1, CC m2 => Node2 l1 o (PTree.Nodes m2)
+  | Same2, Same1 => Node2 l2 o r1
+  | Same2, CC0 => Node2 l2 o PTree.Empty
+  | Same2, CC m2 => Node2 l2 o (PTree.Nodes m2)
+  | CC0, (Same|Same1) => Node2 PTree.Empty o r1
+  | CC0, Same2 => Node2 PTree.Empty o r2
+  | CC0, CC0 => Node2 PTree.Empty o PTree.Empty
+  | CC0, CC m2 => Node2 PTree.Empty o (PTree.Nodes m2)
+  | CC m1, (Same|Same1) => Node2 (PTree.Nodes m1) o r1
+  | CC m1, Same2 => Node2 (PTree.Nodes m1) o r2
+  | CC m1, CC0 => Node2 (PTree.Nodes m1) o PTree.Empty
+  | CC m1, CC m2 => Node2 (PTree.Nodes m1) o (PTree.Nodes m2)
+  end.
+
+Definition xcombine_l (m: PTree.t L.t) : changed2 :=
+  match map_filter (fun o => f o None) m with
+  | Unchanged => Same1
+  | Chempty => CC0
+  | Changed m' => CC m'
+  end.
+
+Definition xcombine_r (m: PTree.t L.t) : changed2 :=
+  match map_filter (fun o => f None o) m with
+  | Unchanged => Same2
+  | Chempty => CC0
+  | Changed m' => CC m'
+  end.
+
+Definition xcombine :=
+  Eval cbv beta iota delta [Node_share2 Node2] in
+  PTree.tree_rec2
+    xcombine_r
+    xcombine_l
+    Node_share2.
+
+Definition tree_agree (m1 m2 m: PTree.t L.t) : Prop :=
+  forall i, opt_eq m!i (f m1!i m2!i).
+
+Lemma tree_agree_node: forall l1 o1 r1 l2 o2 r2 l o r,
+  tree_agree l1 l2 l -> tree_agree r1 r2 r -> opt_eq (f o1 o2) o ->
+  tree_agree (PTree.Node l1 o1 r1) (PTree.Node l2 o2 r2) (PTree.Node l o r).
 Proof.
-Opaque combine_l combine_r PTree.xcombine_l PTree.xcombine_r.
-  induction m1; destruct m2; simpl.
-  split; apply tree_eq_refl.
-  generalize (combine_r_eq (PTree.Node m2_1 o m2_2)).
-  destruct (combine_r (PTree.Node m2_1 o m2_2)); auto.
-  generalize (combine_l_eq (PTree.Node m1_1 o m1_2)).
-  destruct (combine_l (PTree.Node m1_1 o m1_2)); auto.
-  generalize (IHm1_1 m2_1) (IHm1_2 m2_2).
-  destruct (xcombine m1_1 m2_1);
-  destruct (xcombine m1_2 m2_2); auto with combine;
-  intuition; case_eq (opt_beq (f o o0) o); case_eq (opt_beq (f o o0) o0); auto with combine.
+  intros; red; intros. rewrite ! PTree.gNode. destruct i; auto using opt_eq_sym.
+Qed.
+
+Local Hint Resolve tree_agree_node : combine.
+
+Inductive xcombine_spec (m1 m2: PTree.t L.t) : changed2 -> Prop :=
+  | XCS_Same:
+      tree_agree m1 m2 m1 -> tree_agree m1 m2 m2 -> xcombine_spec m1 m2 Same
+  | XCS_Same1:
+      tree_agree m1 m2 m1 -> xcombine_spec m1 m2 Same1
+  | XCS_Same2:
+      tree_agree m1 m2 m2 -> xcombine_spec m1 m2 Same2
+  | XCS_CC0:
+      tree_agree m1 m2 PTree.Empty -> xcombine_spec m1 m2 CC0
+  | XCS_CC: forall m',
+      tree_agree m1 m2 (PTree.Nodes m') -> xcombine_spec m1 m2 (CC m').
+
+Local Hint Constructors xcombine_spec : combine.
+
+Lemma gNode2: forall l o r m1 m2,
+  tree_agree m1 m2 (PTree.Node l o r) ->
+  xcombine_spec m1 m2 (Node2 l o r).
+Proof.
+  intros. destruct l, o, r; constructor; auto.
+Qed.
+
+Local Hint Resolve gNode2 : combine.
+
+Lemma gxcombine: forall m1 m2, xcombine_spec m1 m2 (xcombine m1 m2).
+Proof.
+  Local Opaque opt_eq.
+  change xcombine with (PTree.tree_rec2 xcombine_r xcombine_l Node_share2).
+  induction m1 using PTree.tree_ind; [ | induction m2 using PTree.tree_ind]; intros.
+- simpl. unfold xcombine_r. 
+  generalize (gmap_filter (fun o => f None o) f_none_none m2).
+  destruct (map_filter (fun o => f None o) m2); auto with combine.
+- rewrite PTree.unroll_tree_rec2_NE by auto. unfold xcombine_l.
+  generalize (gmap_filter (fun o => f o None) f_none_none (PTree.Node l o r)).
+  destruct (map_filter (fun o => f o None) (PTree.Node l o r)); auto with combine.
+- rewrite PTree.unroll_tree_rec2_NN by auto.
+  clear IHm2 IHm3. specialize (IHm1 l0). specialize (IHm0 r0).
+  inv IHm1; inv IHm0; unfold Node_share2; auto with combine;
+  destruct (opt_beq (f o o0) o) eqn:E1; destruct (opt_beq (f o o0) o0) eqn:E2;
+  auto with combine.
 Qed.
 
 Definition combine (m1 m2: PTree.t L.t) : PTree.t L.t :=
   match xcombine m1 m2 with
   | Same|Same1 => m1
   | Same2 => m2
-  | CC m => m
+  | CC0 => PTree.Empty
+  | CC m => PTree.Nodes m
   end.
 
-Lemma gcombine:
+Theorem gcombine:
   forall m1 m2 i, opt_eq (PTree.get i (combine m1 m2)) (f (PTree.get i m1) (PTree.get i m2)).
 Proof.
-  intros.
-  assert (tree_eq (combine m1 m2) (PTree.combine f m1 m2)).
-  unfold combine.
-  generalize (xcombine_eq m1 m2).
-  destruct (xcombine m1 m2); tauto.
-  eapply opt_eq_trans. apply H. rewrite PTree.gcombine; auto. apply opt_eq_refl.
+  intros. unfold combine. 
+  generalize (gxcombine m1 m2); intros XS; inv XS; auto.
 Qed.
 
 End COMBINE.
@@ -526,7 +570,7 @@ Definition top := Top_except (PTree.empty L.t).
 
 Lemma get_top: forall p, get p top = L.top.
 Proof.
-  unfold top; intros; simpl. rewrite PTree.gempty. auto.
+  unfold top; intros; auto.
 Qed.
 
 Lemma ge_top: forall x, ge top x.


### PR DESCRIPTION
This PR replaces the "PTree" data structure used in lib/Maps.v by the canonical binary tries data structure described in the paper [Efficient Extensional Binary Tries](https://arxiv.org/abs/2110.05063).

The new implementation is more memory-efficient and a bit faster, resulting in reduced compilation times (-5% on typical C programs, up to -10% on very large C functions).

It also enjoys the extensionality property (two tries mapping equal keys to equal data are equal), which simplifies some proofs.
