### PR TITLE
a patch to Makefile.menhir for ocaml-non-native architctures.

### DIFF
--- a/Makefile.menhir
+++ b/Makefile.menhir
@@ -42,10 +42,18 @@ MENHIR_FLAGS = -v --no-stdlib -la 1
 # Using Menhir in --table mode requires MenhirLib.
 
 ifeq ($(MENHIR_TABLE),true)
-  ifeq ($(wildcard $(MENHIR_DIR)/menhirLib.cmxa),)
-    MENHIR_LIBS = menhirLib.cmx
+  ifeq ($(OCAML_NATIVE_COMP), true)
+    ifeq ($(wildcard $(MENHIR_DIR)/menhirLib.cmxa),)
+      MENHIR_LIBS = menhirLib.cmx
+    else
+      MENHIR_LIBS = menhirLib.cmxa
+    endif
   else
-    MENHIR_LIBS = menhirLib.cmxa
+    ifeq ($(wildcard $(MENHIR_DIR)/menhirLib.cma),)
+      MENHIR_LIBS = menhirLib.cmo
+    else
+      MENHIR_LIBS = menhirLib.cma
+    endif
   endif
 else
   MENHIR_LIBS =


### PR DESCRIPTION
OpenBSD ports recently updated CompCert to 3.13, but does not work for ocaml-non-native architectures.
The problem comes from Makefile.menhir expecting either menhirLib.cmxa or .cmx is available.
It assumes ocaml native compilation environment.

This patch adds one more condition using OCAML_NATIVE_COMP which is prepared by configure, to adjust MENHIR_LIBS according to ocaml-native or ocaml-non-native environment.
I confirmed this patch works in OpenBSD ports, and believe it's useful for any other environments.