### PR TITLE
for consistency: print flt.s, feq.s, fle.s with a tab after the mnemonic

### DIFF
--- a/riscV/TargetPrinter.ml
+++ b/riscV/TargetPrinter.ml
@@ -404,11 +404,11 @@ module Target : TARGET =
          fprintf oc "	fmax.s	%a, %a, %a\n" freg fd freg fs1 freg fs2
 
       | Pfeqs (rd, fs1, fs2) ->
-         fprintf oc "	feq.s   %a, %a, %a\n" ireg rd freg fs1 freg fs2
+         fprintf oc "	feq.s	%a, %a, %a\n" ireg rd freg fs1 freg fs2
       | Pflts (rd, fs1, fs2) ->
-         fprintf oc "	flt.s   %a, %a, %a\n" ireg rd freg fs1 freg fs2
+         fprintf oc "	flt.s	%a, %a, %a\n" ireg rd freg fs1 freg fs2
       | Pfles (rd, fs1, fs2) ->
-         fprintf oc "	fle.s   %a, %a, %a\n" ireg rd freg fs1 freg fs2
+         fprintf oc "	fle.s	%a, %a, %a\n" ireg rd freg fs1 freg fs2
 
       | Pfsqrts (fd, fs) ->
          fprintf oc "	fsqrt.s %a, %a\n"     freg fd freg fs


### PR DESCRIPTION
All RISC-V instructions are printed with a TAB after the mnemonic, except these three single-precision comparisons. I suppose this is an oversight.