### PR TITLE
install .v files alongside .vo files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -359,6 +359,7 @@ ifeq ($(INSTALL_COQDEV),true)
           set -e; \
           install -d $(DESTDIR)$(COQDEVDIR)/$$d; \
           install -m 0644 $$d/*.vo $(DESTDIR)$(COQDEVDIR)/$$d/; \
+          install -m 0644 $$d/*.v $(DESTDIR)$(COQDEVDIR)/$$d/; \
           if test -d $$d/.coq-native; then \
             install -d $(DESTDIR)$(COQDEVDIR)/$$d/.coq-native; \
             install -m 0644 $$d/.coq-native/* $(DESTDIR)$(COQDEVDIR)/$$d/.coq-native/; \


### PR DESCRIPTION
This is partial work towards #526, and should enable the bug minimizer to at least sometimes minimize files from compcert by reconstructing the .glob files.  I am not sure how to install the .glob files, as it seems they are not even fully generated by the makefile (different directories overwrite each others' .glob files it seems).