### PR TITLE
Improved register allocation for ARM udiv and sdiv.

### DIFF
--- a/arm/Archi.v
+++ b/arm/Archi.v
@@ -100,3 +100,6 @@ Parameter abi: abi_kind.
 (** Whether instructions added with Thumb2 are supported. True for ARMv6T2
   and above. *)
 Parameter thumb2_support: bool.
+
+(** Whether the hardware supports sdiv and udiv *)
+Parameter hardware_idiv : unit -> bool.

--- a/arm/Asm.v
+++ b/arm/Asm.v
@@ -173,10 +173,10 @@ Inductive instruction : Type :=
   | Pstr_a: ireg -> ireg -> shift_op -> instruction (**r any32 store from int register *)
   | Pstrb: ireg -> ireg -> shift_op -> instruction (**r int8 store *)
   | Pstrh: ireg -> ireg -> shift_op -> instruction (**r int16 store *)
-  | Psdiv: instruction                              (**r signed division *)
+  | Psdiv: ireg -> ireg -> ireg     -> instruction (**r signed division *)
   | Psmull: ireg -> ireg -> ireg -> ireg -> instruction (**r signed multiply long *)
   | Psub: ireg -> ireg -> shift_op -> instruction  (**r integer subtraction *)
-  | Pudiv: instruction                             (**r unsigned division *)
+  | Pudiv: ireg -> ireg -> ireg -> instruction     (**r unsigned division *)
   | Pumull: ireg -> ireg -> ireg -> ireg -> instruction (**r unsigned multiply long *)
   (* Floating-point coprocessor instructions (VFP double scalar operations) *)
   | Pfcpyd: freg -> freg -> instruction             (**r float move *)
@@ -657,11 +657,9 @@ Definition exec_instr (f: function) (i: instruction) (rs: regset) (m: mem) : out
       exec_store Mint8unsigned (Val.add rs#r2 (eval_shift_op sa rs)) r1 rs m
   | Pstrh r1 r2 sa =>
       exec_store Mint16unsigned (Val.add rs#r2 (eval_shift_op sa rs)) r1 rs m
-  | Psdiv =>
-      match Val.divs rs#IR0 rs#IR1 with
-      | Some v => Next (nextinstr (rs#IR0 <- v
-                                     #IR1 <- Vundef #IR2 <- Vundef
-                                     #IR3 <- Vundef #IR12 <- Vundef)) m
+  | Psdiv r1 r2 r3 =>
+      match Val.divs rs#r2 rs#r3 with
+      | Some v => Next (nextinstr (rs#r1 <- v )) m
       | None => Stuck
       end
   | Psbfx r1 r2 lsb sz =>
@@ -671,11 +669,9 @@ Definition exec_instr (f: function) (i: instruction) (rs: regset) (m: mem) : out
                          #rdh <- (Val.mulhs rs#r1 rs#r2))) m
   | Psub r1 r2 so =>
       Next (nextinstr_nf (rs#r1 <- (Val.sub rs#r2 (eval_shift_op so rs)))) m
-  | Pudiv =>
-      match Val.divu rs#IR0 rs#IR1 with
-      | Some v => Next (nextinstr (rs#IR0 <- v
-                                     #IR1 <- Vundef #IR2 <- Vundef
-                                     #IR3 <- Vundef #IR12 <- Vundef)) m
+  | Pudiv r1 r2 r3 =>
+      match Val.divu rs#r2 rs#r3 with
+      | Some v => Next (nextinstr (rs#r1 <- v)) m
       | None => Stuck
       end
   | Pumull rdl rdh r1 r2 =>

--- a/arm/AsmToJSON.ml
+++ b/arm/AsmToJSON.ml
@@ -278,7 +278,7 @@ let pp_instructions pp ic =
     | Prsc(r1, r2, so) -> instruction pp "Prsc" [Ireg r1; Ireg r2; Shift so]
     | Psbc(r1, r2, so) -> instruction pp "Psbc" [Ireg r1; Ireg r2; Shift so]
     | Psbfx(r1, r2, lsb, sz) -> instruction pp "Psbfx" [Ireg r1; Ireg r2; Long lsb; Long sz]
-    | Psdiv -> instruction pp "Psdiv" [Ireg IR0; Ireg IR0; Ireg IR1]
+    | Psdiv(r1,r2,r3) -> instruction pp "Psdiv" [Ireg r1; Ireg r2; Ireg r3]
     | Psmull(r1, r2, r3, r4) -> instruction pp "Psmull" [Ireg r1; Ireg r2; Ireg r3; Ireg r4]
     | Pstr(r1, r2, so) | Pstr_a(r1, r2, so) -> instruction pp "Pstr" [Ireg r1; Ireg r2; Shift so]
     | Pstr_p(r1, r2, so) -> instruction pp "Pstr_p" [Ireg r1; Ireg r2; Shift so]
@@ -288,7 +288,7 @@ let pp_instructions pp ic =
     | Pstrh_p(r1, r2, so) -> instruction pp "Pstrh_p" [Ireg r1; Ireg r2; Shift so]
     | Psub(r1, r2, so) -> instruction pp "Psub" [Ireg r1; Ireg r2; Shift so]
     | Psubs(r1, r2, so) -> instruction pp "Psubs" [Ireg r1; Ireg r2; Shift so]
-    | Pudiv -> instruction pp "Pudiv" [Ireg IR0; Ireg IR0; Ireg IR1]
+    | Pudiv(r1,r2,r3) -> instruction pp "Pudiv" [Ireg r1; Ireg r2; Ireg r3]
     | Pumull(r1, r2, r3, r4) -> instruction pp "Pumull" [Ireg r1; Ireg r2; Ireg r3; Ireg r4]
     (* Fixup instructions for calling conventions *)
     | Pfcpy_fs(r1, r2) -> instruction pp "Pfcpy_fs" [SFreg r1; SPreg r2]

--- a/arm/Asmexpand.ml
+++ b/arm/Asmexpand.ml
@@ -413,6 +413,16 @@ let expand_builtin_inline name args res =
   (* Optimization hint *)
   | "__builtin_unreachable", [], _ ->
      ()
+  (* Soft integer division *)
+  | "__aeabi_idiv", args , res ->
+     assert ((args,res) = ([BA(IR IR0); BA(IR IR1)] , BR (IR IR0)));
+     let id = intern_string "__aeabi_idiv" in
+     emit (Pblsymb(id,Builtins1.platform_builtin_sig Builtins1.BI_idiv))
+  | "__aeabi_uidiv", args , res ->
+     assert ((args,res) = ([BA(IR IR0); BA(IR IR1)] , BR (IR IR0)));
+     let id = intern_string "__aeabi_uidiv" in
+     emit (Pblsymb(id,Builtins1.platform_builtin_sig Builtins1.BI_uidiv))
+
   (* Catch-all *)
   | _ ->
       raise (Error ("unrecognized builtin " ^ name))

--- a/arm/Asmgen.v
+++ b/arm/Asmgen.v
@@ -417,15 +417,11 @@ Definition transl_op
       do r <- ireg_of res; do r1 <- ireg_of a1; do r2 <- ireg_of a2;
       OK (Pumull IR14 r r1 r2 :: k)
   | Odiv, a1 :: a2 :: nil =>
-      assertion (mreg_eq res R0);
-      assertion (mreg_eq a1 R0);
-      assertion (mreg_eq a2 R1);
-      OK (Psdiv :: k)
+      do r <- ireg_of res; do r1 <- ireg_of a1 ; do r2 <- ireg_of a2;
+      OK (Psdiv r r1 r2:: k)
   | Odivu, a1 :: a2 :: nil =>
-      assertion (mreg_eq res R0);
-      assertion (mreg_eq a1 R0);
-      assertion (mreg_eq a2 R1);
-      OK (Pudiv :: k)
+      do r <- ireg_of res; do r1 <- ireg_of a1 ; do r2 <- ireg_of a2;
+      OK (Pudiv r r1 r2:: k)
   | Oand, a1 :: a2 :: nil =>
       do r <- ireg_of res; do r1 <- ireg_of a1; do r2 <- ireg_of a2;
       OK (Pand r r1 (SOreg r2) :: k)

--- a/arm/Builtins1.v
+++ b/arm/Builtins1.v
@@ -20,15 +20,40 @@ Require Import String Coqlib.
 Require Import AST Integers Floats Values.
 Require Import Builtins0.
 
-Inductive platform_builtin : Type := .
+Inductive platform_builtin : Type :=
+| BI_idiv
+| BI_uidiv.
 
 Local Open Scope string_scope.
 
 Definition platform_builtin_table : list (string * platform_builtin) :=
-  nil.
+  ("__aeabi_idiv", BI_idiv) ::   ("__aeabi_uidiv", BI_uidiv) :: nil.
 
 Definition platform_builtin_sig (b: platform_builtin) : signature :=
-  match b with end.
+  match b with
+  | BI_idiv | BI_uidiv => mksignature (Tint :: Tint :: nil) Tint cc_default
+  end.
+
+Definition divs (n1 n2: int) : option int :=
+  if Int.eq n2 Int.zero || Int.eq n1 (Int.repr Int.min_signed) && Int.eq n2 Int.mone then None else Some (Int.divs n1 n2).
+
+Remark divs_is_divs : forall n1 n2, Val.divs (Vint n1) (Vint n2) = option_map Vint (divs n1 n2).
+Proof.
+  unfold divs. simpl. intros.
+  destruct (Int.eq n2 Int.zero || Int.eq n1 (Int.repr Int.min_signed) && Int.eq n2 Int.mone);reflexivity.
+Qed.
+
+Definition divu (n1 n2: int) : option int :=
+  if Int.eq n2 Int.zero then None else Some (Int.divu n1 n2).
+
+Remark divu_is_divu : forall n1 n2, Val.divu (Vint n1) (Vint n2) = option_map Vint (divu n1 n2).
+Proof.
+  unfold divu. simpl. intros.
+  destruct (Int.eq n2 Int.zero);reflexivity.
+Qed.
 
 Definition platform_builtin_sem (b: platform_builtin) : builtin_sem (sig_res (platform_builtin_sig b)) :=
-  match b with end.
+  match b with
+  | BI_idiv => mkbuiltin_n2p Tint Tint (Tret Tint) divs
+  | BI_uidiv => mkbuiltin_n2p Tint Tint (Tret Tint) divu
+  end.

--- a/arm/SelectOp.vp
+++ b/arm/SelectOp.vp
@@ -276,19 +276,26 @@ Nondetfunction xor (e1: expr) (e2: expr) :=
 
 (** ** Integer division and modulus *)
 
-Definition mod_aux (divop: operation) (e1 e2: expr) :=
+Definition mod_aux (divop: expr -> expr -> expr) (e1 e2: expr) :=
   Elet e1
     (Elet (lift e2)
       (Eop Osub (Eletvar 1 :::
-                 Eop Omul (Eop divop (Eletvar 1 ::: Eletvar 0 ::: Enil) :::
+                 Eop Omul (divop (Eletvar 1) (Eletvar 0) :::
                            Eletvar 0 :::
                            Enil) :::
                  Enil))).
 
-Definition divs_base (e1: expr) (e2: expr) := Eop Odiv (e1:::e2:::Enil).
-Definition mods_base := mod_aux Odiv.
-Definition divu_base (e1: expr) (e2: expr) := Eop Odivu (e1:::e2:::Enil).
-Definition modu_base := mod_aux Odivu.
+Definition divs_base :=
+  if Archi.hardware_idiv tt then fun (e1: expr) (e2: expr) => Eop Odiv (e1:::e2:::Enil)
+  else fun (e1: expr) (e2: expr) => Ebuiltin (EF_builtin "__aeabi_idiv" (platform_builtin_sig BI_idiv)) (e1::: e2:::Enil).
+
+Definition mods_base := mod_aux divs_base.
+
+Definition divu_base :=
+  if Archi.hardware_idiv tt then fun (e1: expr) (e2: expr) =>  Eop Odivu (e1:::e2:::Enil)
+  else fun (e1: expr) (e2: expr) => Ebuiltin (EF_builtin "__aeabi_uidiv" (platform_builtin_sig BI_uidiv)) (e1::: e2:::Enil).
+
+Definition modu_base := mod_aux divu_base.
 
 Definition shrximm (e1: expr) (n2: int) :=
   if Int.eq n2 Int.zero then e1 else Eop (Oshrximm n2) (e1:::Enil).

--- a/arm/TargetPrinter.ml
+++ b/arm/TargetPrinter.ml
@@ -323,11 +323,9 @@ struct
       fprintf oc "	strb	%a, [%a], %a\n" ireg r1 ireg r2 shift_op sa
     | Pstrh_p(r1, r2, sa) ->
       fprintf oc "	strh	%a, [%a], %a\n" ireg r1 ireg r2 shift_op sa
-    | Psdiv ->
-      if Opt.hardware_idiv then
-        fprintf oc "	sdiv	r0, r0, r1\n"
-      else
-        fprintf oc "	bl	__aeabi_idiv\n"
+    | Psdiv(r1,r2,r3) ->
+       assert Opt.hardware_idiv;
+        fprintf oc "	sdiv	%a, %a, %a\n" ireg r1 ireg r2 ireg r3
     | Psbfx(r1, r2, lsb, sz) ->
       fprintf oc "	sbfx	%a, %a, #%a, #%a\n" ireg r1 ireg r2 coqint lsb coqint sz
     | Psmull(r1, r2, r3, r4) ->
@@ -338,11 +336,9 @@ struct
     | Psubs(r1, r2, so) ->
       fprintf oc "	subs	%a, %a, %a\n"
         ireg r1 ireg r2 shift_op so
-    | Pudiv ->
-      if Opt.hardware_idiv then
-        fprintf oc "	udiv	r0, r0, r1\n"
-      else
-         fprintf oc "	bl	__aeabi_uidiv\n"
+    | Pudiv(r1,r2,r3)->
+       assert Opt.hardware_idiv;
+        fprintf oc "	udiv	%a, %a, %a\n" ireg r1 ireg r2 ireg r3
     | Pumull(r1, r2, r3, r4) ->
       fprintf oc "	umull	%a, %a, %a, %a\n" ireg r1 ireg r2 ireg r3 ireg r4
     (* Floating-point VFD instructions *)

--- a/arm/extractionMachdep.v
+++ b/arm/extractionMachdep.v
@@ -36,3 +36,10 @@ Extract Constant Archi.big_endian =>
 (* Whether the model is ARMv6T2 or above and hence supports Thumb2. *)
 Extract Constant Archi.thumb2_support =>
   "(Configuration.model = ""armv6t2"" || Configuration.model >= ""armv7"")".
+
+(* Whether the model features hardware division (see TargetPrinter.sel_target) *)
+Extract Constant Archi.hardware_idiv =>
+  "fun () -> begin match  Configuration.model with
+   | ""armv7r"" | ""armv7m"" -> !Clflags.option_mthumb
+   | _ -> false
+   end".


### PR DESCRIPTION
To accommodate hardware with and without support for integer division, the ARM backend imposes strong constraints on register allocation.

For hardware with support for integer division, the PR lifts this restriction.
For hardware without support for integer division, instruction selection generates builtins.

*NB* Though this requires more testing, I think this is worth sharing.