### PR TITLE
Use a shorter insruction on x86 for loading unsigned 32-bit immediates into 64-bit registers.

### DIFF
--- a/x86/TargetPrinter.ml
+++ b/x86/TargetPrinter.ml
@@ -432,7 +432,9 @@ module Target(System: SYSTEM):TARGET =
       | Pmovq_ri(rd, n) ->
           let n1 = camlint64_of_coqint n in
           let n2 = Int64.to_int32 n1 in
-          if n1 = Int64.of_int32 n2 then
+          if Int64.shift_right_logical n1 32 = Int64.zero then
+            fprintf oc "	movl	$%Ld, %a\n" n1 ireg32 rd
+          else if n1 = Int64.of_int32 n2 then
             fprintf oc "	movq	$%ld, %a\n" n2 ireg64 rd
           else
             fprintf oc "	movabsq	$%Ld, %a\n" n1 ireg64 rd


### PR DESCRIPTION
Writing into a 32-bit register erases the upper 32 bits of a 64-bit register. This is the shortest instruction for loading unsigned 32-bit immediates. The length of those instructions is:
- movl: 5 bytes
- movq: 7 bytes
- movabsq: 10 bytes

Note: Most assemblers will choose the proper instruction by themselves;  this commit just makes this explicit.