### PR TITLE
Support the -std=<standard> command-line option

### DIFF
--- a/configure
+++ b/configure
@@ -248,7 +248,7 @@ if test "$arch" = "arm"; then
         exit 2;;
   esac
 
-  cprepro_options="-std=c99 -U__GNUC__ '-D__REDIRECT(name,proto,alias)=name proto' '-D__REDIRECT_NTH(name,proto,alias)=name proto' -E"
+  cprepro_options="-U__GNUC__ '-D__REDIRECT(name,proto,alias)=name proto' '-D__REDIRECT_NTH(name,proto,alias)=name proto' -E"
   system="linux"
 fi
 
@@ -293,7 +293,7 @@ if test "$arch" = "powerpc"; then
         ;;
     *)
         casmruntime="${toolprefix}gcc -c -Wa,-mregnames"
-        cprepro_options="-std=c99 -U__GNUC__ -E"
+        cprepro_options="-U__GNUC__ -E"
         system="linux"
         ;;
   esac
@@ -311,7 +311,7 @@ if test "$arch" = "x86" -a "$bitsize" = "32"; then
         cc_options="-m32"
         casm_options="-m32 -c"
         clinker_options="-m32"
-        cprepro_options="-std=c99 -m32 -U__GNUC__ -E"
+        cprepro_options="-m32 -U__GNUC__ -E"
         system="bsd"
         ;;
     cygwin)
@@ -319,7 +319,7 @@ if test "$arch" = "x86" -a "$bitsize" = "32"; then
         cc_options="-m32"
         casm_options="-m32 -c"
         clinker_options="-m32"
-        cprepro_options="-std=c99 -m32 -U__GNUC__ '-D__attribute__(x)=' -E"
+        cprepro_options="-m32 -U__GNUC__ '-D__attribute__(x)=' -E"
         system="cygwin"
         ;;
     linux)
@@ -327,7 +327,7 @@ if test "$arch" = "x86" -a "$bitsize" = "32"; then
         cc_options="-m32"
         casm_options="-m32 -c"
         clinker_options="-m32"
-        cprepro_options="-std=c99 -m32 -U__GNUC__ -E"
+        cprepro_options="-m32 -U__GNUC__ -E"
         system="linux"
         ;;
     *)
@@ -348,7 +348,7 @@ if test "$arch" = "x86" -a "$bitsize" = "64"; then
         cc_options="-m64"
         casm_options="-m64 -c"
         clinker_options="-m64"
-        cprepro_options="-std=c99 -m64 -U__GNUC__ -U__SIZEOF_INT128__ -E"
+        cprepro_options="-m64 -U__GNUC__ -U__SIZEOF_INT128__ -E"
         system="bsd"
         ;;
     linux)
@@ -356,7 +356,7 @@ if test "$arch" = "x86" -a "$bitsize" = "64"; then
         cc_options="-m64"
         casm_options="-m64 -c"
         clinker_options="-m64"
-        cprepro_options="-std=c99 -m64 -U__GNUC__ -U__SIZEOF_INT128__ -E"
+        cprepro_options="-m64 -U__GNUC__ -U__SIZEOF_INT128__ -E"
         system="linux"
         ;;
     macos|macosx)
@@ -365,7 +365,7 @@ if test "$arch" = "x86" -a "$bitsize" = "64"; then
         casm_options="-arch x86_64 -c"
         clinker_options="-arch x86_64"
         clinker_needs_no_pie=false
-        cprepro_options="-std=c99 -arch x86_64 -U__GNUC__ -U__SIZEOF_INT128__ -U__clang__ -U__BLOCKS__ '-D__attribute__(x)=' '-D__asm(x)=' '-D_Nullable=' '-D_Nonnull=' '-D__DARWIN_OS_INLINE=static inline' -Wno-\\#warnings -E"
+        cprepro_options="-arch x86_64 -U__GNUC__ -U__SIZEOF_INT128__ -U__clang__ -U__BLOCKS__ '-D__attribute__(x)=' '-D__asm(x)=' '-D_Nullable=' '-D_Nonnull=' '-D__DARWIN_OS_INLINE=static inline' -Wno-\\#warnings -E"
         libmath=""
         system="macos"
         ;;
@@ -374,7 +374,7 @@ if test "$arch" = "x86" -a "$bitsize" = "64"; then
         cc_options="-m64"
         casm_options="-m64 -c"
         clinker_options="-m64"
-        cprepro_options="-std=c99 -m64 -U__GNUC__ -U__SIZEOF_INT128__ '-D__attribute__(x)=' -E"
+        cprepro_options="-m64 -U__GNUC__ -U__SIZEOF_INT128__ '-D__attribute__(x)=' -E"
         system="cygwin"
         ;;
     *)
@@ -398,7 +398,7 @@ if test "$arch" = "riscV"; then
   cc_options="$model_options"
   casm_options="$model_options -c"
   clinker_options="$model_options"
-  cprepro_options="$model_options -std=c99 -U__GNUC__ -E"
+  cprepro_options="$model_options -U__GNUC__ -E"
   system="linux"
 fi
 
@@ -409,7 +409,7 @@ if test "$arch" = "aarch64"; then
   case "$target" in
     linux)
         abi="standard"
-        cprepro_options="-std=c99 -U__GNUC__ -E"
+        cprepro_options="-U__GNUC__ -E"
         system="linux";;
     macos|macosx)
         abi="apple"
@@ -419,7 +419,7 @@ if test "$arch" = "aarch64"; then
         clinker="${toolprefix}cc"
         clinker_needs_no_pie=false
         cprepro="${toolprefix}cc"
-        cprepro_options="-std=c99 -arch arm64 -U__GNUC__ -U__clang__ -U__BLOCKS__ '-D__attribute__(x)=' '-D__asm(x)=' '-D_Nullable=' '-D_Nonnull=' '-D__DARWIN_OS_INLINE=static inline' -Wno-\\#warnings -E"
+        cprepro_options="-arch arm64 -U__GNUC__ -U__clang__ -U__BLOCKS__ '-D__attribute__(x)=' '-D__asm(x)=' '-D_Nullable=' '-D_Nonnull=' '-D__DARWIN_OS_INLINE=static inline' -Wno-\\#warnings -E"
         libmath=""
         system="macos"
         ;;

--- a/cparser/Diagnostics.mli
+++ b/cparser/Diagnostics.mli
@@ -100,3 +100,16 @@ val error_summary : unit -> unit
 
 val active_warning : warning_type -> bool
 (** Test whether a warning is active to avoid costly checks *)
+
+val activate_warning : warning_type -> unit -> unit
+(** Turn the given warning on *)
+
+val deactivate_warning : warning_type -> unit -> unit
+(** Turn the given warning off *)
+
+val warning_as_error : warning_type -> unit -> unit
+(** Turn the given warning on and report it as an error *)
+
+val warning_not_as_error : warning_type -> unit -> unit
+(** Do not report the given warning as an error *)
+

--- a/debug/DebugInit.ml
+++ b/debug/DebugInit.ml
@@ -36,14 +36,16 @@ let init () =
     init_none ()
 
 let gnu_debugging_help =
-"  -gdwarf-       Generate debug information in DWARF v2 or DWARF v3\n"
+{|  -gdwarf-2     Generate debug information in DWARF v2 format
+  -gdwarf-3     Generate debug information in DWARF v3 format
+|}
 
 let debugging_help =
 {|Debugging options:
   -g             Generate debugging information
   -g<n>          Control generation of debugging information
-                 (<n>=0: none, <n>=1: only-globals, <n>=2: globals + locals
-                 without locations, <n>=3: full;)
+                 (<n>=0: none, <n>=1: only globals,
+                  <n>=2: globals + locals without locations, <n>=3: full)
 |}
 ^ (if Configuration.gnu_toolchain then gnu_debugging_help else "")
 

--- a/driver/Clflags.ml
+++ b/driver/Clflags.ml
@@ -64,6 +64,7 @@ let option_small_data =
        then 8 else 0)
 let option_small_const = ref (!option_small_data)
 let option_timings = ref false
+let option_std = ref "c99"
 let stdlib_path = ref Configuration.stdlib_path
 let use_standard_headers =  ref Configuration.has_standard_headers
 let main_function_name = ref "main"

--- a/driver/Frontend.ml
+++ b/driver/Frontend.ml
@@ -57,6 +57,9 @@ let preprocess ifile ofile =
     if ofile = "-" then None else Some ofile in
   let cmd = List.concat [
     Configuration.prepro;
+    (if Configuration.gnu_toolchain
+     then ["-std=" ^ !option_std]
+     else []);
     predefined_macros;
     (if !Clflags.use_standard_headers
      then ["-I" ^ Filename.concat !Clflags.stdlib_path "include" ]

--- a/lib/Commandline.mli
+++ b/lib/Commandline.mli
@@ -47,6 +47,11 @@ val parse_cmdline: (pattern * action) list -> unit
     and performs all [actions].  Raises [CmdError] if an error occurred.
 *)
 
+val longopt: string -> (string -> unit) -> pattern * action
+(** [longopt_int key fn] generates a pattern and an action for
+    options of the form [key=<text>] and calls [fn] with the string argument
+*)
+
 val longopt_int: string -> (int -> unit) -> pattern * action
 (** [longopt_int key fn] generates a pattern and an action for
     options of the form [key=<n>] and calls [fn] with the integer argument

--- a/test/export/Makefile
+++ b/test/export/Makefile
@@ -13,7 +13,7 @@ endif
 COQINCLUDES += -R ./clight compcert.test.clight
 COQINCLUDES += -R ./csyntax compcert.test.csyntax
 
-CLIGHTGEN=../../clightgen
+CLIGHTGEN=../../clightgen -stdlib ../../runtime
 COQC=coqc
 
 # Regression tests in the current directory


### PR DESCRIPTION
This PR adds a `-std` command-line option similar to those of GCC and Clang.

Currently three values are supported: `-std=c99`, `-std=c11` and `-std=c18`.

The option has two effects:
- With a GNU toolchain, it's passed down to the preprocessor.  This influences the contents of standard header files.  
- It determines the default handling of the "C11 feature" warning: with `-std=c99`, CompCert warns on the use of C11 features; with `-std=c11` or `-std=c18`, no warnings are emitted.

For backward compatibility with CompCert's current behavior, if no `-std` option is given, the default is to not warn, but `-std=c99` is passed to the preprocessor.  This may change in the future, when C11 will become the default instead of C99.
