### PR TITLE
To use movt/movw, what matters is not whether the processor is in Thu…

### DIFF
--- a/arm/Constantexpand.ml
+++ b/arm/Constantexpand.ml
@@ -162,7 +162,7 @@ let expand_instruction = function
     end
   | Ploadsymbol(r1, id, ofs) ->
     let o = camlint_of_coqint ofs in
-    if o >= -32768l && o <= 32767l && !Clflags.option_mthumb then begin
+    if o >= -32768l && o <= 32767l && Archi.thumb2_support then begin
       emit (Ploadsymbol_imm (r1,id,ofs));
       2
     end else begin


### PR DESCRIPTION
…mb2 mode, but whether the processor supports Thumb2 mode. These instructions are also available in ARM mode on such processors.