### PR TITLE
More precise value analysis for "known integer or Vundef" results

### DIFF
--- a/aarch64/ConstpropOp.vp
+++ b/aarch64/ConstpropOp.vp
@@ -23,7 +23,7 @@ Require SelectOp.
 
 Definition const_for_result (a: aval) : option operation :=
   match a with
-  | I n => Some(Ointconst n)
+  | I n | IU n => Some(Ointconst n)
   | L n => Some(Olongconst n)
   | F n => if Compopts.generate_float_constants tt then Some(Ofloatconst n) else None
   | FS n => if Compopts.generate_float_constants tt then Some(Osingleconst n) else None

--- a/aarch64/ConstpropOpproof.v
+++ b/aarch64/ConstpropOpproof.v
@@ -92,6 +92,8 @@ Proof.
   unfold const_for_result; intros; destruct a; inv H; SimplVM.
 - (* integer *)
   exists (Vint n); auto.
+- (* integer or undef *)
+  exists (Vint n); split; auto. inv H0; auto.
 - (* long *)
   exists (Vlong n); auto.
 - (* float *)

--- a/arm/ConstpropOp.vp
+++ b/arm/ConstpropOp.vp
@@ -26,7 +26,7 @@ Require Import ValueDomain ValueAOp.
 
 Definition const_for_result (a: aval) : option operation :=
   match a with
-  | I n => Some(Ointconst n)
+  | I n | IU n => Some(Ointconst n)
   | F n => if Compopts.generate_float_constants tt then Some(Ofloatconst n) else None
   | FS n => if Compopts.generate_float_constants tt then Some(Osingleconst n) else None
   | Ptr(Gl id ofs) => Some (Oaddrsymbol id ofs)

--- a/arm/ConstpropOpproof.v
+++ b/arm/ConstpropOpproof.v
@@ -107,6 +107,8 @@ Proof.
   destruct a; inv H; SimplVM.
 - (* integer *)
   exists (Vint n); auto.
+- (* integer or undef *)
+  exists (Vint n); split; auto. inv H0; auto.
 - (* float *)
   destruct (generate_float_constants tt); inv H2. exists (Vfloat f); auto.
 - (* single *)

--- a/powerpc/ConstpropOp.vp
+++ b/powerpc/ConstpropOp.vp
@@ -22,7 +22,7 @@ Require Import ValueDomain ValueAOp.
 
 Definition const_for_result (a: aval) : option operation :=
   match a with
-  | I n => Some(Ointconst n)
+  | I n | IU n => Some(Ointconst n)
   | L n => if Archi.ppc64 then Some (Olongconst n) else None
   | F n => if Compopts.generate_float_constants tt then Some(Ofloatconst n) else None
   | FS n => if Compopts.generate_float_constants tt then Some(Osingleconst n) else None

--- a/powerpc/ConstpropOpproof.v
+++ b/powerpc/ConstpropOpproof.v
@@ -101,6 +101,8 @@ Proof.
   destruct a; inv H; SimplVM.
 - (* integer *)
   exists (Vint n); auto.
+- (* integer or undef *)
+  exists (Vint n); split; auto. inv H0; auto.
 - (* long *)
   destruct (Archi.ppc64); inv H2. exists (Vlong n); auto.
 - (* float *)

--- a/riscV/ConstpropOp.vp
+++ b/riscV/ConstpropOp.vp
@@ -23,7 +23,7 @@ Require Import ValueDomain.
 
 Definition const_for_result (a: aval) : option operation :=
   match a with
-  | I n => Some(Ointconst n)
+  | I n | IU n => Some(Ointconst n)
   | L n => if Archi.ptr64 then Some(Olongconst n) else None
   | F n => if Compopts.generate_float_constants tt then Some(Ofloatconst n) else None
   | FS n => if Compopts.generate_float_constants tt then Some(Osingleconst n) else None

--- a/riscV/ConstpropOpproof.v
+++ b/riscV/ConstpropOpproof.v
@@ -91,6 +91,8 @@ Proof.
   destruct a; inv H; SimplVM.
 - (* integer *)
   exists (Vint n); auto.
+- (* integer or undef *)
+  exists (Vint n); split; auto. inv H0; auto.
 - (* long *)
   destruct ptr64; inv H2. exists (Vlong n); auto.
 - (* float *)

--- a/x86/ConstpropOp.vp
+++ b/x86/ConstpropOp.vp
@@ -25,7 +25,7 @@ Definition Olea_ptr (a: addressing) := if Archi.ptr64 then Oleal a else Olea a.
 
 Definition const_for_result (a: aval) : option operation :=
   match a with
-  | I n => Some(Ointconst n)
+  | I n | IU n => Some(Ointconst n)
   | L n => if Archi.ptr64 then Some(Olongconst n) else None
   | F n => if Compopts.generate_float_constants tt then Some(Ofloatconst n) else None
   | FS n => if Compopts.generate_float_constants tt then Some(Osingleconst n) else None

--- a/x86/ConstpropOpproof.v
+++ b/x86/ConstpropOpproof.v
@@ -98,6 +98,8 @@ Proof.
   destruct a; inv H; SimplVM.
 - (* integer *)
   exists (Vint n); auto.
+- (* integer or undef *)
+  exists (Vint n); split; auto. inv H0; auto.
 - (* long *)
   destruct ptr64; inv H2. exists (Vlong n); auto.
 - (* float *)


### PR DESCRIPTION
This PR introduces a new abstract value `IU n`, standing for "either `Vint n` or `Vundef`".

It enables more precise value analysis of comparison and selection operators, which in turn enables more compile-time evaluation of these operators.

Example:
```
struct s { char c[4]; char d[2]; };

int f(void)
{ struct s x; return (x.c + 6 == x.d); }

int g(void)
{ struct s x; if (x.c + 6 == x.d) return 1; else return 0; }
```

The current CompCert optimizes `g` into `return 0`, but fails to optimize `f`, as the result of the pointer comparison can be Vundef, so its abstract value cannot be `I Int.zero`.

With this PR, the expression `x.c + 6 == x.d` is analyzed as `IU Int.zero`, and constant-propagated to the constant 0.  Hence, `f` and `g` produce the same `return 0;` code.
