### PR TITLE
Revert "Do not print cfi_sections for bsd."

### DIFF
--- a/x86/TargetPrinter.ml
+++ b/x86/TargetPrinter.ml
@@ -900,7 +900,7 @@ module Target(System: SYSTEM):TARGET =
       need_masks := false;
       if !Clflags.option_g then begin
         section oc Section_text;
-        if Configuration.system <> "bsd" then cfi_section oc
+        cfi_section oc
       end
 
     let print_epilogue oc =


### PR DESCRIPTION
0af96302ae861e35c7e2dace1182e30be0b67851

FreeBSD / OpenBSD no longer use ancient binutils assembler.