### PR TITLE
Use .data.rel.ro section for const data with relocatable inits on ELF targets

### DIFF
--- a/aarch64/TargetPrinter.ml
+++ b/aarch64/TargetPrinter.ml
@@ -164,7 +164,10 @@ module ELF_System : SYSTEM =
       | Section_data i | Section_small_data i ->
           variable_section ~sec:".data" ~bss:".bss" i
       | Section_const i | Section_small_const i ->
-          variable_section ~sec:".section	.rodata" i
+          variable_section
+            ~sec:".section      .rodata"
+            ~reloc:".section    .data.rel.ro,\"aw\",@progbits"
+            i
       | Section_string sz ->
           elf_mergeable_string_section sz ".section	.rodata"
       | Section_literal sz ->

--- a/arm/TargetPrinter.ml
+++ b/arm/TargetPrinter.ml
@@ -150,7 +150,10 @@ struct
     | Section_data i | Section_small_data i ->
         variable_section ~sec:".data" ~bss:".bss" i
     | Section_const i | Section_small_const i ->
-        variable_section ~sec:".section	.rodata" i
+        variable_section
+          ~sec:".section      .rodata"
+          ~reloc:".section    .data.rel.ro,\"aw\",%progbits"
+          i
     | Section_string _ -> ".section	.rodata"
     | Section_literal _ -> ".text"
     | Section_jumptable -> ".text"

--- a/riscV/TargetPrinter.ml
+++ b/riscV/TargetPrinter.ml
@@ -110,7 +110,10 @@ module Target : TARGET =
       | Section_data i | Section_small_data i ->
           variable_section ~sec:".data" ~bss:".bss" i
       | Section_const i | Section_small_const i ->
-          variable_section ~sec:".section	.rodata" i
+          variable_section
+            ~sec:".section      .rodata"
+            ~reloc:".section    .data.rel.ro,\"aw\",@progbits"
+            i
       | Section_string sz ->
           elf_mergeable_string_section sz ".section	.rodata"
       | Section_literal sz ->

--- a/x86/TargetPrinter.ml
+++ b/x86/TargetPrinter.ml
@@ -137,7 +137,10 @@ module ELF_System : SYSTEM =
       | Section_data i | Section_small_data i ->
           variable_section ~sec:".data" ~bss:".bss" i
       | Section_const i | Section_small_const i ->
-          variable_section ~sec:".section	.rodata" i
+          variable_section
+            ~sec:".section      .rodata"
+            ~reloc:".section    .data.rel.ro,\"aw\",@progbits"
+            i
       | Section_string sz ->
           elf_mergeable_string_section sz ".section	.rodata"
       | Section_literal sz ->


### PR DESCRIPTION
This is a follow-up to ed89275cb.  With the Clang/LLVM linker and loader, "const" variables initialized with symbol addresses which may need relocation cannot go in a readonly section and must go in a special `const_data` (for macOS) or `.data.rel.ro` (for ELF) section.  The GNU linker and loader support `.data.rel.ro` but can also manage if relocatable addresses are put in the `.rodata` section.

In this PR, AArch64, ARM, RISC-V and x86 ELF targets are changed to use `.data.rel.ro`.

PowerPC / ELF is unchanged because we use the EABI variant, which has no `.data.rel.ro` section as far as I can see in GCC's output. (The SVR4 variant has `.data.rel.ro` but does not have `.sdata2`, which CompCert uses.)

Fixes: #454