### PR TITLE
fix some vlub non monotonic behavior

### DIFF
--- a/backend/ValueDomain.v
+++ b/backend/ValueDomain.v
@@ -918,7 +918,7 @@ Definition vlub (v w: aval) : aval :=
       else uns p (Z.max (usize i) n)
   | I i, Sgn p n | Sgn p n, I i =>
       sgn p (Z.max (ssize i) n)
-  | I i, (Ptr p | Ifptr p) | (Ptr p | Ifptr p), I i => Ifptr p
+  | (I _ | L _), (Ptr p | Ifptr p) | (Ptr p | Ifptr p), (I _ | L _) => Ifptr p
   | Uns p1 n1, Uns p2 n2 => Uns (plub p1 p2) (Z.max n1 n2)
   | Uns p1 n1, Sgn p2 n2 => sgn (plub p1 p2) (Z.max (n1 + 1) n2)
   | Sgn p1 n1, Uns p2 n2 => sgn (plub p1 p2) (Z.max n1 (n2 + 1))

--- a/backend/ValueDomain.v
+++ b/backend/ValueDomain.v
@@ -918,7 +918,7 @@ Definition vlub (v w: aval) : aval :=
       else uns p (Z.max (usize i) n)
   | I i, Sgn p n | Sgn p n, I i =>
       sgn p (Z.max (ssize i) n)
-  | (I _ | L _), (Ptr p | Ifptr p) | (Ptr p | Ifptr p), (I _ | L _) => Ifptr p
+  | (I _ | L _ | F _ | FS _), (Ptr p | Ifptr p) | (Ptr p | Ifptr p), (I _ | L _ | F _ | FS _) => Ifptr p
   | Uns p1 n1, Uns p2 n2 => Uns (plub p1 p2) (Z.max n1 n2)
   | Uns p1 n1, Sgn p2 n2 => sgn (plub p1 p2) (Z.max (n1 + 1) n2)
   | Sgn p1 n1, Uns p2 n2 => sgn (plub p1 p2) (Z.max n1 (n2 + 1))
@@ -935,7 +935,6 @@ Definition vlub (v w: aval) : aval :=
   | Ifptr p1, Ifptr p2 => Ifptr(plub p1 p2)
   | (Ptr p1 | Ifptr p1), (Uns p2 _ | Sgn p2 _) => Ifptr(plub p1 p2)
   | (Uns p1 _ | Sgn p1 _), (Ptr p2 | Ifptr p2) => Ifptr(plub p1 p2)
-  | _, (Ptr p | Ifptr p) | (Ptr p | Ifptr p), _ => if va_strict tt then Ifptr p else Vtop
   | _, _ => Vtop
   end.
 


### PR DESCRIPTION
Previously, `vlub (Ifptr Pbot) (I i)` produced `Ifptr Ptop` if `va_strict tt` was false, yet `vlub (Ifptr Pbot) (Ifptr bot)` was `Ifptr Pbot`.
 
Not only this was non-monotonic, it also resulted in integer sequences (`i`=0, 1, …) being over-approximated by `Ifptr Ptop`, as opposed to `Ifptr Pbot`. This in turn resulted in e.g. being unable to conclude that `t+i` was `Nonstack` if `t` was `Nonstack`.

Note: there remain some non-monotonic behaviors in `vlub`, which I have not fixed.
