### PR TITLE
SimplExpr: revised handling of nested conditional, `||`, `&&` expressions

### DIFF
--- a/cfrontend/SimplExprproof.v
+++ b/cfrontend/SimplExprproof.v
@@ -1611,7 +1611,7 @@ Ltac NOTIN :=
   apply push_seq. reflexivity. reflexivity.
   rewrite <- Kseqlist_app.
   eapply match_exprstates; eauto.
-  apply S. apply tr_paren_set with (a1 := a2) (t := sd_temp sd); auto.
+  apply S. apply tr_paren_set with (a1 := a2) (t := t); auto.
   apply tr_expr_monotone with tmp2; eauto. auto. auto.
 - (* seqand false *)
   exploit tr_top_leftcontext; eauto. clear TR.
@@ -1720,7 +1720,7 @@ Ltac NOTIN :=
   apply push_seq. reflexivity. reflexivity.
   rewrite <- Kseqlist_app.
   eapply match_exprstates; eauto.
-  apply S. apply tr_paren_set with (a1 := a2) (t := sd_temp sd); auto.
+  apply S. apply tr_paren_set with (a1 := a2) (t := t); auto.
   apply tr_expr_monotone with tmp2; eauto. auto. auto.
 - (* condition *)
   exploit tr_top_leftcontext; eauto. clear TR.

--- a/test/regression/Makefile
+++ b/test/regression/Makefile
@@ -15,7 +15,7 @@ TESTS=int32 int64 floats floats-basics floats-lit \
   volatile1 volatile2 volatile3 volatile4 \
   funct3 expr5 struct7 struct8 struct11 struct12 casts1 casts2 char1 \
   sizeof1 sizeof2 binops bool for1 for2 switch switch2 compound \
-  decl1 bitfields9 ptrs3 \
+  decl1 bitfields9 ptrs3 telescopes \
   parsing krfun ifconv generic
 
 # stringlit charlit # temporarily removed

--- a/test/regression/Results/telescopes
+++ b/test/regression/Results/telescopes
@@ -1,0 +1,7 @@
+orand: 1 0 0 1
+andor: 0 1 1 0
+choose: 23 45
+choose2: 23 45 89 67
+choosed: 23.32 45.54
+choose2d: 23 45 89 67.76
+chooseandl: 23 0 0 1

--- a/test/regression/telescopes.c
+++ b/test/regression/telescopes.c
@@ -1,0 +1,47 @@
+/* Nested `||`, `&&` and ` ? : ` expressions. */
+
+#include <stdio.h>
+
+int orand(int x, int y, int z) { return x || (y && z); }
+
+int andor(int x, int y, int z) { return (x || y) && z; }
+
+int choose(int x, int y, int z) { return x ? y : z; }
+
+int choose2(int a, int x1, int y1, int z1, int x2, int y2, int z2)
+{ return a ? (x1 ? y1 : z1) : (x2 ? y2 : z2); }
+
+double choosed(int x, double y, double z) { return x ? y : z; }
+
+double choose2d(int a, int x1, long long y1, int z1, int x2, double y2, long long z2)
+{ return a ? (x1 ? y1 : z1) : (x2 ? y2 : z2); }
+
+long long chooseandl(int a, long long x, int y, int z)
+{ return a ? x : y && z; }
+
+int main()
+{
+  printf("orand: %d %d %d %d\n",
+         orand(1,0,0), orand(0,1,0), orand(0,0,1), orand(0,1,1));
+  printf("andor: %d %d %d %d\n",
+         andor(0,0,1), andor(1,0,1), andor(0,1,1), andor(1,1,0));
+  printf("choose: %d %d\n",
+         choose(1, 23, 45), choose(0, 23, 45));
+  printf("choose2: %d %d %d %d\n",
+         choose2(1, 1, 23, 45, 0, 67, 89),
+         choose2(1, 0, 23, 45, 0, 67, 89),
+         choose2(0, 0, 23, 45, 0, 67, 89),
+         choose2(0, 0, 23, 45, 1, 67, 89));
+  printf("choosed: %g %g\n",
+         choosed(1, 23.32, 45.54), choosed(0, 23.32, 45.54));
+  printf("choose2d: %g %g %g %g\n",
+         choose2d(1, 1, 23, 45, 0, 67.76, 89),
+         choose2d(1, 0, 23, 45, 0, 67.76, 89),
+         choose2d(0, 0, 23, 45, 0, 67.76, 89),
+         choose2d(0, 0, 23, 45, 1, 67.76, 89));
+  printf("chooseandl: %lld %lld %lld %lld\n",
+         chooseandl(1, 23, 0, 0),
+         chooseandl(0, 23, 0, 1),
+         chooseandl(0, 23, 1, 0),
+         chooseandl(0, 23, 1, 1));
+}


### PR DESCRIPTION
In a `For_set` destination, a temporary can be reused only if it always used with the same type. Otherwise, typing of Cminor code fails later in the compilation pipeline.

This commit implements temporary reuse if and only if the typing constraint is respected.
- For `&&` and `||`, it avoids the possibility of wrong reuse (as reported in #453)
- For nested conditional expressions, it improves a bit the generated code by reusing the temporary when possible.

Fixes: #453 
