### PR TITLE
Adapt to coq/coq#16920

### DIFF
--- a/backend/SelectDivproof.v
+++ b/backend/SelectDivproof.v
@@ -39,7 +39,7 @@ Lemma Zdiv_mul_pos:
   Z.div n d = Z.div (m * n) (two_p (N + l)).
 Proof.
   intros m l l_pos [LO HI] n RANGE.
-  exploit (Z_div_mod_eq n d). auto.
+  generalize (Z_div_mod_eq_full n d).
   set (q := n / d).
   set (r := n mod d).
   intro EUCL.
@@ -105,7 +105,7 @@ Lemma Zdiv_mul_opp:
 Proof.
   intros m l l_pos [LO HI] n RANGE.
   replace (m * (-n)) with (- (m * n)) by ring.
-  exploit (Z_div_mod_eq n d). auto.
+  generalize (Z_div_mod_eq_full n d).
   set (q := n / d).
   set (r := n mod d).
   intro EUCL.
@@ -591,7 +591,6 @@ Proof.
       econstructor; eauto. eapply eval_mod_from_div.
       eapply eval_divu_mul; eauto. simpl; eauto. simpl; eauto.
       rewrite Int.modu_divu. auto.
-      red; intros; subst n2; discriminate.
     * eapply eval_modu_base; eauto. EvalOp.
 Qed.
 
@@ -817,10 +816,9 @@ Proof.
 ** destruct x; simpl in H1; try discriminate.
    destruct (Int64.eq n2 Int64.zero) eqn:Z; inv H1.
    rewrite Int64.modu_divu.
-    econstructor; split; eauto. econstructor. eauto.
-    eapply eval_modl_from_divl; eauto.
-    eapply eval_divlu_mull; eauto.
-    red; intros; subst n2; discriminate Z.
+   econstructor; split; eauto. econstructor. eauto.
+   eapply eval_modl_from_divl; eauto.
+   eapply eval_divlu_mull; eauto.
 ** eapply eval_modlu_base; eauto.
 - eapply eval_modlu_base; eauto.
 Qed.

--- a/cfrontend/Ctypes.v
+++ b/cfrontend/Ctypes.v
@@ -762,7 +762,7 @@ Proof.
   assert (C: forall x y, x * 8 <= y -> x <= bytes_of_bits y).
   { unfold bytes_of_bits; intros. 
     assert (P: 8 > 0) by lia.
-    generalize (Z_div_mod_eq (y + 7) 8 P) (Z_mod_lt (y + 7) 8 P).
+    generalize (Z_div_mod_eq_full (y + 7) 8) (Z_mod_lt (y + 7) 8 P).
     lia. }
   split. lia. apply C. lia.
 Qed.

--- a/common/Values.v
+++ b/common/Values.v
@@ -1254,7 +1254,6 @@ Proof.
   destruct (Int.eq i0 Int.zero) eqn:?; inv H.
   exists (Vint (Int.divu i i0)); split; auto.
   simpl. rewrite Int.modu_divu. auto.
-  generalize (Int.eq_spec i0 Int.zero). rewrite Heqb; auto.
 Qed.
 
 Theorem modls_divls:
@@ -1276,7 +1275,6 @@ Proof.
   destruct (Int64.eq i0 Int64.zero) eqn:?; inv H.
   exists (Vlong (Int64.divu i i0)); split; auto.
   simpl. rewrite Int64.modu_divu. auto.
-  generalize (Int64.eq_spec i0 Int64.zero). rewrite Heqb; auto.
 Qed.
 
 Theorem divs_pow2:

--- a/lib/Coqlib.v
+++ b/lib/Coqlib.v
@@ -436,7 +436,7 @@ Lemma Zdiv_interval_1:
   lo <= a/b < hi.
 Proof.
   intros.
-  generalize (Z_div_mod_eq a b H1). generalize (Z_mod_lt a b H1). intros.
+  generalize (Z_div_mod_eq_full a b). generalize (Z_mod_lt a b H1). intros.
   set (q := a/b) in *. set (r := a mod b) in *.
   split.
   assert (lo < (q + 1)).
@@ -511,7 +511,7 @@ Definition align (n: Z) (amount: Z) :=
 Lemma align_le: forall x y, y > 0 -> x <= align x y.
 Proof.
   intros. unfold align.
-  generalize (Z_div_mod_eq (x + y - 1) y H). intro.
+  generalize (Z_div_mod_eq_full (x + y - 1) y). intro.
   replace ((x + y - 1) / y * y)
      with ((x + y - 1) - (x + y - 1) mod y).
   generalize (Z_mod_lt (x + y - 1) y H). lia.
@@ -526,7 +526,7 @@ Qed.
 Lemma align_lt: forall x y, y > 0 -> align x y < x + y.
 Proof.
   intros. unfold align.
-  generalize (Z_div_mod_eq (x + y - 1) y H); intro.
+  generalize (Z_div_mod_eq_full (x + y - 1) y); intro.
   generalize (Z_mod_lt (x + y - 1) y H); intro.
   lia.
 Qed.
@@ -549,7 +549,7 @@ Lemma floor_interval:
   forall x y, y > 0 -> floor x y <= x < floor x y + y.
 Proof.
   unfold floor; intros.
-  generalize (Z_div_mod_eq x y H) (Z_mod_lt x y H).
+  generalize (Z_div_mod_eq_full x y) (Z_mod_lt x y H).
   set (q := x / y). set (r := x mod y). intros. lia.
 Qed.
 

--- a/lib/Integers.v
+++ b/lib/Integers.v
@@ -468,7 +468,7 @@ Qed.
 Lemma eqm_unsigned_repr:
   forall z, eqm z (unsigned (repr z)).
 Proof.
-  unfold eqm; intros. rewrite unsigned_repr_eq. apply eqmod_mod. auto with ints.
+  unfold eqm; intros. rewrite unsigned_repr_eq. apply eqmod_mod.
 Qed.
 Global Hint Resolve eqm_unsigned_repr: ints.
 
@@ -948,29 +948,25 @@ Qed.
 (** ** Properties of division and modulus *)
 
 Lemma modu_divu_Euclid:
-  forall x y, y <> zero -> x = add (mul (divu x y) y) (modu x y).
+  forall x y, x = add (mul (divu x y) y) (modu x y).
 Proof.
   intros. unfold add, mul, divu, modu.
   transitivity (repr (unsigned x)). auto with ints.
   apply eqm_samerepr.
   set (x' := unsigned x). set (y' := unsigned y).
   apply eqm_trans with ((x' / y') * y' + x' mod y').
-  apply eqm_refl2. rewrite Z.mul_comm. apply Z_div_mod_eq.
-  generalize (unsigned_range y); intro.
-  assert (unsigned y <> 0). red; intro.
-  elim H. rewrite <- (repr_unsigned y). unfold zero. congruence.
-  unfold y'. lia.
+  apply eqm_refl2. rewrite Z.mul_comm. apply Z_div_mod_eq_full.
   auto with ints.
 Qed.
 
 Theorem modu_divu:
-  forall x y, y <> zero -> modu x y = sub x (mul (divu x y) y).
+  forall x y, modu x y = sub x (mul (divu x y) y).
 Proof.
   intros.
   assert (forall a b c, a = add b c -> c = sub a b).
   intros. subst a. rewrite sub_add_l. rewrite sub_idem.
   rewrite add_commut. rewrite add_zero. auto.
-  apply H0. apply modu_divu_Euclid. auto.
+  apply H. apply modu_divu_Euclid.
 Qed.
 
 Lemma mods_divs_Euclid:
@@ -1013,7 +1009,6 @@ Theorem modu_one:
   forall x, modu x one = zero.
 Proof.
   intros. rewrite modu_divu. rewrite divu_one. rewrite mul_one. apply sub_idem.
-  apply one_not_zero.
 Qed.
 
 Theorem divs_mone:
@@ -1936,7 +1931,7 @@ Lemma bits_rol:
   testbit (rol x y) i = testbit x ((i - unsigned y) mod zwordsize).
 Proof.
   intros. unfold rol.
-  exploit (Z_div_mod_eq (unsigned y) zwordsize). apply wordsize_pos.
+  generalize (Z_div_mod_eq_full (unsigned y) zwordsize).
   set (j := unsigned y mod zwordsize). set (k := unsigned y / zwordsize).
   intros EQ.
   exploit (Z_mod_lt (unsigned y) zwordsize). apply wordsize_pos.
@@ -1964,7 +1959,7 @@ Lemma bits_ror:
   testbit (ror x y) i = testbit x ((i + unsigned y) mod zwordsize).
 Proof.
   intros. unfold ror.
-  exploit (Z_div_mod_eq (unsigned y) zwordsize). apply wordsize_pos.
+  generalize (Z_div_mod_eq_full (unsigned y) zwordsize).
   set (j := unsigned y mod zwordsize). set (k := unsigned y / zwordsize).
   intros EQ.
   exploit (Z_mod_lt (unsigned y) zwordsize). apply wordsize_pos.
@@ -2071,13 +2066,13 @@ Proof.
   set (M := unsigned m); set (N := unsigned n).
   apply eqmod_trans with (i - M - N).
   apply eqmod_sub.
-  apply eqmod_sym. apply eqmod_mod. apply wordsize_pos.
+  apply eqmod_sym. apply eqmod_mod.
   apply eqmod_refl.
   replace (i - M - N) with (i - (M + N)) by lia.
   apply eqmod_sub.
   apply eqmod_refl.
   apply eqmod_trans with (Z.modulo (unsigned n + unsigned m) zwordsize).
-  replace (M + N) with (N + M) by lia. apply eqmod_mod. apply wordsize_pos.
+  replace (M + N) with (N + M) by lia. apply eqmod_mod.
   unfold modu, add. fold M; fold N. rewrite unsigned_repr_wordsize.
   assert (forall a, eqmod zwordsize a (unsigned (repr a))).
     intros. eapply eqmod_divides. apply eqm_unsigned_repr. assumption.
@@ -2800,7 +2795,6 @@ Lemma eqmod_zero_ext:
   forall n x, 0 <= n < zwordsize -> eqmod (two_p n) (unsigned (zero_ext n x)) (unsigned x).
 Proof.
   intros. rewrite zero_ext_mod; auto. apply eqmod_sym. apply eqmod_mod.
-  apply two_p_gt_ZERO. lia.
 Qed.
 
 (** [sign_ext n x] is the unique integer congruent to [x] modulo [2^n]
@@ -4506,7 +4500,7 @@ Proof.
   set (p := Int.unsigned x * Int.unsigned y).
   set (ph := p / Int.modulus). set (pl := p mod Int.modulus).
   transitivity (repr (ph * Int.modulus + pl)).
-- f_equal. rewrite Z.mul_comm. apply Z_div_mod_eq. apply Int.modulus_pos.
+- f_equal. rewrite Z.mul_comm. apply Z_div_mod_eq_full.
 - apply eqm_samerepr. apply eqm_add. apply eqm_mul_2p32. auto with ints.
   rewrite Int.unsigned_repr_eq. apply eqm_refl.
 Qed.

--- a/lib/Zbits.v
+++ b/lib/Zbits.v
@@ -72,7 +72,7 @@ Lemma eqmod_mod:
   forall x, eqmod x (x mod modul).
 Proof.
   intros; red. exists (x / modul).
-  rewrite Z.mul_comm. apply Z_div_mod_eq. auto.
+  rewrite Z.mul_comm. apply Z_div_mod_eq_full.
 Qed.
 
 Lemma eqmod_add:
@@ -187,7 +187,7 @@ Proof.
   - rewrite Zmod_0_l. auto.
   - apply P_mod_two_p_eq.
   - generalize (P_mod_two_p_range n p) (P_mod_two_p_eq n p). intros A B.
-    exploit (Z_div_mod_eq (Zpos p) (two_power_nat n)); auto. intros C.
+    assert (C := Z_div_mod_eq_full (Zpos p) (two_power_nat n)).
     set (q := Zpos p / two_power_nat n) in *.
     set (r := P_mod_two_p p n) in *.
     rewrite <- B in C.
@@ -479,7 +479,7 @@ Proof.
       apply Zmod_unique with (x1 / two_p x).
       rewrite !Zshiftin_spec. rewrite Z.add_assoc. f_equal.
       transitivity (2 * (two_p x * (x1 / two_p x) + x1 mod two_p x)).
-      f_equal. apply Z_div_mod_eq. apply two_p_gt_ZERO; auto.
+      f_equal. apply Z_div_mod_eq_full.
       ring.
       rewrite Zshiftin_spec. exploit (Z_mod_lt x1 (two_p x)). apply two_p_gt_ZERO; auto.
       destruct (Z.odd x0); lia.
@@ -658,7 +658,6 @@ Lemma eqmod_Zzero_ext:
   forall n x, 0 <= n -> eqmod (two_p n) (Zzero_ext n x) x.
 Proof.
   intros. rewrite Zzero_ext_mod; auto. apply eqmod_sym. apply eqmod_mod.
-  apply two_p_gt_ZERO. lia.
 Qed.
 
 (** Relation between [Zsign_ext n x] and (Zzero_ext n x] *)
@@ -943,7 +942,7 @@ Proof.
        exploit (Z_mod_lt (x + y - 1) y); auto.
        rewrite Z.abs_eq. lia. lia.
      + transitivity ((y * ((x + y - 1) / y) + (x + y - 1) mod y) - (y-1)).
-       rewrite <- Z_div_mod_eq. ring. auto. ring.
+       rewrite <- Z_div_mod_eq_full. ring. ring.
   - apply Zquot_Zdiv_pos; lia.
 Qed.
 
@@ -951,7 +950,7 @@ Lemma Zdiv_shift:
   forall x y, y > 0 ->
   (x + (y - 1)) / y = x / y + if zeq (Z.modulo x y) 0 then 0 else 1.
 Proof.
-  intros. generalize (Z_div_mod_eq x y H). generalize (Z_mod_lt x y H).
+  intros. generalize (Z_div_mod_eq_full x y). generalize (Z_mod_lt x y H).
   set (q := x / y). set (r := x mod y). intros.
   destruct (zeq r 0).
   apply Zdiv_unique with (y - 1). rewrite H1. rewrite e. ring. lia.


### PR DESCRIPTION
Use `Z_div_mod_eq_full` instead of deprecated `Z_div_mod_eq` (coq/coq#16920).