### PR TITLE
Parsing of unprototyped function types in casts

### DIFF
--- a/cparser/Parser.vy
+++ b/cparser/Parser.vy
@@ -720,9 +720,9 @@ direct_abstract_declarator:
 | LPAREN params = parameter_type_list RPAREN
     { Cabs.PROTO Cabs.JUSTBASE params }
 | typ = direct_abstract_declarator LPAREN RPAREN
-    { Cabs.PROTO typ ([], false) }
+    { Cabs.PROTO_OLD typ [] }
 | LPAREN RPAREN
-    { Cabs.PROTO Cabs.JUSTBASE ([], false) }
+    { Cabs.PROTO_OLD Cabs.JUSTBASE [] }
 
 (* 6.7.8 *)
 c_initializer:


### PR DESCRIPTION
Currently, in the context of casts, the unprotototyped function type `int (*)()` is parsed like the prototyped function type `int (*)(void)`.  This causes the following example to be rejected:
```
int f(int x) { return x; }

int main() { return ((int (*)()) &f)(42); }
```
CompCert complains that a function of zero arguments is applied to one argument.  This example is accepted by GCC and Clang, and seems correct according to the ISO C standards.

This is probably a leftover from the days when CompCert didn't fully support unprototyped functions.  

It's only casts that have this problem; declarations are correctly parsed, e.g. `int (*f)();` and `int (*f)(void);` have different types.

This PR is the trivial fix for this problem.  It needs some testing, though.
