### PR TITLE
'spass' test: correctly typed function call

### DIFF
--- a/test/spass/cnf.c
+++ b/test/spass/cnf.c
@@ -2758,7 +2758,7 @@ static LIST cnf_FreeVariablesBut(TERM Term, LIST Symbols)
   follist = fol_FreeVariables(Term);
   for (Scan = follist; !list_Empty(Scan); Scan = list_Cdr(Scan))
     if (list_Member(Symbols, (POINTER)term_TopSymbol(list_Car(Scan)),
-		    (BOOL (*)(POINTER,POINTER))symbol_Equal))
+		    symbol_PtrEqual))
       list_Rplaca(Scan,NULL);
   follist = list_PointerDeleteElement(follist,NULL);
     

--- a/test/spass/symbol.h
+++ b/test/spass/symbol.h
@@ -178,6 +178,11 @@ static __inline__ BOOL symbol_Equal(SYMBOL A, SYMBOL B)
   return A==B;
 }
 
+static __inline__ BOOL symbol_PtrEqual(POINTER A, POINTER B)
+{
+  return symbol_Equal((SYMBOL) A, (SYMBOL) B);
+}
+
 static __inline__ BOOL symbol_IsSignature(SYMBOL S)
 {
   return S < 0;


### PR DESCRIPTION
'Spass' is implemented using forms of data abstraction making use of function pointers. Also, some integer values are hidden inside function pointers.

The benchmark, at some point, casts a function pointer for a function taking two integer parameters into a pointer for a function taking two pointer parameters. Then this function is called with pointer parameters.

This seems to me incorrect with respect to the C standard.

In CompCert, if applying inlining after constant propagation, this leads to an ill-typed function.

My proposed fix is to use correctly-typed function pointers.