### PR TITLE
Add `Declare Scope` where appropriate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ endif
 
 # Notes on silenced Coq warnings:
 #
-# undeclared-scope:
-#    warning introduced in 8.12
-#    suggested change (use `Declare Scope`) supported since 8.12
 # unused-pattern-matching-variable:
 #    warning introduced in 8.13
 #    the code rewrite that avoids the warning is not desirable
@@ -62,7 +59,6 @@ endif
 #    triggered by Menhir-generated files, to be solved upstream in Menhir
 
 COQCOPTS ?= \
-  -w -undeclared-scope \
   -w -unused-pattern-matching-variable \
   -w -deprecated-ident-entry
 

--- a/MenhirLib/Interpreter.v
+++ b/MenhirLib/Interpreter.v
@@ -84,8 +84,8 @@ CoInductive buffer : Type :=
   Buf_cons { buf_head : token; buf_tail : buffer }.
 
 (* Note: Coq 8.12.0 wants a Declare Scope command,
-   but this breaks compatibility with Coq < 8.10.
-   Declare Scope buffer_scope. *)
+   but this breaks compatibility with Coq < 8.10. *)
+Declare Scope buffer_scope.
 Delimit Scope buffer_scope with buf.
 Bind Scope buffer_scope with buffer.
 

--- a/aarch64/Asm.v
+++ b/aarch64/Asm.v
@@ -96,6 +96,7 @@ Coercion preg_of_iregsp: iregsp >-> preg.
 
 (** Conventional name for return address ([RA]) *)
 
+Declare Scope asm.
 Notation "'RA'" := X30 (only parsing) : asm.
 
 (** The instruction set.  Most instructions correspond exactly to

--- a/arm/Asm.v
+++ b/arm/Asm.v
@@ -94,6 +94,7 @@ Module Pregmap := EMap(PregEq).
 
 (** Conventional names for stack pointer ([SP]) and return address ([RA]) *)
 
+Declare Scope asm.
 Notation "'SP'" := IR13 (only parsing) : asm.
 Notation "'RA'" := IR14 (only parsing) : asm.
 

--- a/backend/Allocation.v
+++ b/backend/Allocation.v
@@ -167,6 +167,8 @@ Definition check_succ (s: node) (b: LTL.bblock) : bool :=
   | _ => false
   end.
 
+Declare Scope option_monad_scope.
+
 Notation "'do' X <- A ; B" := (match A with Some X => B | None => None end)
          (at level 200, X ident, A at level 100, B at level 200)
          : option_monad_scope.

--- a/backend/CminorSel.v
+++ b/backend/CminorSel.v
@@ -54,6 +54,7 @@ with condexpr : Type :=
   | CEcondition : condexpr -> condexpr -> condexpr -> condexpr
   | CElet: expr -> condexpr -> condexpr.
 
+Declare Scope cminorsel_scope.
 Infix ":::" := Econs (at level 60, right associativity) : cminorsel_scope.
 
 (** Conditional expressions [condexpr] are expressions that are evaluated

--- a/backend/Registers.v
+++ b/backend/Registers.v
@@ -61,6 +61,8 @@ Definition regmap_setres
   | _ => rs
   end.
 
+Declare Scope rtl.
+
 Notation "a # b" := (Regmap.get b a) (at level 1) : rtl.
 Notation "a ## b" := (List.map (fun r => Regmap.get r a) b) (at level 1) : rtl.
 Notation "a # b <- c" := (Regmap.set b c a) (at level 1, b at next level) : rtl.

--- a/cfrontend/Cexec.v
+++ b/cfrontend/Cexec.v
@@ -25,6 +25,8 @@ Local Open Scope list_scope.
 
 (** Error monad with options or lists *)
 
+Declare Scope option_monad_scope.
+
 Notation "'do' X <- A ; B" := (match A with Some X => B | None => None end)
   (at level 200, X ident, A at level 100, B at level 200)
   : option_monad_scope.
@@ -44,6 +46,8 @@ Notation "'do' X , Y , Z , W <- A ; B" := (match A with Some (X, Y, Z, W) => B |
 Notation " 'check' A ; B" := (if A then B else None)
   (at level 200, A at level 100, B at level 200)
   : option_monad_scope.
+
+Declare Scope list_monad_scope.
 
 Notation "'do' X <- A ; B" := (match A with Some X => B | None => nil end)
   (at level 200, X ident, A at level 100, B at level 200)
@@ -744,6 +748,8 @@ Definition incontext2 {A1 A2 B: Type}
                      (ctx1: A1 -> B) (ll1: reducts A1)
                      (ctx2: A2 -> B) (ll2: reducts A2) : reducts B :=
   incontext ctx1 ll1 ++ incontext ctx2 ll2.
+
+Declare Scope reducts_monad_scope.
 
 Notation "'do' X <- A ; B" := (match A with Some X => B | None => stuck end)
   (at level 200, X ident, A at level 100, B at level 200)

--- a/cfrontend/SimplExpr.v
+++ b/cfrontend/SimplExpr.v
@@ -55,6 +55,7 @@ Definition bind {A B: Type} (x: mon A) (f: A -> mon B) : mon B :=
 Definition bind2 {A B C: Type} (x: mon (A * B)) (f: A -> B -> mon C) : mon C :=
   bind x (fun p => f (fst p) (snd p)).
 
+Declare Scope gensym_monad_scope.
 Notation "'do' X <- A ; B" := (bind A (fun X => B))
    (at level 200, X ident, A at level 100, B at level 200)
    : gensym_monad_scope.

--- a/common/Errors.v
+++ b/common/Errors.v
@@ -67,6 +67,8 @@ Definition bind2 (A B C: Type) (f: res (A * B)) (g: A -> B -> res C) : res C :=
 
 (** The [do] notation, inspired by Haskell's, keeps the code readable. *)
 
+Declare Scope error_monad_scope.
+
 Notation "'do' X <- A ; B" := (bind A (fun X => B))
  (at level 200, X ident, A at level 100, B at level 200)
  : error_monad_scope.

--- a/common/Globalenvs.v
+++ b/common/Globalenvs.v
@@ -39,9 +39,9 @@ Require Import Zwf.
 Require Import Axioms Coqlib Errors Maps AST Linking.
 Require Import Integers Floats Values Memory.
 
+Declare Scope pair_scope.
 Notation "s #1" := (fst s) (at level 9, format "s '#1'") : pair_scope.
 Notation "s #2" := (snd s) (at level 9, format "s '#2'") : pair_scope.
-
 Local Open Scope pair_scope.
 Local Open Scope error_monad_scope.
 

--- a/common/Linking.v
+++ b/common/Linking.v
@@ -862,6 +862,8 @@ Inductive Passes: Language -> Language -> Type :=
   | pass_nil: forall l, Passes l l
   | pass_cons: forall l1 l2 l3, Pass l1 l2 -> Passes l2 l3 -> Passes l1 l3.
 
+Declare Scope linking_scope.
+
 Infix ":::" := pass_cons (at level 60, right associativity) : linking_scope.
 
 (** The pass corresponding to the composition of a list of passes. *)

--- a/common/Separation.v
+++ b/common/Separation.v
@@ -54,6 +54,7 @@ Record massert : Type := {
   m_valid: forall m b ofs, m_pred m -> m_footprint b ofs -> Mem.valid_block m b
 }.
 
+Declare Scope sep_scope.
 Notation "m |= p" := (m_pred p m) (at level 74, no associativity) : sep_scope.
 
 (** Implication and logical equivalence between memory predicates *)

--- a/common/Smallstep.v
+++ b/common/Smallstep.v
@@ -501,6 +501,8 @@ Definition Semantics {state funtype vartype: Type}
 
 (** Handy notations. *)
 
+Declare Scope smallstep_scope.
+
 Notation " 'Step' L " := (step L (globalenv L)) (at level 1) : smallstep_scope.
 Notation " 'Star' L " := (star (step L) (globalenv L)) (at level 1) : smallstep_scope.
 Notation " 'Plus' L " := (plus (step L) (globalenv L)) (at level 1) : smallstep_scope.

--- a/export/Clightdefs.v
+++ b/export/Clightdefs.v
@@ -49,6 +49,8 @@ Definition mkprogram (types: list composite_definition)
 
 (** ** Notations *)
 
+Declare Scope clight_scope.
+
 Module ClightNotations.
 
 (** A convenient notation [$ "ident"] to force evaluation of

--- a/export/Csyntaxdefs.v
+++ b/export/Csyntaxdefs.v
@@ -49,6 +49,8 @@ Definition mkprogram (types: list composite_definition)
 
 (** ** Notations *)
 
+Declare Scope csyntax_scope.
+
 Module CsyntaxNotations.
 
 (** A convenient notation [$ "ident"] to force evaluation of

--- a/powerpc/Asm.v
+++ b/powerpc/Asm.v
@@ -87,6 +87,7 @@ Module Pregmap := EMap(PregEq).
 
 (** Conventional names for stack pointer ([SP]) and return address ([RA]) *)
 
+Declare Scope asm.
 Notation "'SP'" := GPR1 (only parsing) : asm.
 Notation "'RA'" := LR (only parsing) : asm.
 

--- a/riscV/Asm.v
+++ b/riscV/Asm.v
@@ -93,6 +93,7 @@ Module Pregmap := EMap(PregEq).
 
 (** Conventional names for stack pointer ([SP]) and return address ([RA]). *)
 
+Declare Scope asm.
 Notation "'SP'" := X2 (only parsing) : asm.
 Notation "'RA'" := X1 (only parsing) : asm.
 

--- a/x86/Asm.v
+++ b/x86/Asm.v
@@ -312,6 +312,7 @@ Module Pregmap := EMap(PregEq).
 Definition regset := Pregmap.t val.
 Definition genv := Genv.t fundef unit.
 
+Declare Scope asm.
 Notation "a # b" := (a b) (at level 1, only parsing) : asm.
 Notation "a # b <- c" := (Pregmap.set b c a) (at level 1, b at next level) : asm.
 


### PR DESCRIPTION
`Declare Scope` makes it possible to declare a new notation scope before adding notations to it.  This construct has been available since Coq 8.12, and is recommended, to the point that a warning is triggered (by default) if a notation is added to an undeclared scope.  

Now that 8.12 is the lowest supported Coq version, we can use `Declare Scope` and stop silencing the `undeclared-scope` warning.


