### PR TITLE
Support C99 array declarator syntax involving `static` and `*`

### DIFF
--- a/cparser/Parser.vy
+++ b/cparser/Parser.vy
@@ -649,8 +649,23 @@ direct_declarator:
 | decl = direct_declarator LBRACK RBRACK
     { let 'Cabs.Name name typ attr loc := decl in
       Cabs.Name name (Cabs.ARRAY typ [] None) attr loc }
-(*| direct_declarator LBRACK ... STATIC ... RBRACK
-| direct_declarator LBRACK STAR RBRACK*)
+| decl = direct_declarator LBRACK STATIC quallst = type_qualifier_list
+  expr = assignment_expression RBRACK
+    { let 'Cabs.Name name typ attr loc := decl in
+      Cabs.Name name (Cabs.ARRAY typ (rev' quallst) (Some (fst expr))) attr loc }
+| decl = direct_declarator LBRACK STATIC expr = assignment_expression RBRACK
+    { let 'Cabs.Name name typ attr loc := decl in
+      Cabs.Name name (Cabs.ARRAY typ [] (Some (fst expr))) attr loc }
+| decl = direct_declarator LBRACK quallst = type_qualifier_list STATIC
+  expr = assignment_expression RBRACK
+    { let 'Cabs.Name name typ attr loc := decl in
+      Cabs.Name name (Cabs.ARRAY typ (rev' quallst) (Some (fst expr))) attr loc }
+| decl = direct_declarator LBRACK quallst = type_qualifier_list STAR RBRACK
+    { let 'Cabs.Name name typ attr loc := decl in
+      Cabs.Name name (Cabs.ARRAY typ (rev' quallst) None) attr loc }
+| decl = direct_declarator LBRACK STAR RBRACK
+    { let 'Cabs.Name name typ attr loc := decl in
+      Cabs.Name name (Cabs.ARRAY typ [] None) attr loc }
 | decl = direct_declarator LPAREN params = parameter_type_list RPAREN
     { let 'Cabs.Name name typ attr loc := decl in
       Cabs.Name name (Cabs.PROTO typ params) attr loc }
@@ -739,8 +754,28 @@ direct_abstract_declarator:
     { Cabs.ARRAY typ [] None }
 | LBRACK RBRACK
     { Cabs.ARRAY Cabs.JUSTBASE [] None }
-(*| direct_abstract_declarator? LBRACK STAR RBRACK*)
-(*| direct_abstract_declarator? LBRACK ... STATIC ... RBRACK*)
+| typ = direct_abstract_declarator LBRACK STATIC cvspec = type_qualifier_list
+  expr = assignment_expression RBRACK
+    { Cabs.ARRAY typ cvspec (Some (fst expr)) }
+| LBRACK STATIC cvspec = type_qualifier_list expr = assignment_expression RBRACK
+    { Cabs.ARRAY Cabs.JUSTBASE cvspec (Some (fst expr)) }
+| typ = direct_abstract_declarator LBRACK STATIC expr = assignment_expression RBRACK
+    { Cabs.ARRAY typ [] (Some (fst expr)) }
+| LBRACK STATIC expr = assignment_expression RBRACK
+    { Cabs.ARRAY Cabs.JUSTBASE [] (Some (fst expr)) }
+| typ = direct_abstract_declarator LBRACK cvspec = type_qualifier_list STATIC
+  expr = assignment_expression RBRACK
+    { Cabs.ARRAY typ cvspec (Some (fst expr)) }
+| LBRACK cvspec = type_qualifier_list STATIC expr = assignment_expression RBRACK
+    { Cabs.ARRAY Cabs.JUSTBASE cvspec (Some (fst expr)) }
+| typ = direct_abstract_declarator LBRACK cvspec = type_qualifier_list STAR RBRACK
+    { Cabs.ARRAY typ cvspec None }
+| typ = direct_abstract_declarator LBRACK STAR RBRACK
+    { Cabs.ARRAY typ [] None }
+| LBRACK cvspec = type_qualifier_list STAR RBRACK
+    { Cabs.ARRAY Cabs.JUSTBASE cvspec None }
+| LBRACK STAR RBRACK
+    { Cabs.ARRAY Cabs.JUSTBASE [] None }
 | typ = direct_abstract_declarator LPAREN params = parameter_type_list RPAREN
     { Cabs.PROTO typ params }
 | LPAREN params = parameter_type_list RPAREN

--- a/cparser/handcrafted.messages
+++ b/cparser/handcrafted.messages
@@ -182,9 +182,9 @@
 
 translation_unit_file: ALIGNAS LPAREN INT XOR_ASSIGN
 ##
-## Ends in an error in state: 315.
+## Ends in an error in state: 336.
 ##
-## attribute_specifier -> ALIGNAS LPAREN type_name . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ALIGNAS LPAREN type_name . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ALIGNAS LPAREN type_name
@@ -193,9 +193,9 @@ translation_unit_file: ALIGNAS LPAREN INT XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 159, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
-## In state 317, spurious reduction of production option(abstract_declarator(type_name)) ->
-## In state 323, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
+## In state 160, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
+## In state 338, spurious reduction of production option(abstract_declarator(type_name)) ->
+## In state 344, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
 ##
 
 # Maybe the type name was not complete, but we have reduced anyway
@@ -215,7 +215,7 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ ALIGNOF LPAREN VOID XOR_ASSIGN
 ##
-## Ends in an error in state: 327.
+## Ends in an error in state: 348.
 ##
 ## unary_expression -> ALIGNOF LPAREN type_name . RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LEQ LEFT_ASSIGN LEFT HAT GT GEQ EQEQ EQ DIV_ASSIGN COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -226,13 +226,13 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ ALIGNOF LPAREN VOID XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 159, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
-## In state 317, spurious reduction of production option(abstract_declarator(type_name)) ->
-## In state 323, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
+## In state 160, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
+## In state 338, spurious reduction of production option(abstract_declarator(type_name)) ->
+## In state 344, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ SIZEOF LPAREN VOID XOR_ASSIGN
 ##
-## Ends in an error in state: 412.
+## Ends in an error in state: 433.
 ##
 ## postfix_expression -> LPAREN type_name . RPAREN LBRACE initializer_list option(COMMA) RBRACE [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ## unary_expression -> SIZEOF LPAREN type_name . RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LEQ LEFT_ASSIGN LEFT HAT GT GEQ EQEQ EQ DIV_ASSIGN COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -244,9 +244,9 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ SIZEOF LPAREN VOID XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 159, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
-## In state 317, spurious reduction of production option(abstract_declarator(type_name)) ->
-## In state 323, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
+## In state 160, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
+## In state 338, spurious reduction of production option(abstract_declarator(type_name)) ->
+## In state 344, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
 ##
 
 Ill-formed use of $2.
@@ -259,7 +259,7 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ BUILTIN_VA_ARG LPAREN PRE_NAME VAR_NAME COMMA VOID XOR_ASSIGN
 ##
-## Ends in an error in state: 371.
+## Ends in an error in state: 392.
 ##
 ## postfix_expression -> BUILTIN_VA_ARG LPAREN assignment_expression COMMA type_name . RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -270,9 +270,9 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ BUILTIN_VA_ARG LPAREN PRE_NAME V
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 159, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
-## In state 317, spurious reduction of production option(abstract_declarator(type_name)) ->
-## In state 323, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
+## In state 160, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
+## In state 338, spurious reduction of production option(abstract_declarator(type_name)) ->
+## In state 344, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
 ##
 
 Ill-formed use of __builtin_va_arg.
@@ -285,7 +285,7 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ INC LPAREN VOID XOR_ASSIGN
 ##
-## Ends in an error in state: 387.
+## Ends in an error in state: 408.
 ##
 ## postfix_expression -> LPAREN type_name . RPAREN LBRACE initializer_list option(COMMA) RBRACE [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -296,9 +296,9 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ INC LPAREN VOID XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 159, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
-## In state 317, spurious reduction of production option(abstract_declarator(type_name)) ->
-## In state 323, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
+## In state 160, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
+## In state 338, spurious reduction of production option(abstract_declarator(type_name)) ->
+## In state 344, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
 ##
 
 # gcc simply says it expects a closing parenthesis,
@@ -314,7 +314,7 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LPAREN VOID XOR_ASSIGN
 ##
-## Ends in an error in state: 409.
+## Ends in an error in state: 430.
 ##
 ## cast_expression -> LPAREN type_name . RPAREN cast_expression [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LEQ LEFT_ASSIGN LEFT HAT GT GEQ EQEQ EQ DIV_ASSIGN COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ## postfix_expression -> LPAREN type_name . RPAREN LBRACE initializer_list option(COMMA) RBRACE [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -326,9 +326,9 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ LPAREN VOID XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 159, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
-## In state 317, spurious reduction of production option(abstract_declarator(type_name)) ->
-## In state 323, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
+## In state 160, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
+## In state 338, spurious reduction of production option(abstract_declarator(type_name)) ->
+## In state 344, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
 ##
 
 # gcc and clang say they expect a closing parenthesis.
@@ -342,10 +342,10 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: ALIGNAS LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 325.
+## Ends in an error in state: 346.
 ##
 ## argument_expression_list -> argument_expression_list . COMMA assignment_expression [ RPAREN COMMA ]
-## attribute_specifier -> ALIGNAS LPAREN argument_expression_list . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ALIGNAS LPAREN argument_expression_list . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ALIGNAS LPAREN argument_expression_list
@@ -354,21 +354,21 @@ translation_unit_file: ALIGNAS LPAREN PRE_NAME VAR_NAME SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 146, spurious reduction of production argument_expression_list -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 147, spurious reduction of production argument_expression_list -> assignment_expression
 ##
 
 # We are trying to recognize an alignas specifier.
@@ -394,23 +394,228 @@ translation_unit_file: ALIGNAS LPAREN INT LBRACK RPAREN
 ##
 ## Ends in an error in state: 251.
 ##
-## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK option(type_qualifier_list) . optional(assignment_expression,RBRACK) [ RPAREN LPAREN LBRACK COMMA COLON ]
-## type_qualifier_list -> option(type_qualifier_list) . type_qualifier_noattr [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT RBRACK PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
-## type_qualifier_list -> option(type_qualifier_list) . attribute_specifier [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT RBRACK PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK . option(type_qualifier_list) optional(assignment_expression,RBRACK) [ RPAREN LPAREN LBRACK COMMA COLON ]
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK . STATIC option(type_qualifier_list) assignment_expression RBRACK [ RPAREN LPAREN LBRACK COMMA COLON ]
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK . type_qualifier_list STATIC assignment_expression RBRACK [ RPAREN LPAREN LBRACK COMMA COLON ]
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK . option(type_qualifier_list) STAR RBRACK [ RPAREN LPAREN LBRACK COMMA COLON ]
 ##
 ## The known suffix of the stack is as follows:
-## option(direct_abstract_declarator) LBRACK option(type_qualifier_list)
+## option(direct_abstract_declarator) LBRACK
+##
+translation_unit_file: ALIGNAS LPAREN VOID LBRACK STAR XOR_ASSIGN
+##
+## Ends in an error in state: 261.
+##
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK option(type_qualifier_list) STAR . RBRACK [ RPAREN LPAREN LBRACK COMMA COLON ]
+## unary_operator -> STAR . [ TILDE STRING_LITERAL STAR SIZEOF PRE_NAME PLUS MINUS LPAREN INC GENERIC DEC CONSTANT BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AND ALIGNOF ]
+##
+## The known suffix of the stack is as follows:
+## option(direct_abstract_declarator) LBRACK option(type_qualifier_list) STAR
+##
+translation_unit_file: ALIGNAS LPAREN VOID LBRACK STATIC STRING_LITERAL WHILE
+##
+## Ends in an error in state: 254.
+##
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK STATIC option(type_qualifier_list) assignment_expression . RBRACK [ RPAREN LPAREN LBRACK COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## option(direct_abstract_declarator) LBRACK STATIC option(type_qualifier_list) assignment_expression
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 71, spurious reduction of production primary_expression -> string_literals_list
+## In state 73, spurious reduction of production postfix_expression -> primary_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+##
+translation_unit_file: ALIGNAS LPAREN VOID LBRACK STATIC XOR_ASSIGN
+##
+## Ends in an error in state: 253.
+##
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK STATIC option(type_qualifier_list) . assignment_expression RBRACK [ RPAREN LPAREN LBRACK COMMA COLON ]
+## type_qualifier_list -> option(type_qualifier_list) . type_qualifier_noattr [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## type_qualifier_list -> option(type_qualifier_list) . attribute_specifier [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
+##
+## The known suffix of the stack is as follows:
+## option(direct_abstract_declarator) LBRACK STATIC option(type_qualifier_list)
+##
+translation_unit_file: ALIGNAS LPAREN VOID LBRACK VOLATILE STATIC STRING_LITERAL WHILE
+##
+## Ends in an error in state: 258.
+##
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK type_qualifier_list STATIC assignment_expression . RBRACK [ RPAREN LPAREN LBRACK COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## option(direct_abstract_declarator) LBRACK type_qualifier_list STATIC assignment_expression
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 71, spurious reduction of production primary_expression -> string_literals_list
+## In state 73, spurious reduction of production postfix_expression -> primary_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+##
+translation_unit_file: ALIGNAS LPAREN VOID LBRACK VOLATILE STATIC XOR_ASSIGN
+##
+## Ends in an error in state: 257.
+##
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK type_qualifier_list STATIC . assignment_expression RBRACK [ RPAREN LPAREN LBRACK COMMA COLON ]
+##
+## The known suffix of the stack is as follows:
+## option(direct_abstract_declarator) LBRACK type_qualifier_list STATIC
+##
+translation_unit_file: ALIGNAS LPAREN VOID LBRACK VOLATILE XOR_ASSIGN
+##
+## Ends in an error in state: 256.
+##
+## direct_abstract_declarator -> option(direct_abstract_declarator) LBRACK type_qualifier_list . STATIC assignment_expression RBRACK [ RPAREN LPAREN LBRACK COMMA COLON ]
+## option(type_qualifier_list) -> type_qualifier_list . [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT RBRACK PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
+##
+## The known suffix of the stack is as follows:
+## option(direct_abstract_declarator) LBRACK type_qualifier_list
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LBRACK RPAREN
 ##
-## Ends in an error in state: 268.
+## Ends in an error in state: 278.
 ##
-## direct_declarator -> direct_declarator LBRACK option(type_qualifier_list) . optional(assignment_expression,RBRACK) [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
-## type_qualifier_list -> option(type_qualifier_list) . type_qualifier_noattr [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT RBRACK PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
-## type_qualifier_list -> option(type_qualifier_list) . attribute_specifier [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT RBRACK PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## direct_declarator -> direct_declarator LBRACK . option(type_qualifier_list) optional(assignment_expression,RBRACK) [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## direct_declarator -> direct_declarator LBRACK . STATIC option(type_qualifier_list) assignment_expression RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## direct_declarator -> direct_declarator LBRACK . type_qualifier_list STATIC assignment_expression RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## direct_declarator -> direct_declarator LBRACK . option(type_qualifier_list) STAR RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
-## direct_declarator LBRACK option(type_qualifier_list)
+## direct_declarator LBRACK
+##
+translation_unit_file: CHAR PRE_NAME TYPEDEF_NAME LBRACK STATIC XOR_ASSIGN
+##
+## Ends in an error in state: 280.
+##
+## direct_declarator -> direct_declarator LBRACK STATIC option(type_qualifier_list) . assignment_expression RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## type_qualifier_list -> option(type_qualifier_list) . type_qualifier_noattr [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## type_qualifier_list -> option(type_qualifier_list) . attribute_specifier [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
+##
+## The known suffix of the stack is as follows:
+## direct_declarator LBRACK STATIC option(type_qualifier_list)
+##
+translation_unit_file: CHAR PRE_NAME TYPEDEF_NAME LBRACK STATIC STRING_LITERAL WHILE
+##
+## Ends in an error in state: 281.
+##
+## direct_declarator -> direct_declarator LBRACK STATIC option(type_qualifier_list) assignment_expression . RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+##
+## The known suffix of the stack is as follows:
+## direct_declarator LBRACK STATIC option(type_qualifier_list) assignment_expression
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 71, spurious reduction of production primary_expression -> string_literals_list
+## In state 73, spurious reduction of production postfix_expression -> primary_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+##
+# Variant of the above
+translation_unit_file: CHAR PRE_NAME TYPEDEF_NAME LBRACK CONST XOR_ASSIGN
+##
+## Ends in an error in state: 283.
+##
+## direct_declarator -> direct_declarator LBRACK type_qualifier_list . STATIC assignment_expression RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## option(type_qualifier_list) -> type_qualifier_list . [ VOLATILE TILDE STRING_LITERAL STAR SIZEOF RESTRICT RBRACK PRE_NAME PLUS PACKED MINUS LPAREN INC GENERIC DEC CONSTANT CONST BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG ATTRIBUTE AND ALIGNOF ALIGNAS ]
+##
+## The known suffix of the stack is as follows:
+## direct_declarator LBRACK type_qualifier_list
+##
+translation_unit_file: CHAR PRE_NAME TYPEDEF_NAME LBRACK CONST STATIC XOR_ASSIGN
+##
+## Ends in an error in state: 284.
+##
+## direct_declarator -> direct_declarator LBRACK type_qualifier_list STATIC . assignment_expression RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+##
+## The known suffix of the stack is as follows:
+## direct_declarator LBRACK type_qualifier_list STATIC
+##
+# Variant of the above
+translation_unit_file: CHAR PRE_NAME TYPEDEF_NAME LBRACK CONST STATIC STRING_LITERAL WHILE
+##
+## Ends in an error in state: 285.
+##
+## direct_declarator -> direct_declarator LBRACK type_qualifier_list STATIC assignment_expression . RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+##
+## The known suffix of the stack is as follows:
+## direct_declarator LBRACK type_qualifier_list STATIC assignment_expression
+##
+## WARNING: This example involves spurious reductions.
+## This implies that, although the LR(1) items shown above provide an
+## accurate view of the past (what has been recognized so far), they
+## may provide an INCOMPLETE view of the future (what was expected next).
+## In state 71, spurious reduction of production primary_expression -> string_literals_list
+## In state 73, spurious reduction of production postfix_expression -> primary_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+##
+# Variant of the above
+translation_unit_file: CHAR PRE_NAME TYPEDEF_NAME LBRACK STAR XOR_ASSIGN
+##
+## Ends in an error in state: 288.
+##
+## direct_declarator -> direct_declarator LBRACK option(type_qualifier_list) STAR . RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## unary_operator -> STAR . [ TILDE STRING_LITERAL STAR SIZEOF PRE_NAME PLUS MINUS LPAREN INC GENERIC DEC CONSTANT BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AND ALIGNOF ]
+##
+## The known suffix of the stack is as follows:
+## direct_declarator LBRACK option(type_qualifier_list) STAR
 ##
 
 # We are trying to recognize an array declarator.
@@ -437,7 +642,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: ALIGNAS LPAREN INT LPAREN INT COMMA ELLIPSIS XOR_ASSIGN
 ##
-## Ends in an error in state: 279.
+## Ends in an error in state: 300.
 ##
 ## direct_abstract_declarator -> LPAREN option(context_parameter_type_list) . RPAREN [ RPAREN LPAREN LBRACK COMMA COLON ]
 ##
@@ -446,7 +651,7 @@ translation_unit_file: ALIGNAS LPAREN INT LPAREN INT COMMA ELLIPSIS XOR_ASSIGN
 ##
 translation_unit_file: ALIGNAS LPAREN INT LBRACK RBRACK LPAREN INT COMMA ELLIPSIS XOR_ASSIGN
 ##
-## Ends in an error in state: 262.
+## Ends in an error in state: 273.
 ##
 ## direct_abstract_declarator -> direct_abstract_declarator LPAREN option(context_parameter_type_list) . RPAREN [ RPAREN LPAREN LBRACK COMMA COLON ]
 ##
@@ -455,9 +660,9 @@ translation_unit_file: ALIGNAS LPAREN INT LBRACK RBRACK LPAREN INT COMMA ELLIPSI
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT COMMA ELLIPSIS XOR_ASSIGN
 ##
-## Ends in an error in state: 296.
+## Ends in an error in state: 317.
 ##
-## direct_declarator -> direct_declarator LPAREN context_parameter_type_list . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## direct_declarator -> direct_declarator LPAREN context_parameter_type_list . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## direct_declarator LPAREN context_parameter_type_list
@@ -472,7 +677,7 @@ At this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: ALIGNAS LPAREN INT LPAREN LPAREN RPAREN COMMA
 ##
-## Ends in an error in state: 277.
+## Ends in an error in state: 298.
 ##
 ## direct_abstract_declarator -> LPAREN save_context abstract_declarator(type_name) . RPAREN [ RPAREN LPAREN LBRACK COMMA COLON ]
 ##
@@ -483,7 +688,7 @@ translation_unit_file: ALIGNAS LPAREN INT LPAREN LPAREN RPAREN COMMA
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 270, spurious reduction of production abstract_declarator(type_name) -> direct_abstract_declarator
+## In state 291, spurious reduction of production abstract_declarator(type_name) -> direct_abstract_declarator
 ##
 #
 # The first LPAREN in this example must be the beginning of an abstract_declarator.
@@ -514,7 +719,7 @@ At this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: ALIGNAS LPAREN INT LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 318.
+## Ends in an error in state: 339.
 ##
 ## direct_abstract_declarator -> LPAREN . save_context abstract_declarator(type_name) RPAREN [ RPAREN LPAREN LBRACK COMMA COLON ]
 ## direct_abstract_declarator -> LPAREN . option(context_parameter_type_list) RPAREN [ RPAREN LPAREN LBRACK COMMA COLON ]
@@ -537,7 +742,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 245.
+## Ends in an error in state: 246.
 ##
 ## direct_abstract_declarator -> LPAREN . save_context abstract_declarator(type_name) RPAREN [ RPAREN LPAREN LBRACK COMMA ]
 ## direct_abstract_declarator -> LPAREN . option(context_parameter_type_list) RPAREN [ RPAREN LPAREN LBRACK COMMA ]
@@ -560,7 +765,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: ALIGNAS LPAREN VOLATILE ADD_ASSIGN
 ##
-## Ends in an error in state: 310.
+## Ends in an error in state: 331.
 ##
 ## option(type_qualifier_list) -> type_qualifier_list . [ VOLATILE RESTRICT PACKED CONST ATTRIBUTE ALIGNAS ]
 ## specifier_qualifier_list(type_name) -> type_qualifier_list . typedef_name option(type_qualifier_list) [ STAR RPAREN LPAREN LBRACK COMMA COLON ]
@@ -585,10 +790,10 @@ At this point, one of the following is expected:
 
 translation_unit_file: ALIGNAS LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 67.
+## Ends in an error in state: 68.
 ##
-## attribute_specifier -> ALIGNAS LPAREN . argument_expression_list RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
-## attribute_specifier -> ALIGNAS LPAREN . type_name RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ALIGNAS LPAREN . argument_expression_list RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ALIGNAS LPAREN . type_name RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ALIGNAS LPAREN
@@ -607,10 +812,10 @@ At this point, one of the following is expected:
 
 translation_unit_file: ALIGNAS XOR_ASSIGN
 ##
-## Ends in an error in state: 66.
+## Ends in an error in state: 67.
 ##
-## attribute_specifier -> ALIGNAS . LPAREN argument_expression_list RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
-## attribute_specifier -> ALIGNAS . LPAREN type_name RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ALIGNAS . LPAREN argument_expression_list RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ALIGNAS . LPAREN type_name RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ALIGNAS
@@ -625,7 +830,7 @@ At this point, an opening parenthesis '(' is expected.
 
 translation_unit_file: ATTRIBUTE LPAREN LPAREN COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 338.
+## Ends in an error in state: 359.
 ##
 ## gcc_attribute_list -> gcc_attribute_list COMMA . gcc_attribute [ RPAREN COMMA ]
 ##
@@ -647,9 +852,9 @@ At this point, a gcc attribute is expected.
 
 translation_unit_file: ATTRIBUTE LPAREN LPAREN RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 336.
+## Ends in an error in state: 357.
 ##
-## attribute_specifier -> ATTRIBUTE LPAREN LPAREN gcc_attribute_list RPAREN . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ATTRIBUTE LPAREN LPAREN gcc_attribute_list RPAREN . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ATTRIBUTE LPAREN LPAREN gcc_attribute_list RPAREN
@@ -662,9 +867,9 @@ At this point, a second closing parenthesis ')' is expected.
 
 translation_unit_file: ATTRIBUTE LPAREN LPAREN PRE_NAME VAR_NAME LPAREN RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 335.
+## Ends in an error in state: 356.
 ##
-## attribute_specifier -> ATTRIBUTE LPAREN LPAREN gcc_attribute_list . RPAREN RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ATTRIBUTE LPAREN LPAREN gcc_attribute_list . RPAREN RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ## gcc_attribute_list -> gcc_attribute_list . COMMA gcc_attribute [ RPAREN COMMA ]
 ##
 ## The known suffix of the stack is as follows:
@@ -685,7 +890,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: ATTRIBUTE LPAREN LPAREN PRE_NAME VAR_NAME LPAREN PRE_NAME TYPEDEF_NAME COMMA PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 331.
+## Ends in an error in state: 352.
 ##
 ## argument_expression_list -> argument_expression_list . COMMA assignment_expression [ RPAREN COMMA ]
 ## gcc_attribute -> gcc_attribute_word LPAREN typedef_name COMMA argument_expression_list . RPAREN [ RPAREN COMMA ]
@@ -697,21 +902,21 @@ translation_unit_file: ATTRIBUTE LPAREN LPAREN PRE_NAME VAR_NAME LPAREN PRE_NAME
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 146, spurious reduction of production argument_expression_list -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 147, spurious reduction of production argument_expression_list -> assignment_expression
 ##
 
 # We know for sure that we are parsing a gcc attribute.
@@ -729,7 +934,7 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: ATTRIBUTE LPAREN LPAREN PRE_NAME VAR_NAME LPAREN PRE_NAME TYPEDEF_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 330.
+## Ends in an error in state: 351.
 ##
 ## gcc_attribute -> gcc_attribute_word LPAREN typedef_name COMMA . argument_expression_list RPAREN [ RPAREN COMMA ]
 ##
@@ -746,7 +951,7 @@ At this point, an expression is expected.
 
 translation_unit_file: ATTRIBUTE LPAREN LPAREN PRE_NAME VAR_NAME LPAREN PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 329.
+## Ends in an error in state: 350.
 ##
 ## gcc_attribute -> gcc_attribute_word LPAREN typedef_name . COMMA argument_expression_list RPAREN [ RPAREN COMMA ]
 ##
@@ -763,7 +968,7 @@ At this point, a comma ',' is expected.
 
 translation_unit_file: ATTRIBUTE LPAREN LPAREN PRE_NAME VAR_NAME LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 55.
+## Ends in an error in state: 56.
 ##
 ## gcc_attribute -> gcc_attribute_word LPAREN . option(argument_expression_list) RPAREN [ RPAREN COMMA ]
 ## gcc_attribute -> gcc_attribute_word LPAREN . typedef_name COMMA argument_expression_list RPAREN [ RPAREN COMMA ]
@@ -783,7 +988,7 @@ At this point, a list of expressions is expected.
 
 translation_unit_file: ATTRIBUTE LPAREN LPAREN PRE_NAME VAR_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 54.
+## Ends in an error in state: 55.
 ##
 ## gcc_attribute -> gcc_attribute_word . [ RPAREN COMMA ]
 ## gcc_attribute -> gcc_attribute_word . LPAREN option(argument_expression_list) RPAREN [ RPAREN COMMA ]
@@ -809,9 +1014,9 @@ At this point, one of the following is expected:
 
 translation_unit_file: ATTRIBUTE LPAREN LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 47.
+## Ends in an error in state: 48.
 ##
-## attribute_specifier -> ATTRIBUTE LPAREN LPAREN . gcc_attribute_list RPAREN RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ATTRIBUTE LPAREN LPAREN . gcc_attribute_list RPAREN RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ATTRIBUTE LPAREN LPAREN
@@ -831,9 +1036,9 @@ At this point, a gcc attribute is expected.
 
 translation_unit_file: ATTRIBUTE LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 46.
+## Ends in an error in state: 47.
 ##
-## attribute_specifier -> ATTRIBUTE LPAREN . LPAREN gcc_attribute_list RPAREN RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ATTRIBUTE LPAREN . LPAREN gcc_attribute_list RPAREN RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ATTRIBUTE LPAREN
@@ -846,9 +1051,9 @@ At this point, a second opening parenthesis '(' is expected.
 
 translation_unit_file: ATTRIBUTE XOR_ASSIGN
 ##
-## Ends in an error in state: 45.
+## Ends in an error in state: 46.
 ##
-## attribute_specifier -> ATTRIBUTE . LPAREN LPAREN gcc_attribute_list RPAREN RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> ATTRIBUTE . LPAREN LPAREN gcc_attribute_list RPAREN RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ATTRIBUTE
@@ -861,7 +1066,7 @@ At this point, two opening parentheses '((' are expected.
 
 translation_unit_file: ENUM LBRACE PRE_NAME VAR_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 346.
+## Ends in an error in state: 367.
 ##
 ## enumerator_list -> enumerator_list COMMA . declare_varname(enumerator) [ RBRACE COMMA ]
 ## option(COMMA) -> COMMA . [ RBRACE ]
@@ -882,9 +1087,9 @@ At this point, an enumerator is expected.
 
 translation_unit_file: ENUM LBRACE PRE_NAME VAR_NAME EQ CONSTANT SEMICOLON
 ##
-## Ends in an error in state: 345.
+## Ends in an error in state: 366.
 ##
-## enum_specifier -> ENUM attribute_specifier_list option(other_identifier) LBRACE enumerator_list . option(COMMA) RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## enum_specifier -> ENUM attribute_specifier_list option(other_identifier) LBRACE enumerator_list . option(COMMA) RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ## enumerator_list -> enumerator_list . COMMA declare_varname(enumerator) [ RBRACE COMMA ]
 ##
 ## The known suffix of the stack is as follows:
@@ -894,22 +1099,22 @@ translation_unit_file: ENUM LBRACE PRE_NAME VAR_NAME EQ CONSTANT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 69, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 350, spurious reduction of production enumerator -> enumeration_constant EQ conditional_expression
-## In state 347, spurious reduction of production declare_varname(enumerator) -> enumerator
-## In state 354, spurious reduction of production enumerator_list -> declare_varname(enumerator)
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 70, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 371, spurious reduction of production enumerator -> enumeration_constant EQ conditional_expression
+## In state 368, spurious reduction of production declare_varname(enumerator) -> enumerator
+## In state 375, spurious reduction of production enumerator_list -> declare_varname(enumerator)
 ##
 #
 # At first sight, it seems that the last enumerator that we have recognized
@@ -940,7 +1145,7 @@ then at this point, a closing brace '}' is expected.
 
 translation_unit_file: ENUM LBRACE PRE_NAME VAR_NAME EQ XOR_ASSIGN
 ##
-## Ends in an error in state: 349.
+## Ends in an error in state: 370.
 ##
 ## enumerator -> enumeration_constant EQ . conditional_expression [ RBRACE COMMA ]
 ##
@@ -955,7 +1160,7 @@ At this point, a constant expression is expected.
 
 translation_unit_file: ENUM LBRACE PRE_NAME VAR_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 348.
+## Ends in an error in state: 369.
 ##
 ## enumerator -> enumeration_constant . [ RBRACE COMMA ]
 ## enumerator -> enumeration_constant . EQ conditional_expression [ RBRACE COMMA ]
@@ -976,9 +1181,9 @@ At this point, one of the following is expected:
 
 translation_unit_file: ENUM LBRACE XOR_ASSIGN
 ##
-## Ends in an error in state: 343.
+## Ends in an error in state: 364.
 ##
-## enum_specifier -> ENUM attribute_specifier_list option(other_identifier) LBRACE . enumerator_list option(COMMA) RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## enum_specifier -> ENUM attribute_specifier_list option(other_identifier) LBRACE . enumerator_list option(COMMA) RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM attribute_specifier_list option(other_identifier) LBRACE
@@ -994,10 +1199,10 @@ At this point, an enumerator is expected.
 
 translation_unit_file: ENUM XOR_ASSIGN
 ##
-## Ends in an error in state: 341.
+## Ends in an error in state: 362.
 ##
-## enum_specifier -> ENUM attribute_specifier_list . option(other_identifier) LBRACE enumerator_list option(COMMA) RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
-## enum_specifier -> ENUM attribute_specifier_list . general_identifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## enum_specifier -> ENUM attribute_specifier_list . option(other_identifier) LBRACE enumerator_list option(COMMA) RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## enum_specifier -> ENUM attribute_specifier_list . general_identifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ENUM attribute_specifier_list
@@ -1006,7 +1211,7 @@ translation_unit_file: ENUM XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 44, spurious reduction of production attribute_specifier_list ->
+## In state 45, spurious reduction of production attribute_specifier_list ->
 ##
 
 # Here, both clang and gcc give an incomplete diagnostic message.
@@ -1021,7 +1226,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ ALIGNOF LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 59.
+## Ends in an error in state: 60.
 ##
 ## unary_expression -> ALIGNOF LPAREN . type_name RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LEQ LEFT_ASSIGN LEFT HAT GT GEQ EQEQ EQ DIV_ASSIGN COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1054,7 +1259,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ ALIGNOF XOR_ASSIGN
 ##
-## Ends in an error in state: 58.
+## Ends in an error in state: 59.
 ##
 ## unary_expression -> ALIGNOF . LPAREN type_name RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LEQ LEFT_ASSIGN LEFT HAT GT GEQ EQEQ EQ DIV_ASSIGN COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1092,7 +1297,7 @@ followed with an expression or a type name.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ BUILTIN_VA_ARG LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 369.
+## Ends in an error in state: 390.
 ##
 ## postfix_expression -> BUILTIN_VA_ARG LPAREN assignment_expression . COMMA type_name RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1103,20 +1308,20 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ BUILTIN_VA_ARG LPAREN PRE_NAME V
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
 ##
 
 Ill-formed use of $2.
@@ -1129,7 +1334,7 @@ then at this point, a comma ',' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ BUILTIN_VA_ARG LPAREN PRE_NAME VAR_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 370.
+## Ends in an error in state: 391.
 ##
 ## postfix_expression -> BUILTIN_VA_ARG LPAREN assignment_expression COMMA . type_name RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1198,7 +1403,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ INC LPAREN INT RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 388.
+## Ends in an error in state: 409.
 ##
 ## postfix_expression -> LPAREN type_name RPAREN . LBRACE initializer_list option(COMMA) RBRACE [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1250,7 +1455,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 406.
+## Ends in an error in state: 427.
 ##
 ## expression -> expression . COMMA assignment_expression [ RPAREN COMMA ]
 ## primary_expression -> LPAREN expression . RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -1262,21 +1467,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ LPAREN PRE_NAME VAR_NAME SEMICOL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 # Since we are saying "if this expression is complete",
@@ -1294,7 +1499,7 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LPAREN INT RPAREN LBRACE PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 403.
+## Ends in an error in state: 424.
 ##
 ## initializer_list -> initializer_list . COMMA option(designation) c_initializer [ RBRACE COMMA ]
 ## postfix_expression -> LPAREN type_name RPAREN LBRACE initializer_list . option(COMMA) RBRACE [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -1306,22 +1511,22 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ LPAREN INT RPAREN LBRACE PRE_NAM
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 396, spurious reduction of production c_initializer -> assignment_expression
-## In state 402, spurious reduction of production initializer_list -> option(designation) c_initializer
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 417, spurious reduction of production c_initializer -> assignment_expression
+## In state 423, spurious reduction of production initializer_list -> option(designation) c_initializer
 ##
 
 # Let's ignore the fact that a comma can precede a closing brace.
@@ -1336,7 +1541,7 @@ then at this point, a closing brace '}' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LPAREN INT RPAREN LBRACE XOR_ASSIGN
 ##
-## Ends in an error in state: 389.
+## Ends in an error in state: 410.
 ##
 ## postfix_expression -> LPAREN type_name RPAREN LBRACE . initializer_list option(COMMA) RBRACE [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1353,7 +1558,7 @@ At this point, an initializer is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LPAREN INT RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 410.
+## Ends in an error in state: 431.
 ##
 ## cast_expression -> LPAREN type_name RPAREN . cast_expression [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LEQ LEFT_ASSIGN LEFT HAT GT GEQ EQEQ EQ DIV_ASSIGN COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ## postfix_expression -> LPAREN type_name RPAREN . LBRACE initializer_list option(COMMA) RBRACE [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -1397,7 +1602,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ TILDE XOR_ASSIGN
 ##
-## Ends in an error in state: 68.
+## Ends in an error in state: 69.
 ##
 ## unary_expression -> unary_operator . cast_expression [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LEQ LEFT_ASSIGN LEFT HAT GT GEQ EQEQ EQ DIV_ASSIGN COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1414,7 +1619,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME AND XOR_ASSIGN
 ##
-## Ends in an error in state: 129.
+## Ends in an error in state: 130.
 ##
 ## and_expression -> and_expression AND . equality_expression [ SEMICOLON RPAREN RBRACK RBRACE QUESTION HAT COMMA COLON BARBAR BAR ANDAND AND ]
 ##
@@ -1423,7 +1628,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME AND XOR_ASSIGN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME ANDAND XOR_ASSIGN
 ##
-## Ends in an error in state: 118.
+## Ends in an error in state: 119.
 ##
 ## logical_and_expression -> logical_and_expression ANDAND . inclusive_or_expression [ SEMICOLON RPAREN RBRACK RBRACE QUESTION COMMA COLON BARBAR ANDAND ]
 ##
@@ -1432,7 +1637,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME ANDAND XOR_ASS
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME BAR XOR_ASSIGN
 ##
-## Ends in an error in state: 120.
+## Ends in an error in state: 121.
 ##
 ## inclusive_or_expression -> inclusive_or_expression BAR . exclusive_or_expression [ SEMICOLON RPAREN RBRACK RBRACE QUESTION COMMA COLON BARBAR BAR ANDAND ]
 ##
@@ -1441,7 +1646,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME BAR XOR_ASSIGN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME BARBAR XOR_ASSIGN
 ##
-## Ends in an error in state: 141.
+## Ends in an error in state: 142.
 ##
 ## logical_or_expression -> logical_or_expression BARBAR . logical_and_expression [ SEMICOLON RPAREN RBRACK RBRACE QUESTION COMMA COLON BARBAR ]
 ##
@@ -1450,7 +1655,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME BARBAR XOR_ASS
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME HAT XOR_ASSIGN
 ##
-## Ends in an error in state: 122.
+## Ends in an error in state: 123.
 ##
 ## exclusive_or_expression -> exclusive_or_expression HAT . and_expression [ SEMICOLON RPAREN RBRACK RBRACE QUESTION HAT COMMA COLON BARBAR BAR ANDAND ]
 ##
@@ -1459,7 +1664,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME HAT XOR_ASSIGN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME LT XOR_ASSIGN
 ##
-## Ends in an error in state: 112.
+## Ends in an error in state: 113.
 ##
 ## relational_expression -> relational_expression relational_operator . shift_expression [ SEMICOLON RPAREN RBRACK RBRACE QUESTION NEQ LT LEQ HAT GT GEQ EQEQ COMMA COLON BARBAR BAR ANDAND AND ]
 ##
@@ -1468,7 +1673,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME LT XOR_ASSIGN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME NEQ XOR_ASSIGN
 ##
-## Ends in an error in state: 126.
+## Ends in an error in state: 127.
 ##
 ## equality_expression -> equality_expression equality_operator . relational_expression [ SEMICOLON RPAREN RBRACK RBRACE QUESTION NEQ HAT EQEQ COMMA COLON BARBAR BAR ANDAND AND ]
 ##
@@ -1477,7 +1682,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME NEQ XOR_ASSIGN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME PLUS XOR_ASSIGN
 ##
-## Ends in an error in state: 105.
+## Ends in an error in state: 106.
 ##
 ## additive_expression -> additive_expression additive_operator . multiplicative_expression [ SEMICOLON RPAREN RIGHT RBRACK RBRACE QUESTION PLUS NEQ MINUS LT LEQ LEFT HAT GT GEQ EQEQ COMMA COLON BARBAR BAR ANDAND AND ]
 ##
@@ -1486,7 +1691,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME PLUS XOR_ASSIG
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME RIGHT XOR_ASSIGN
 ##
-## Ends in an error in state: 93.
+## Ends in an error in state: 94.
 ##
 ## shift_expression -> shift_expression shift_operator . additive_expression [ SEMICOLON RPAREN RIGHT RBRACK RBRACE QUESTION NEQ LT LEQ LEFT HAT GT GEQ EQEQ COMMA COLON BARBAR BAR ANDAND AND ]
 ##
@@ -1495,7 +1700,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME RIGHT XOR_ASSI
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME STAR XOR_ASSIGN
 ##
-## Ends in an error in state: 98.
+## Ends in an error in state: 99.
 ##
 ## multiplicative_expression -> multiplicative_expression multiplicative_operator . cast_expression [ STAR SLASH SEMICOLON RPAREN RIGHT RBRACK RBRACE QUESTION PLUS PERCENT NEQ MINUS LT LEQ LEFT HAT GT GEQ EQEQ COMMA COLON BARBAR BAR ANDAND AND ]
 ##
@@ -1512,7 +1717,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME XOR_ASSIGN XOR_ASSIGN
 ##
-## Ends in an error in state: 89.
+## Ends in an error in state: 90.
 ##
 ## assignment_expression -> unary_expression assignment_operator . assignment_expression [ SEMICOLON RPAREN RBRACK RBRACE COMMA COLON ]
 ##
@@ -1529,7 +1734,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 148.
+## Ends in an error in state: 149.
 ##
 ## argument_expression_list -> argument_expression_list COMMA . assignment_expression [ RPAREN COMMA ]
 ##
@@ -1550,7 +1755,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME DOT XOR_ASSIGN
 ##
-## Ends in an error in state: 154.
+## Ends in an error in state: 155.
 ##
 ## postfix_expression -> postfix_expression DOT . general_identifier [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1559,7 +1764,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME DOT XOR_ASSIGN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME PTR XOR_ASSIGN
 ##
-## Ends in an error in state: 74.
+## Ends in an error in state: 75.
 ##
 ## postfix_expression -> postfix_expression PTR . general_identifier [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1576,7 +1781,7 @@ At this point, the name of a struct or union member is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME LBRACK PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 151.
+## Ends in an error in state: 152.
 ##
 ## expression -> expression . COMMA assignment_expression [ RBRACK COMMA ]
 ## postfix_expression -> postfix_expression LBRACK expression . RBRACK [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -1588,21 +1793,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME LBRACK PRE_NAM
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 # We know for sure that an array subscript expression has begun, and
@@ -1621,7 +1826,7 @@ then at this point, a closing bracket ']' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME LBRACK XOR_ASSIGN
 ##
-## Ends in an error in state: 150.
+## Ends in an error in state: 151.
 ##
 ## postfix_expression -> postfix_expression LBRACK . expression RBRACK [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1636,7 +1841,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 147.
+## Ends in an error in state: 148.
 ##
 ## argument_expression_list -> argument_expression_list . COMMA assignment_expression [ RPAREN COMMA ]
 ## option(argument_expression_list) -> argument_expression_list . [ RPAREN ]
@@ -1648,21 +1853,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME LPAREN PRE_NAM
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 146, spurious reduction of production argument_expression_list -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 147, spurious reduction of production argument_expression_list -> assignment_expression
 ##
 
 Up to this point, a list of expressions has been recognized:
@@ -1674,7 +1879,7 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 76.
+## Ends in an error in state: 77.
 ##
 ## postfix_expression -> postfix_expression LPAREN . option(argument_expression_list) RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -1692,7 +1897,7 @@ followed with a closing parenthesis ')', is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME QUESTION PRE_NAME VAR_NAME COLON XOR_ASSIGN
 ##
-## Ends in an error in state: 138.
+## Ends in an error in state: 139.
 ##
 ## conditional_expression -> logical_or_expression QUESTION expression COLON . conditional_expression [ SEMICOLON RPAREN RBRACK RBRACE COMMA COLON ]
 ##
@@ -1701,7 +1906,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME QUESTION PRE_N
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME QUESTION XOR_ASSIGN
 ##
-## Ends in an error in state: 116.
+## Ends in an error in state: 117.
 ##
 ## conditional_expression -> logical_or_expression QUESTION . expression COLON conditional_expression [ SEMICOLON RPAREN RBRACK RBRACE COMMA COLON ]
 ##
@@ -1716,7 +1921,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME QUESTION PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 134.
+## Ends in an error in state: 135.
 ##
 ## conditional_expression -> logical_or_expression QUESTION expression . COLON conditional_expression [ SEMICOLON RPAREN RBRACK RBRACE COMMA COLON ]
 ## expression -> expression . COMMA assignment_expression [ COMMA COLON ]
@@ -1728,21 +1933,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ PRE_NAME VAR_NAME QUESTION PRE_N
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 # gcc and clang simply expect a colon.
@@ -1759,10 +1964,10 @@ then at this point, a colon ':' is expected.
 
 translation_unit_file: PACKED LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 415.
+## Ends in an error in state: 436.
 ##
 ## argument_expression_list -> argument_expression_list . COMMA assignment_expression [ RPAREN COMMA ]
-## attribute_specifier -> PACKED LPAREN argument_expression_list . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> PACKED LPAREN argument_expression_list . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## PACKED LPAREN argument_expression_list
@@ -1771,21 +1976,21 @@ translation_unit_file: PACKED LPAREN PRE_NAME VAR_NAME SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 146, spurious reduction of production argument_expression_list -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 147, spurious reduction of production argument_expression_list -> assignment_expression
 ##
 
 Ill-formed $2 attribute.
@@ -1800,7 +2005,7 @@ translation_unit_file: PACKED LPAREN XOR_ASSIGN
 ##
 ## Ends in an error in state: 19.
 ##
-## attribute_specifier -> PACKED LPAREN . argument_expression_list RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> PACKED LPAREN . argument_expression_list RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## PACKED LPAREN
@@ -1835,7 +2040,7 @@ translation_unit_file: PACKED XOR_ASSIGN
 ##
 ## Ends in an error in state: 18.
 ##
-## attribute_specifier -> PACKED . LPAREN argument_expression_list RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
+## attribute_specifier -> PACKED . LPAREN argument_expression_list RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE STRUCT STRING_LITERAL STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER RBRACK PRE_NAME PLUS PACKED NORETURN MINUS LPAREN LONG LBRACK LBRACE INT INLINE INC GENERIC FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE DEC CONSTANT CONST COMMA COLON CHAR BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AUTO ATTRIBUTE AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## PACKED
@@ -1855,7 +2060,7 @@ translation_unit_file: XOR_ASSIGN
 ##
 ## Ends in an error in state: 2.
 ##
-## list(translation_item) -> list(translation_item) . translation_item [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC_ASSERT STATIC SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PRAGMA PACKED NORETURN LONG INT INLINE FLOAT EXTERN EOF ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(translation_item) -> list(translation_item) . translation_item [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC_ASSERT STATIC SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PRAGMA PACKED NORETURN LONG INT INLINE FLOAT16 FLOAT EXTERN EOF ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ## translation_unit_file -> list(translation_item) . EOF [ # ]
 ##
 ## The known suffix of the stack is as follows:
@@ -1876,7 +2081,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: TYPEDEF PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 418.
+## Ends in an error in state: 439.
 ##
 ## declaration_specifiers_typedef -> TYPEDEF list(declaration_specifier_no_type) typedef_name list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE STATIC STAR SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN INLINE EXTERN CONST AUTO ATTRIBUTE ALIGNAS ]
@@ -1889,7 +2094,7 @@ translation_unit_file: TYPEDEF PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
 translation_unit_file: PRE_NAME TYPEDEF_NAME TYPEDEF XOR_ASSIGN
 ##
-## Ends in an error in state: 427.
+## Ends in an error in state: 448.
 ##
 ## declaration_specifiers_typedef -> typedef_name list(declaration_specifier_no_type) TYPEDEF list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE STATIC STAR SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN INLINE EXTERN CONST AUTO ATTRIBUTE ALIGNAS ]
@@ -1902,7 +2107,7 @@ translation_unit_file: PRE_NAME TYPEDEF_NAME TYPEDEF XOR_ASSIGN
 ##
 translation_unit_file: VOLATILE TYPEDEF PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 438.
+## Ends in an error in state: 459.
 ##
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) TYPEDEF list(declaration_specifier_no_type) typedef_name list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE STATIC STAR SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN INLINE EXTERN CONST AUTO ATTRIBUTE ALIGNAS ]
@@ -1915,7 +2120,7 @@ translation_unit_file: VOLATILE TYPEDEF PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
 translation_unit_file: VOLATILE PRE_NAME TYPEDEF_NAME TYPEDEF XOR_ASSIGN
 ##
-## Ends in an error in state: 444.
+## Ends in an error in state: 465.
 ##
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) typedef_name list(declaration_specifier_no_type) TYPEDEF list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE STATIC STAR SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN INLINE EXTERN CONST AUTO ATTRIBUTE ALIGNAS ]
@@ -1928,40 +2133,40 @@ translation_unit_file: VOLATILE PRE_NAME TYPEDEF_NAME TYPEDEF XOR_ASSIGN
 ##
 translation_unit_file: TYPEDEF INT XOR_ASSIGN
 ##
-## Ends in an error in state: 420.
+## Ends in an error in state: 441.
 ##
 ## declaration_specifiers_typedef -> TYPEDEF list(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## TYPEDEF list(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
 ##
 translation_unit_file: INT TYPEDEF XOR_ASSIGN
 ##
-## Ends in an error in state: 431.
+## Ends in an error in state: 452.
 ##
 ## declaration_specifiers_typedef -> type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) TYPEDEF list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) TYPEDEF list(declaration_specifier_no_typedef_name)
 ##
 translation_unit_file: VOLATILE TYPEDEF INT XOR_ASSIGN
 ##
-## Ends in an error in state: 440.
+## Ends in an error in state: 461.
 ##
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) TYPEDEF list(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## rlist(declaration_specifier_no_type) TYPEDEF list(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
 ##
 translation_unit_file: VOLATILE INT TYPEDEF XOR_ASSIGN
 ##
-## Ends in an error in state: 448.
+## Ends in an error in state: 469.
 ##
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) TYPEDEF list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) TYPEDEF list(declaration_specifier_no_typedef_name)
@@ -2001,24 +2206,24 @@ translation_unit_file: TYPEDEF XOR_ASSIGN
 ##
 ## declaration_specifiers_typedef -> TYPEDEF list(declaration_specifier_no_type) . typedef_name list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> TYPEDEF list(declaration_specifier_no_type) . type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
-## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . type_qualifier_noattr [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
-## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . function_specifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
-## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . attribute_specifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . type_qualifier_noattr [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . function_specifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . attribute_specifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## TYPEDEF list(declaration_specifier_no_type)
 ##
 translation_unit_file: VOLATILE TYPEDEF XOR_ASSIGN
 ##
-## Ends in an error in state: 436.
+## Ends in an error in state: 457.
 ##
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) TYPEDEF list(declaration_specifier_no_type) . typedef_name list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) TYPEDEF list(declaration_specifier_no_type) . type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
-## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . type_qualifier_noattr [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
-## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . function_specifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
-## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . attribute_specifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . type_qualifier_noattr [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . function_specifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . attribute_specifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## rlist(declaration_specifier_no_type) TYPEDEF list(declaration_specifier_no_type)
@@ -2045,7 +2250,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN VOLATILE XOR_ASSIGN
 ##
-## Ends in an error in state: 233.
+## Ends in an error in state: 234.
 ##
 ## declaration_specifiers(parameter_declaration) -> rlist(declaration_specifier_no_type) . typedef_name list(declaration_specifier_no_type) [ STAR RPAREN PRE_NAME LPAREN LBRACK COMMA ]
 ## declaration_specifiers(parameter_declaration) -> rlist(declaration_specifier_no_type) . type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) [ STAR RPAREN PRE_NAME LPAREN LBRACK COMMA ]
@@ -2057,7 +2262,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN VOLATILE XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 225, spurious reduction of production rlist(declaration_specifier_no_type) -> type_qualifier_noattr
+## In state 226, spurious reduction of production rlist(declaration_specifier_no_type) -> type_qualifier_noattr
 ##
 
 # Analogous to the above, except we are in the context of a parameter declaration,
@@ -2081,7 +2286,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 425.
+## Ends in an error in state: 446.
 ##
 ## declaration_specifiers(declaration(external_declaration)) -> typedef_name list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> typedef_name list(declaration_specifier_no_type) . TYPEDEF list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
@@ -2095,7 +2300,7 @@ translation_unit_file: PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
 translation_unit_file: VOLATILE PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 442.
+## Ends in an error in state: 463.
 ##
 ## declaration_specifiers(declaration(external_declaration)) -> rlist(declaration_specifier_no_type) typedef_name list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) typedef_name list(declaration_specifier_no_type) . TYPEDEF list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
@@ -2109,22 +2314,22 @@ translation_unit_file: VOLATILE PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
 translation_unit_file: INT XOR_ASSIGN
 ##
-## Ends in an error in state: 429.
+## Ends in an error in state: 450.
 ##
 ## declaration_specifiers(declaration(external_declaration)) -> type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . TYPEDEF list(declaration_specifier_no_typedef_name) [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
 ##
 translation_unit_file: VOLATILE INT XOR_ASSIGN
 ##
-## Ends in an error in state: 446.
+## Ends in an error in state: 467.
 ##
 ## declaration_specifiers(declaration(external_declaration)) -> rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . TYPEDEF list(declaration_specifier_no_typedef_name) [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
@@ -2181,7 +2386,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 212.
+## Ends in an error in state: 213.
 ##
 ## declaration_specifiers(parameter_declaration) -> typedef_name list(declaration_specifier_no_type) . [ STAR RPAREN PRE_NAME LPAREN LBRACK COMMA ]
 ## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE STATIC STAR RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LBRACK INLINE EXTERN CONST COMMA AUTO ATTRIBUTE ALIGNAS ]
@@ -2194,7 +2399,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME TYPEDEF_NAME XOR_AS
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN VOLATILE PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 235.
+## Ends in an error in state: 236.
 ##
 ## declaration_specifiers(parameter_declaration) -> rlist(declaration_specifier_no_type) typedef_name list(declaration_specifier_no_type) . [ STAR RPAREN PRE_NAME LPAREN LBRACK COMMA ]
 ## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE STATIC STAR RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LBRACK INLINE EXTERN CONST COMMA AUTO ATTRIBUTE ALIGNAS ]
@@ -2207,20 +2412,20 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN VOLATILE PRE_NAME TYPEDEF_NA
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT XOR_ASSIGN
 ##
-## Ends in an error in state: 218.
+## Ends in an error in state: 219.
 ##
 ## declaration_specifiers(parameter_declaration) -> type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR RPAREN PRE_NAME LPAREN LBRACK COMMA ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMMA CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST COMMA CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN VOLATILE INT XOR_ASSIGN
 ##
-## Ends in an error in state: 237.
+## Ends in an error in state: 238.
 ##
 ## declaration_specifiers(parameter_declaration) -> rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR RPAREN PRE_NAME LPAREN LBRACK COMMA ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMMA CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST COMMA CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
@@ -2266,7 +2471,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: VOLATILE XOR_ASSIGN
 ##
-## Ends in an error in state: 434.
+## Ends in an error in state: 455.
 ##
 ## declaration_specifiers(declaration(external_declaration)) -> rlist(declaration_specifier_no_type) . typedef_name list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers(declaration(external_declaration)) -> rlist(declaration_specifier_no_type) . type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) [ STAR SEMICOLON PRE_NAME LPAREN ]
@@ -2282,7 +2487,7 @@ translation_unit_file: VOLATILE XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 225, spurious reduction of production rlist(declaration_specifier_no_type) -> type_qualifier_noattr
+## In state 226, spurious reduction of production rlist(declaration_specifier_no_type) -> type_qualifier_noattr
 ##
 
 # We have seen some specifiers or qualifiers. We have probably seen at least
@@ -2311,7 +2516,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE VOLATILE XOR_ASSIGN
 ##
-## Ends in an error in state: 544.
+## Ends in an error in state: 565.
 ##
 ## declaration_specifiers(declaration(block_item)) -> rlist(declaration_specifier_no_type) . typedef_name list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers(declaration(block_item)) -> rlist(declaration_specifier_no_type) . type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) [ STAR SEMICOLON PRE_NAME LPAREN ]
@@ -2327,7 +2532,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 225, spurious reduction of production rlist(declaration_specifier_no_type) -> type_qualifier_noattr
+## In state 226, spurious reduction of production rlist(declaration_specifier_no_type) -> type_qualifier_noattr
 ##
 # Identical to the previous one, except we are not at the top level,
 # so we know this cannot be the beginning of a function definition.
@@ -2342,7 +2547,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE PRE_NAME TYPEDEF_NAME VOLATILE XOR_ASSIGN
 ##
-## Ends in an error in state: 540.
+## Ends in an error in state: 561.
 ##
 ## declaration_specifiers(declaration(block_item)) -> typedef_name list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> typedef_name list(declaration_specifier_no_type) . TYPEDEF list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
@@ -2356,7 +2561,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE VOLATILE PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 546.
+## Ends in an error in state: 567.
 ##
 ## declaration_specifiers(declaration(block_item)) -> rlist(declaration_specifier_no_type) typedef_name list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) typedef_name list(declaration_specifier_no_type) . TYPEDEF list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
@@ -2370,22 +2575,22 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE INT XOR_ASSIGN
 ##
-## Ends in an error in state: 542.
+## Ends in an error in state: 563.
 ##
 ## declaration_specifiers(declaration(block_item)) -> type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . TYPEDEF list(declaration_specifier_no_typedef_name) [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE VOLATILE INT XOR_ASSIGN
 ##
-## Ends in an error in state: 548.
+## Ends in an error in state: 569.
 ##
 ## declaration_specifiers(declaration(block_item)) -> rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . TYPEDEF list(declaration_specifier_no_typedef_name) [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
@@ -2421,9 +2626,9 @@ At this point, one of the following is expected:
 
 translation_unit_file: UNION LBRACE PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 192.
+## Ends in an error in state: 193.
 ##
-## struct_declaration -> specifier_qualifier_list(struct_declaration) . option(struct_declarator_list) SEMICOLON [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC_ASSERT SIGNED SHORT RESTRICT RBRACE PRE_NAME PACKED LONG INT FLOAT ENUM DOUBLE CONST CHAR ATTRIBUTE ALIGNAS ]
+## struct_declaration -> specifier_qualifier_list(struct_declaration) . option(struct_declarator_list) SEMICOLON [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC_ASSERT SIGNED SHORT RESTRICT RBRACE PRE_NAME PACKED LONG INT FLOAT16 FLOAT ENUM DOUBLE CONST CHAR ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## specifier_qualifier_list(struct_declaration)
@@ -2432,7 +2637,7 @@ translation_unit_file: UNION LBRACE PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 177, spurious reduction of production specifier_qualifier_list(struct_declaration) -> typedef_name option(type_qualifier_list)
+## In state 178, spurious reduction of production specifier_qualifier_list(struct_declaration) -> typedef_name option(type_qualifier_list)
 ##
 
 # We have (spuriously) recognized a specifier_qualifier_list,
@@ -2466,7 +2671,7 @@ at this point, one of the following is expected:
 
 translation_unit_file: UNION LBRACE LONG COLON CONSTANT RPAREN
 ##
-## Ends in an error in state: 298.
+## Ends in an error in state: 319.
 ##
 ## option(struct_declarator_list) -> struct_declarator_list . [ SEMICOLON ]
 ## struct_declarator_list -> struct_declarator_list . COMMA struct_declarator [ SEMICOLON COMMA ]
@@ -2478,21 +2683,21 @@ translation_unit_file: UNION LBRACE LONG COLON CONSTANT RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 69, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 303, spurious reduction of production struct_declarator -> option(declarator) COLON conditional_expression
-## In state 305, spurious reduction of production struct_declarator_list -> struct_declarator
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 70, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 324, spurious reduction of production struct_declarator -> option(declarator) COLON conditional_expression
+## In state 326, spurious reduction of production struct_declarator_list -> struct_declarator
 ##
 
 # We have seen a non-empty struct_declarator_list.
@@ -2510,7 +2715,7 @@ then at this point, a semicolon ';' is expected.
 
 translation_unit_file: UNION LBRACE INT COLON XOR_ASSIGN
 ##
-## Ends in an error in state: 302.
+## Ends in an error in state: 323.
 ##
 ## struct_declarator -> option(declarator) COLON . conditional_expression [ SEMICOLON COMMA ]
 ##
@@ -2525,7 +2730,7 @@ At this point, a constant expression is expected.
 
 translation_unit_file: UNION LBRACE INT PRE_NAME VAR_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 299.
+## Ends in an error in state: 320.
 ##
 ## struct_declarator_list -> struct_declarator_list COMMA . struct_declarator [ SEMICOLON COMMA ]
 ##
@@ -2540,7 +2745,7 @@ At this point, a struct declarator is expected.
 
 translation_unit_file: UNION LBRACE INT PRE_NAME VAR_NAME RPAREN
 ##
-## Ends in an error in state: 304.
+## Ends in an error in state: 325.
 ##
 ## option(declarator) -> declarator . [ COLON ]
 ## struct_declarator -> declarator . [ SEMICOLON COMMA ]
@@ -2552,9 +2757,9 @@ translation_unit_file: UNION LBRACE INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 266, spurious reduction of production declarator_noattrend -> direct_declarator
-## In state 271, spurious reduction of production attribute_specifier_list ->
-## In state 272, spurious reduction of production declarator -> declarator_noattrend attribute_specifier_list
+## In state 277, spurious reduction of production declarator_noattrend -> direct_declarator
+## In state 292, spurious reduction of production attribute_specifier_list ->
+## In state 293, spurious reduction of production declarator -> declarator_noattrend attribute_specifier_list
 ##
 
 # Assuming the declarator so far is complete, we expect
@@ -2577,7 +2782,7 @@ then at this point, one of the following is expected:
 
 translation_unit_file: UNION LBRACE VOLATILE ADD_ASSIGN
 ##
-## Ends in an error in state: 185.
+## Ends in an error in state: 186.
 ##
 ## option(type_qualifier_list) -> type_qualifier_list . [ VOLATILE RESTRICT PACKED CONST ATTRIBUTE ALIGNAS ]
 ## specifier_qualifier_list(struct_declaration) -> type_qualifier_list . typedef_name option(type_qualifier_list) [ STAR SEMICOLON PRE_NAME LPAREN COLON ]
@@ -2600,10 +2805,10 @@ At this point, one of the following is expected:
 
 translation_unit_file: UNION LBRACE XOR_ASSIGN
 ##
-## Ends in an error in state: 167.
+## Ends in an error in state: 168.
 ##
-## struct_declaration_list -> struct_declaration_list . struct_declaration [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC_ASSERT SIGNED SHORT RESTRICT RBRACE PRE_NAME PACKED LONG INT FLOAT ENUM DOUBLE CONST CHAR ATTRIBUTE ALIGNAS ]
-## struct_or_union_specifier -> struct_or_union attribute_specifier_list option(other_identifier) LBRACE struct_declaration_list . RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## struct_declaration_list -> struct_declaration_list . struct_declaration [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC_ASSERT SIGNED SHORT RESTRICT RBRACE PRE_NAME PACKED LONG INT FLOAT16 FLOAT ENUM DOUBLE CONST CHAR ATTRIBUTE ALIGNAS ]
+## struct_or_union_specifier -> struct_or_union attribute_specifier_list option(other_identifier) LBRACE struct_declaration_list . RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## struct_or_union attribute_specifier_list option(other_identifier) LBRACE struct_declaration_list
@@ -2620,10 +2825,10 @@ At this point, one of the following is expected:
 
 translation_unit_file: UNION XOR_ASSIGN
 ##
-## Ends in an error in state: 164.
+## Ends in an error in state: 165.
 ##
-## struct_or_union_specifier -> struct_or_union attribute_specifier_list . option(other_identifier) LBRACE struct_declaration_list RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
-## struct_or_union_specifier -> struct_or_union attribute_specifier_list . general_identifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## struct_or_union_specifier -> struct_or_union attribute_specifier_list . option(other_identifier) LBRACE struct_declaration_list RBRACE [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## struct_or_union_specifier -> struct_or_union attribute_specifier_list . general_identifier [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF STRUCT STATIC STAR SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## struct_or_union attribute_specifier_list
@@ -2632,7 +2837,7 @@ translation_unit_file: UNION XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 163, spurious reduction of production attribute_specifier_list ->
+## In state 164, spurious reduction of production attribute_specifier_list ->
 ##
 
 # gcc expects '{'.
@@ -2649,9 +2854,9 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 275.
+## Ends in an error in state: 296.
 ##
-## direct_declarator -> LPAREN save_context declarator . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## direct_declarator -> LPAREN save_context declarator . RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN save_context declarator
@@ -2660,9 +2865,9 @@ translation_unit_file: INT LPAREN PRE_NAME VAR_NAME SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 266, spurious reduction of production declarator_noattrend -> direct_declarator
-## In state 271, spurious reduction of production attribute_specifier_list ->
-## In state 272, spurious reduction of production declarator -> declarator_noattrend attribute_specifier_list
+## In state 277, spurious reduction of production declarator_noattrend -> direct_declarator
+## In state 292, spurious reduction of production attribute_specifier_list ->
+## In state 293, spurious reduction of production declarator -> declarator_noattrend attribute_specifier_list
 ##
 
 Up to this point, a declarator has been recognized:
@@ -2674,9 +2879,9 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 198.
+## Ends in an error in state: 199.
 ##
-## direct_declarator -> LPAREN save_context . declarator RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## direct_declarator -> LPAREN save_context . declarator RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## LPAREN save_context
@@ -2691,7 +2896,7 @@ At this point, a declarator is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 292.
+## Ends in an error in state: 313.
 ##
 ## identifier_list -> identifier_list . COMMA PRE_NAME VAR_NAME [ RPAREN COMMA ]
 ## option(identifier_list) -> identifier_list . [ RPAREN ]
@@ -2710,10 +2915,10 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 204.
+## Ends in an error in state: 205.
 ##
 ## context_parameter_type_list -> save_context . parameter_type_list save_context [ RPAREN ]
-## direct_declarator -> direct_declarator LPAREN save_context . option(identifier_list) RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## direct_declarator -> direct_declarator LPAREN save_context . option(identifier_list) RPAREN [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## direct_declarator LPAREN save_context
@@ -2734,9 +2939,9 @@ followed with a closing parenthesis ')', is expected.
 
 translation_unit_file: INT STAR RPAREN
 ##
-## Ends in an error in state: 201.
+## Ends in an error in state: 202.
 ##
-## declarator_noattrend -> list(pointer1) STAR option(type_qualifier_list) . direct_declarator [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG LBRACE INT INLINE FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## declarator_noattrend -> list(pointer1) STAR option(type_qualifier_list) . direct_declarator [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ## list(pointer1) -> list(pointer1) STAR option(type_qualifier_list) . [ STAR ]
 ## type_qualifier_list -> option(type_qualifier_list) . type_qualifier_noattr [ VOLATILE STAR RESTRICT PRE_NAME PACKED LPAREN CONST ATTRIBUTE ALIGNAS ]
 ## type_qualifier_list -> option(type_qualifier_list) . attribute_specifier [ VOLATILE STAR RESTRICT PRE_NAME PACKED LPAREN CONST ATTRIBUTE ALIGNAS ]
@@ -2767,7 +2972,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: TYPEDEF INT PRE_NAME VAR_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 560.
+## Ends in an error in state: 581.
 ##
 ## option(typedef_declarator_list) -> typedef_declarator_list . [ SEMICOLON ]
 ## typedef_declarator_list -> typedef_declarator_list . COMMA typedef_declarator [ SEMICOLON COMMA ]
@@ -2779,12 +2984,12 @@ translation_unit_file: TYPEDEF INT PRE_NAME VAR_NAME XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 266, spurious reduction of production declarator_noattrend -> direct_declarator
-## In state 271, spurious reduction of production attribute_specifier_list ->
-## In state 272, spurious reduction of production declarator -> declarator_noattrend attribute_specifier_list
-## In state 564, spurious reduction of production declare_typename(declarator) -> declarator
-## In state 563, spurious reduction of production typedef_declarator -> declare_typename(declarator)
-## In state 565, spurious reduction of production typedef_declarator_list -> typedef_declarator
+## In state 277, spurious reduction of production declarator_noattrend -> direct_declarator
+## In state 292, spurious reduction of production attribute_specifier_list ->
+## In state 293, spurious reduction of production declarator -> declarator_noattrend attribute_specifier_list
+## In state 585, spurious reduction of production declare_typename(declarator) -> declarator
+## In state 584, spurious reduction of production typedef_declarator -> declare_typename(declarator)
+## In state 586, spurious reduction of production typedef_declarator_list -> typedef_declarator
 ##
 
 # Because attribute_specifier_list, declarator and declarator_noattrend have been marked
@@ -2810,7 +3015,7 @@ then at this point, a semicolon ';' is expected.
 
 translation_unit_file: TYPEDEF INT PRE_NAME VAR_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 561.
+## Ends in an error in state: 582.
 ##
 ## typedef_declarator_list -> typedef_declarator_list COMMA . typedef_declarator [ SEMICOLON COMMA ]
 ##
@@ -2824,7 +3029,7 @@ At this point, a declarator is expected.
 
 translation_unit_file: ALIGNAS LPAREN INT LPAREN RPAREN LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 260.
+## Ends in an error in state: 271.
 ##
 ## direct_abstract_declarator -> direct_abstract_declarator LPAREN . option(context_parameter_type_list) RPAREN [ RPAREN LPAREN LBRACK COMMA COLON ]
 ##
@@ -2839,7 +3044,7 @@ followed with a closing parenthesis ')', is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM CONST XOR_ASSIGN
 ##
-## Ends in an error in state: 475.
+## Ends in an error in state: 496.
 ##
 ## asm_attributes -> CONST . asm_attributes [ LPAREN ]
 ##
@@ -2848,7 +3053,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM VOLATILE XOR_ASSIGN
 ##
-## Ends in an error in state: 474.
+## Ends in an error in state: 495.
 ##
 ## asm_attributes -> VOLATILE . asm_attributes [ LPAREN ]
 ##
@@ -2857,9 +3062,9 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM XOR_ASSIGN
 ##
-## Ends in an error in state: 473.
+## Ends in an error in state: 494.
 ##
-## asm_statement -> ASM . asm_attributes LPAREN string_literals_list asm_arguments RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## asm_statement -> ASM . asm_attributes LPAREN string_literals_list asm_arguments RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ASM
@@ -2874,7 +3079,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON COLON COLON STRING_LITERAL COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 499.
+## Ends in an error in state: 520.
 ##
 ## asm_flags -> asm_flags COMMA . string_literals_list [ RPAREN COMMA ]
 ##
@@ -2886,7 +3091,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 # first(asm_flags) = STRING_LITERAL
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON COLON COLON XOR_ASSIGN
 ##
-## Ends in an error in state: 496.
+## Ends in an error in state: 517.
 ##
 ## asm_arguments -> COLON asm_operands COLON asm_operands COLON . asm_flags [ RPAREN ]
 ##
@@ -2906,7 +3111,7 @@ Examples of clobbered resources:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON COLON COLON STRING_LITERAL XOR_ASSIGN
 ##
-## Ends in an error in state: 498.
+## Ends in an error in state: 519.
 ##
 ## asm_arguments -> COLON asm_operands COLON asm_operands COLON asm_flags . [ RPAREN ]
 ## asm_flags -> asm_flags . COMMA string_literals_list [ RPAREN COMMA ]
@@ -2918,7 +3123,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 497, spurious reduction of production asm_flags -> string_literals_list
+## In state 518, spurious reduction of production asm_flags -> string_literals_list
 ##
 
 # Let's ignore the possibility of concatenating string literals.
@@ -2935,7 +3140,7 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON STRING_LITERAL LPAREN CONSTANT RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 493.
+## Ends in an error in state: 514.
 ##
 ## asm_arguments -> COLON asm_operands . [ RPAREN ]
 ## asm_arguments -> COLON asm_operands . COLON asm_operands [ RPAREN ]
@@ -2948,7 +3153,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 485, spurious reduction of production asm_operands -> asm_operands_ne
+## In state 506, spurious reduction of production asm_operands -> asm_operands_ne
 ##
 
 # We have seen one COLON, hence the outputs. (The list of outputs may be empty.)
@@ -2965,7 +3170,7 @@ then at this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON COLON XOR_ASSIGN
 ##
-## Ends in an error in state: 495.
+## Ends in an error in state: 516.
 ##
 ## asm_arguments -> COLON asm_operands COLON asm_operands . [ RPAREN ]
 ## asm_arguments -> COLON asm_operands COLON asm_operands . COLON asm_flags [ RPAREN ]
@@ -2977,7 +3182,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 494, spurious reduction of production asm_operands ->
+## In state 515, spurious reduction of production asm_operands ->
 ##
 
 # We have seen two COLONs, hence the outputs and inputs. (The list of inputs may be empty.)
@@ -2997,7 +3202,7 @@ then at this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON LBRACK PRE_NAME VAR_NAME RBRACK XOR_ASSIGN
 ##
-## Ends in an error in state: 488.
+## Ends in an error in state: 509.
 ##
 ## asm_operand -> asm_op_name . string_literals_list LPAREN expression RPAREN [ RPAREN COMMA COLON ]
 ##
@@ -3016,7 +3221,7 @@ At this point, a string literal, representing a constraint, is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON LBRACK PRE_NAME VAR_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 483.
+## Ends in an error in state: 504.
 ##
 ## asm_op_name -> LBRACK general_identifier . RBRACK [ STRING_LITERAL ]
 ##
@@ -3031,7 +3236,7 @@ At this point, a closing bracket ']' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON LBRACK XOR_ASSIGN
 ##
-## Ends in an error in state: 482.
+## Ends in an error in state: 503.
 ##
 ## asm_op_name -> LBRACK . general_identifier RBRACK [ STRING_LITERAL ]
 ##
@@ -3046,7 +3251,7 @@ At this point, an identifier is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON STRING_LITERAL LPAREN CONSTANT RPAREN COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 486.
+## Ends in an error in state: 507.
 ##
 ## asm_operands_ne -> asm_operands_ne COMMA . asm_operand [ RPAREN COMMA COLON ]
 ##
@@ -3063,7 +3268,7 @@ At this point, an assembly operand is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON STRING_LITERAL LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 491.
+## Ends in an error in state: 512.
 ##
 ## asm_operand -> asm_op_name string_literals_list LPAREN expression . RPAREN [ RPAREN COMMA COLON ]
 ## expression -> expression . COMMA assignment_expression [ RPAREN COMMA ]
@@ -3075,21 +3280,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 Ill-formed assembly operand.
@@ -3102,7 +3307,7 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON STRING_LITERAL LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 490.
+## Ends in an error in state: 511.
 ##
 ## asm_operand -> asm_op_name string_literals_list LPAREN . expression RPAREN [ RPAREN COMMA COLON ]
 ##
@@ -3117,7 +3322,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL COLON STRING_LITERAL XOR_ASSIGN
 ##
-## Ends in an error in state: 489.
+## Ends in an error in state: 510.
 ##
 ## asm_operand -> asm_op_name string_literals_list . LPAREN expression RPAREN [ RPAREN COMMA COLON ]
 ## string_literals_list -> string_literals_list . STRING_LITERAL [ STRING_LITERAL LPAREN ]
@@ -3137,9 +3342,9 @@ followed with an expression and a closing parenthesis ')', is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL XOR_ASSIGN
 ##
-## Ends in an error in state: 480.
+## Ends in an error in state: 501.
 ##
-## asm_statement -> ASM asm_attributes LPAREN string_literals_list . asm_arguments RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## asm_statement -> ASM asm_attributes LPAREN string_literals_list . asm_arguments RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ## string_literals_list -> string_literals_list . STRING_LITERAL [ STRING_LITERAL RPAREN COLON ]
 ##
 ## The known suffix of the stack is as follows:
@@ -3159,9 +3364,9 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 479.
+## Ends in an error in state: 500.
 ##
-## asm_statement -> ASM asm_attributes LPAREN . string_literals_list asm_arguments RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## asm_statement -> ASM asm_attributes LPAREN . string_literals_list asm_arguments RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ASM asm_attributes LPAREN
@@ -3174,45 +3379,45 @@ At this point, a string literal, representing an instruction, is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE BREAK XOR_ASSIGN
 ##
-## Ends in an error in state: 471.
+## Ends in an error in state: 492.
 ##
-## jump_statement -> BREAK . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## jump_statement -> BREAK . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## BREAK
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE CONTINUE XOR_ASSIGN
 ##
-## Ends in an error in state: 466.
+## Ends in an error in state: 487.
 ##
-## jump_statement -> CONTINUE . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## jump_statement -> CONTINUE . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## CONTINUE
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DO SEMICOLON WHILE LPAREN PRE_NAME VAR_NAME RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 591.
+## Ends in an error in state: 612.
 ##
-## iteration_statement -> save_context do_statement1 WHILE LPAREN expression RPAREN . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context do_statement1 WHILE LPAREN expression RPAREN . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context do_statement1 WHILE LPAREN expression RPAREN
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE GOTO PRE_NAME VAR_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 462.
+## Ends in an error in state: 483.
 ##
-## jump_statement -> GOTO general_identifier . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## jump_statement -> GOTO general_identifier . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## GOTO general_identifier
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE ASM LPAREN STRING_LITERAL RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 503.
+## Ends in an error in state: 524.
 ##
-## asm_statement -> ASM asm_attributes LPAREN string_literals_list asm_arguments RPAREN . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## asm_statement -> ASM asm_attributes LPAREN string_literals_list asm_arguments RPAREN . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## ASM asm_attributes LPAREN string_literals_list asm_arguments RPAREN
@@ -3225,27 +3430,27 @@ At this point, a semicolon ';' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE CASE CONSTANT COLON XOR_ASSIGN
 ##
-## Ends in an error in state: 470.
+## Ends in an error in state: 491.
 ##
-## labeled_statement -> CASE conditional_expression COLON . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## labeled_statement -> CASE conditional_expression COLON . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE conditional_expression COLON
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DEFAULT COLON XOR_ASSIGN
 ##
-## Ends in an error in state: 465.
+## Ends in an error in state: 486.
 ##
-## labeled_statement -> DEFAULT COLON . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## labeled_statement -> DEFAULT COLON . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## DEFAULT COLON
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE PRE_NAME VAR_NAME COLON XOR_ASSIGN
 ##
-## Ends in an error in state: 519.
+## Ends in an error in state: 540.
 ##
-## labeled_statement -> general_identifier COLON . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## labeled_statement -> general_identifier COLON . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## general_identifier COLON
@@ -3260,9 +3465,9 @@ At this point, a statement is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE CASE CONSTANT SEMICOLON
 ##
-## Ends in an error in state: 469.
+## Ends in an error in state: 490.
 ##
-## labeled_statement -> CASE conditional_expression . COLON statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## labeled_statement -> CASE conditional_expression . COLON statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE conditional_expression
@@ -3271,19 +3476,19 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 69, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 70, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
 ##
 
 Ill-formed labeled statement.
@@ -3296,9 +3501,9 @@ then at this point, a colon ':' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE CASE XOR_ASSIGN
 ##
-## Ends in an error in state: 468.
+## Ends in an error in state: 489.
 ##
-## labeled_statement -> CASE . conditional_expression COLON statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## labeled_statement -> CASE . conditional_expression COLON statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## CASE
@@ -3311,18 +3516,18 @@ At this point, a constant expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DEFAULT XOR_ASSIGN
 ##
-## Ends in an error in state: 464.
+## Ends in an error in state: 485.
 ##
-## labeled_statement -> DEFAULT . COLON statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## labeled_statement -> DEFAULT . COLON statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## DEFAULT
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DO PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 518.
+## Ends in an error in state: 539.
 ##
-## labeled_statement -> general_identifier . COLON statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## labeled_statement -> general_identifier . COLON statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## general_identifier
@@ -3337,10 +3542,10 @@ At this point, a colon ':' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DO SEMICOLON WHILE LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 590.
+## Ends in an error in state: 611.
 ##
 ## expression -> expression . COMMA assignment_expression [ RPAREN COMMA ]
-## iteration_statement -> save_context do_statement1 WHILE LPAREN expression . RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context do_statement1 WHILE LPAREN expression . RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context do_statement1 WHILE LPAREN expression
@@ -3349,21 +3554,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 Ill-formed 'do' ... 'while' statement.
@@ -3376,9 +3581,9 @@ then at this point, a closing parenthesis ')' and a semicolon ';' are expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DO SEMICOLON WHILE LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 589.
+## Ends in an error in state: 610.
 ##
-## iteration_statement -> save_context do_statement1 WHILE LPAREN . expression RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context do_statement1 WHILE LPAREN . expression RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context do_statement1 WHILE LPAREN
@@ -3391,9 +3596,9 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DO SEMICOLON WHILE XOR_ASSIGN
 ##
-## Ends in an error in state: 588.
+## Ends in an error in state: 609.
 ##
-## iteration_statement -> save_context do_statement1 WHILE . LPAREN expression RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context do_statement1 WHILE . LPAREN expression RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context do_statement1 WHILE
@@ -3406,9 +3611,9 @@ At this point, an opening parenthesis '(' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DO SEMICOLON XOR_ASSIGN
 ##
-## Ends in an error in state: 587.
+## Ends in an error in state: 608.
 ##
-## iteration_statement -> save_context do_statement1 . WHILE LPAREN expression RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context do_statement1 . WHILE LPAREN expression RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context do_statement1
@@ -3427,7 +3632,7 @@ At this point, a 'while' keyword is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DO XOR_ASSIGN
 ##
-## Ends in an error in state: 583.
+## Ends in an error in state: 604.
 ##
 ## do_statement1 -> save_context DO . statement [ WHILE ]
 ##
@@ -3444,9 +3649,9 @@ At this point, a statement (the loop body) is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE FOR LPAREN SEMICOLON SEMICOLON RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 553.
+## Ends in an error in state: 574.
 ##
-## iteration_statement -> save_context FOR LPAREN for_statement_header optional(expression,SEMICOLON) optional(expression,RPAREN) . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context FOR LPAREN for_statement_header optional(expression,SEMICOLON) optional(expression,RPAREN) . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context FOR LPAREN for_statement_header optional(expression,SEMICOLON) optional(expression,RPAREN)
@@ -3459,7 +3664,7 @@ At this point, a statement (the loop body) is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE FOR LPAREN SEMICOLON SEMICOLON PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 555.
+## Ends in an error in state: 576.
 ##
 ## expression -> expression . COMMA assignment_expression [ RPAREN COMMA ]
 ## optional(expression,RPAREN) -> expression . RPAREN [ WHILE TILDE SWITCH STRING_LITERAL STAR SIZEOF SEMICOLON RETURN PRE_NAME PLUS MINUS LPAREN LBRACE INC IF GOTO GENERIC FOR DO DEFAULT DEC CONTINUE CONSTANT CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG ASM AND ALIGNOF ]
@@ -3471,21 +3676,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 # The use of optional(expression,RPAREN) tells us that we are in a FOR statement.
@@ -3501,9 +3706,9 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE FOR LPAREN SEMICOLON SEMICOLON XOR_ASSIGN
 ##
-## Ends in an error in state: 551.
+## Ends in an error in state: 572.
 ##
-## iteration_statement -> save_context FOR LPAREN for_statement_header optional(expression,SEMICOLON) . optional(expression,RPAREN) statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context FOR LPAREN for_statement_header optional(expression,SEMICOLON) . optional(expression,RPAREN) statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context FOR LPAREN for_statement_header optional(expression,SEMICOLON)
@@ -3521,9 +3726,9 @@ followed with a closing parenthesis ')', is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE FOR LPAREN SEMICOLON XOR_ASSIGN
 ##
-## Ends in an error in state: 550.
+## Ends in an error in state: 571.
 ##
-## iteration_statement -> save_context FOR LPAREN for_statement_header . optional(expression,SEMICOLON) optional(expression,RPAREN) statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context FOR LPAREN for_statement_header . optional(expression,SEMICOLON) optional(expression,RPAREN) statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context FOR LPAREN for_statement_header
@@ -3540,7 +3745,7 @@ followed with a semicolon ';', is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE FOR LPAREN PRE_NAME VAR_NAME RPAREN
 ##
-## Ends in an error in state: 557.
+## Ends in an error in state: 578.
 ##
 ## expression -> expression . COMMA assignment_expression [ SEMICOLON COMMA ]
 ## optional(expression,SEMICOLON) -> expression . SEMICOLON [ TILDE STRING_LITERAL STAR SIZEOF SEMICOLON RPAREN PRE_NAME PLUS MINUS LPAREN INC GENERIC DEC CONSTANT BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AND ALIGNOF ]
@@ -3552,21 +3757,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 # At the time of writing, optional(expression,SEMICOLON) is used only in FOR
@@ -3582,9 +3787,9 @@ then at this point, a semicolon ';' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE FOR LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 537.
+## Ends in an error in state: 558.
 ##
-## iteration_statement -> save_context FOR LPAREN . for_statement_header optional(expression,SEMICOLON) optional(expression,RPAREN) statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context FOR LPAREN . for_statement_header optional(expression,SEMICOLON) optional(expression,RPAREN) statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context FOR LPAREN
@@ -3603,9 +3808,9 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE FOR XOR_ASSIGN
 ##
-## Ends in an error in state: 536.
+## Ends in an error in state: 557.
 ##
-## iteration_statement -> save_context FOR . LPAREN for_statement_header optional(expression,SEMICOLON) optional(expression,RPAREN) statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context FOR . LPAREN for_statement_header optional(expression,SEMICOLON) optional(expression,RPAREN) statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context FOR
@@ -3618,9 +3823,9 @@ At this point, an opening parenthesis '(' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE GOTO XOR_ASSIGN
 ##
-## Ends in an error in state: 461.
+## Ends in an error in state: 482.
 ##
-## jump_statement -> GOTO . general_identifier SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## jump_statement -> GOTO . general_identifier SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## GOTO
@@ -3633,9 +3838,9 @@ At this point, an identifier (a 'goto' label) is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE DO IF LPAREN CONSTANT RPAREN SEMICOLON ELSE XOR_ASSIGN
 ##
-## Ends in an error in state: 585.
+## Ends in an error in state: 606.
 ##
-## selection_statement -> save_context ifelse_statement1 . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## selection_statement -> save_context ifelse_statement1 . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context ifelse_statement1
@@ -3648,10 +3853,10 @@ At this point, a statement is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE IF LPAREN PRE_NAME VAR_NAME RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 533.
+## Ends in an error in state: 554.
 ##
 ## ifelse_statement1 -> IF LPAREN expression RPAREN save_context . statement ELSE [ WHILE TILDE SWITCH STRING_LITERAL STAR SIZEOF SEMICOLON RETURN PRE_NAME PLUS MINUS LPAREN LBRACE INC IF GOTO GENERIC FOR DO DEFAULT DEC CONTINUE CONSTANT CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG ASM AND ALIGNOF ]
-## selection_statement -> save_context IF LPAREN expression RPAREN save_context . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## selection_statement -> save_context IF LPAREN expression RPAREN save_context . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context IF LPAREN expression RPAREN save_context
@@ -3664,11 +3869,11 @@ At this point, a statement is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE IF LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 531.
+## Ends in an error in state: 552.
 ##
 ## expression -> expression . COMMA assignment_expression [ RPAREN COMMA ]
 ## ifelse_statement1 -> IF LPAREN expression . RPAREN save_context statement ELSE [ WHILE TILDE SWITCH STRING_LITERAL STAR SIZEOF SEMICOLON RETURN PRE_NAME PLUS MINUS LPAREN LBRACE INC IF GOTO GENERIC FOR DO DEFAULT DEC CONTINUE CONSTANT CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG ASM AND ALIGNOF ]
-## selection_statement -> save_context IF LPAREN expression . RPAREN save_context statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## selection_statement -> save_context IF LPAREN expression . RPAREN save_context statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context IF LPAREN expression
@@ -3677,21 +3882,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 Ill-formed 'if' statement.
@@ -3704,10 +3909,10 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE IF LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 530.
+## Ends in an error in state: 551.
 ##
 ## ifelse_statement1 -> IF LPAREN . expression RPAREN save_context statement ELSE [ WHILE TILDE SWITCH STRING_LITERAL STAR SIZEOF SEMICOLON RETURN PRE_NAME PLUS MINUS LPAREN LBRACE INC IF GOTO GENERIC FOR DO DEFAULT DEC CONTINUE CONSTANT CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG ASM AND ALIGNOF ]
-## selection_statement -> save_context IF LPAREN . expression RPAREN save_context statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## selection_statement -> save_context IF LPAREN . expression RPAREN save_context statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context IF LPAREN
@@ -3720,10 +3925,10 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE IF XOR_ASSIGN
 ##
-## Ends in an error in state: 529.
+## Ends in an error in state: 550.
 ##
 ## ifelse_statement1 -> IF . LPAREN expression RPAREN save_context statement ELSE [ WHILE TILDE SWITCH STRING_LITERAL STAR SIZEOF SEMICOLON RETURN PRE_NAME PLUS MINUS LPAREN LBRACE INC IF GOTO GENERIC FOR DO DEFAULT DEC CONTINUE CONSTANT CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG ASM AND ALIGNOF ]
-## selection_statement -> save_context IF . LPAREN expression RPAREN save_context statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## selection_statement -> save_context IF . LPAREN expression RPAREN save_context statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context IF
@@ -3736,9 +3941,9 @@ At this point, an opening parenthesis '(' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE SWITCH LPAREN PRE_NAME VAR_NAME RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 527.
+## Ends in an error in state: 548.
 ##
-## selection_statement -> save_context SWITCH LPAREN expression RPAREN . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## selection_statement -> save_context SWITCH LPAREN expression RPAREN . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context SWITCH LPAREN expression RPAREN
@@ -3760,10 +3965,10 @@ enclosed within braces '{' and '}'.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE SWITCH LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 526.
+## Ends in an error in state: 547.
 ##
 ## expression -> expression . COMMA assignment_expression [ RPAREN COMMA ]
-## selection_statement -> save_context SWITCH LPAREN expression . RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## selection_statement -> save_context SWITCH LPAREN expression . RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context SWITCH LPAREN expression
@@ -3772,21 +3977,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 Ill-formed 'switch' statement.
@@ -3799,9 +4004,9 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE SWITCH LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 525.
+## Ends in an error in state: 546.
 ##
-## selection_statement -> save_context SWITCH LPAREN . expression RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## selection_statement -> save_context SWITCH LPAREN . expression RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context SWITCH LPAREN
@@ -3814,9 +4019,9 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE SWITCH XOR_ASSIGN
 ##
-## Ends in an error in state: 524.
+## Ends in an error in state: 545.
 ##
-## selection_statement -> save_context SWITCH . LPAREN expression RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## selection_statement -> save_context SWITCH . LPAREN expression RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context SWITCH
@@ -3829,9 +4034,9 @@ At this point, an opening parenthesis '(' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE WHILE LPAREN PRE_NAME VAR_NAME RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 511.
+## Ends in an error in state: 532.
 ##
-## iteration_statement -> save_context WHILE LPAREN expression RPAREN . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context WHILE LPAREN expression RPAREN . statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context WHILE LPAREN expression RPAREN
@@ -3844,10 +4049,10 @@ At this point, a statement (the loop body) is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE WHILE LPAREN PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 510.
+## Ends in an error in state: 531.
 ##
 ## expression -> expression . COMMA assignment_expression [ RPAREN COMMA ]
-## iteration_statement -> save_context WHILE LPAREN expression . RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context WHILE LPAREN expression . RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context WHILE LPAREN expression
@@ -3856,21 +4061,21 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 Ill-formed 'while' statement.
@@ -3883,9 +4088,9 @@ then at this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE WHILE LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 509.
+## Ends in an error in state: 530.
 ##
-## iteration_statement -> save_context WHILE LPAREN . expression RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context WHILE LPAREN . expression RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context WHILE LPAREN
@@ -3898,9 +4103,9 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE WHILE XOR_ASSIGN
 ##
-## Ends in an error in state: 508.
+## Ends in an error in state: 529.
 ##
-## iteration_statement -> save_context WHILE . LPAREN expression RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## iteration_statement -> save_context WHILE . LPAREN expression RPAREN statement [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context WHILE
@@ -3913,10 +4118,10 @@ At this point, an opening parenthesis '(' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE XOR_ASSIGN
 ##
-## Ends in an error in state: 452.
+## Ends in an error in state: 473.
 ##
-## block_item_list -> option(block_item_list) . block_item [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
-## compound_statement -> save_context LBRACE option(block_item_list) . RBRACE [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN EOF ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## block_item_list -> option(block_item_list) . block_item [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## compound_statement -> save_context LBRACE option(block_item_list) . RBRACE [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN EOF ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## save_context LBRACE option(block_item_list)
@@ -3941,9 +4146,9 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE RETURN XOR_ASSIGN
 ##
-## Ends in an error in state: 453.
+## Ends in an error in state: 474.
 ##
-## jump_statement -> RETURN . option(expression) SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## jump_statement -> RETURN . option(expression) SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN ENUM ELSE DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## RETURN
@@ -3960,7 +4165,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE STRING_LITERAL RPAREN
 ##
-## Ends in an error in state: 456.
+## Ends in an error in state: 477.
 ##
 ## expression -> expression . COMMA assignment_expression [ SEMICOLON COMMA ]
 ## option(expression) -> expression . [ SEMICOLON ]
@@ -3972,23 +4177,23 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 70, spurious reduction of production primary_expression -> string_literals_list
-## In state 72, spurious reduction of production postfix_expression -> primary_expression
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 140, spurious reduction of production expression -> assignment_expression
+## In state 71, spurious reduction of production primary_expression -> string_literals_list
+## In state 73, spurious reduction of production postfix_expression -> primary_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 141, spurious reduction of production expression -> assignment_expression
 ##
 
 Up to this point, an expression has been recognized:
@@ -4000,7 +4205,7 @@ then at this point, a semicolon ';' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 594.
+## Ends in an error in state: 615.
 ##
 ## declaration_specifiers(declaration(block_item)) -> typedef_name . list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers_typedef -> typedef_name . list(declaration_specifier_no_type) TYPEDEF list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
@@ -4035,7 +4240,7 @@ at this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME RPAREN LBRACE PRE_NAME VAR_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 135.
+## Ends in an error in state: 136.
 ##
 ## expression -> expression COMMA . assignment_expression [ SEMICOLON RPAREN RBRACK COMMA COLON ]
 ##
@@ -4050,7 +4255,7 @@ At this point, an expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME COMMA PRE_NAME VAR_NAME RPAREN
 ##
-## Ends in an error in state: 571.
+## Ends in an error in state: 592.
 ##
 ## init_declarator_list -> init_declarator_list . COMMA init_declarator [ SEMICOLON COMMA ]
 ## option(init_declarator_list) -> init_declarator_list . [ SEMICOLON ]
@@ -4062,12 +4267,12 @@ translation_unit_file: INT PRE_NAME VAR_NAME COMMA PRE_NAME VAR_NAME RPAREN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 266, spurious reduction of production declarator_noattrend -> direct_declarator
-## In state 579, spurious reduction of production declare_varname(declarator_noattrend) -> declarator_noattrend
-## In state 574, spurious reduction of production save_context ->
-## In state 575, spurious reduction of production attribute_specifier_list ->
-## In state 576, spurious reduction of production init_declarator -> declare_varname(declarator_noattrend) save_context attribute_specifier_list
-## In state 573, spurious reduction of production init_declarator_list -> init_declarator_list COMMA init_declarator
+## In state 277, spurious reduction of production declarator_noattrend -> direct_declarator
+## In state 600, spurious reduction of production declare_varname(declarator_noattrend) -> declarator_noattrend
+## In state 595, spurious reduction of production save_context ->
+## In state 596, spurious reduction of production attribute_specifier_list ->
+## In state 597, spurious reduction of production init_declarator -> declare_varname(declarator_noattrend) save_context attribute_specifier_list
+## In state 594, spurious reduction of production init_declarator_list -> init_declarator_list COMMA init_declarator
 ##
 
 Up to this point, a list of declarators has been recognized:
@@ -4079,7 +4284,7 @@ then at this point, a semicolon ';' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 572.
+## Ends in an error in state: 593.
 ##
 ## init_declarator_list -> init_declarator_list COMMA . init_declarator [ SEMICOLON COMMA ]
 ##
@@ -4094,7 +4299,7 @@ At this point, an init declarator is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE DOT PRE_NAME VAR_NAME EQ ALIGNAS
 ##
-## Ends in an error in state: 390.
+## Ends in an error in state: 411.
 ##
 ## initializer_list -> option(designation) . c_initializer [ RBRACE COMMA ]
 ##
@@ -4103,7 +4308,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE DOT PRE_NAME VAR_NAME EQ 
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE PRE_NAME VAR_NAME COMMA DOT PRE_NAME VAR_NAME EQ ALIGNAS
 ##
-## Ends in an error in state: 394.
+## Ends in an error in state: 415.
 ##
 ## initializer_list -> initializer_list COMMA option(designation) . c_initializer [ RBRACE COMMA ]
 ##
@@ -4118,7 +4323,7 @@ At this point, an initializer is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE DOT PRE_NAME VAR_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 397.
+## Ends in an error in state: 418.
 ##
 ## designation -> designator_list . EQ [ TILDE STRING_LITERAL STAR SIZEOF PRE_NAME PLUS MINUS LPAREN LBRACE INC GENERIC DEC CONSTANT BUILTIN_VA_ARG BUILTIN_OFFSETOF BANG AND ALIGNOF ]
 ## option(designator_list) -> designator_list . [ LBRACK DOT ]
@@ -4140,7 +4345,7 @@ then at this point, an equals sign '=' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE DOT XOR_ASSIGN
 ##
-## Ends in an error in state: 364.
+## Ends in an error in state: 385.
 ##
 ## designator -> DOT . general_identifier [ RPAREN LBRACK EQ DOT ]
 ##
@@ -4157,7 +4362,7 @@ At this point, the name of a struct or union member is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE LBRACK PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 362.
+## Ends in an error in state: 383.
 ##
 ## designator -> LBRACK conditional_expression . RBRACK [ RPAREN LBRACK EQ DOT ]
 ##
@@ -4168,19 +4373,19 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE LBRACK PRE_NAME VAR_NAME 
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 69, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 70, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
 ##
 
 Ill-formed designator.
@@ -4193,7 +4398,7 @@ then at this point, a closing bracket ']' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE LBRACK XOR_ASSIGN
 ##
-## Ends in an error in state: 361.
+## Ends in an error in state: 382.
 ##
 ## designator -> LBRACK . conditional_expression RBRACK [ RPAREN LBRACK EQ DOT ]
 ##
@@ -4208,7 +4413,7 @@ At this point, a constant expression is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE PRE_NAME VAR_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 393.
+## Ends in an error in state: 414.
 ##
 ## initializer_list -> initializer_list COMMA . option(designation) c_initializer [ RBRACE COMMA ]
 ## option(COMMA) -> COMMA . [ RBRACE ]
@@ -4229,7 +4434,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE CONSTANT SEMICOLON
 ##
-## Ends in an error in state: 392.
+## Ends in an error in state: 413.
 ##
 ## c_initializer -> LBRACE initializer_list . option(COMMA) RBRACE [ SEMICOLON RBRACE COMMA ]
 ## initializer_list -> initializer_list . COMMA option(designation) c_initializer [ RBRACE COMMA ]
@@ -4241,22 +4446,22 @@ translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE CONSTANT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 396, spurious reduction of production c_initializer -> assignment_expression
-## In state 402, spurious reduction of production initializer_list -> option(designation) c_initializer
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 417, spurious reduction of production c_initializer -> assignment_expression
+## In state 423, spurious reduction of production initializer_list -> option(designation) c_initializer
 ##
 
 # Omitting the fact that the closing brace can be preceded with a comma.
@@ -4271,7 +4476,7 @@ then at this point, a closing brace '}' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ LBRACE XOR_ASSIGN
 ##
-## Ends in an error in state: 391.
+## Ends in an error in state: 412.
 ##
 ## c_initializer -> LBRACE . initializer_list option(COMMA) RBRACE [ SEMICOLON RBRACE COMMA ]
 ##
@@ -4292,7 +4497,7 @@ followed with an initializer, is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME EQ XOR_ASSIGN
 ##
-## Ends in an error in state: 577.
+## Ends in an error in state: 598.
 ##
 ## init_declarator -> declare_varname(declarator_noattrend) save_context attribute_specifier_list EQ . c_initializer [ SEMICOLON COMMA ]
 ##
@@ -4309,9 +4514,9 @@ At this point, an initializer is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LBRACK CONSTANT SEMICOLON
 ##
-## Ends in an error in state: 254.
+## Ends in an error in state: 265.
 ##
-## optional(assignment_expression,RBRACK) -> assignment_expression . RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## optional(assignment_expression,RBRACK) -> assignment_expression . RBRACK [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## assignment_expression
@@ -4320,20 +4525,20 @@ translation_unit_file: INT PRE_NAME VAR_NAME LBRACK CONSTANT SEMICOLON
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
 ##
 
 # At the time of writing, optional(expression,RBRACK) is used only in direct
@@ -4351,7 +4556,7 @@ then at this point, a closing bracket ']' is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 293.
+## Ends in an error in state: 314.
 ##
 ## identifier_list -> identifier_list COMMA . PRE_NAME VAR_NAME [ RPAREN COMMA ]
 ##
@@ -4368,7 +4573,7 @@ At this point, an identifier is expected.
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME COMMA PRE_NAME TYPEDEF_NAME
 ##
-## Ends in an error in state: 294.
+## Ends in an error in state: 315.
 ##
 ## identifier_list -> identifier_list COMMA PRE_NAME . VAR_NAME [ RPAREN COMMA ]
 ##
@@ -4384,27 +4589,27 @@ The following type name is used as a K&R parameter name:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME RPAREN INT XOR_ASSIGN
 ##
-## Ends in an error in state: 612.
+## Ends in an error in state: 633.
 ##
 ## declaration_specifiers(declaration(block_item)) -> type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME RPAREN VOLATILE INT XOR_ASSIGN
 ##
-## Ends in an error in state: 617.
+## Ends in an error in state: 638.
 ##
 ## declaration_specifiers(declaration(block_item)) -> rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) . [ STAR SEMICOLON PRE_NAME LPAREN ]
-## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## list(declaration_specifier_no_typedef_name) -> list(declaration_specifier_no_typedef_name) . declaration_specifier_no_typedef_name [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC STAR SIGNED SHORT SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## rlist(declaration_specifier_no_type) type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name)
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME RPAREN PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 610.
+## Ends in an error in state: 631.
 ##
 ## declaration_specifiers(declaration(block_item)) -> typedef_name list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE STATIC STAR SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN INLINE EXTERN CONST AUTO ATTRIBUTE ALIGNAS ]
@@ -4417,7 +4622,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME RPAREN PRE
 ##
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME RPAREN VOLATILE PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 615.
+## Ends in an error in state: 636.
 ##
 ## declaration_specifiers(declaration(block_item)) -> rlist(declaration_specifier_no_type) typedef_name list(declaration_specifier_no_type) . [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## list(declaration_specifier_no_type) -> list(declaration_specifier_no_type) . storage_class_specifier_no_typedef [ VOLATILE STATIC STAR SEMICOLON RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN INLINE EXTERN CONST AUTO ATTRIBUTE ALIGNAS ]
@@ -4442,7 +4647,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME RPAREN VOLATILE XOR_ASSIGN
 ##
-## Ends in an error in state: 613.
+## Ends in an error in state: 634.
 ##
 ## declaration_specifiers(declaration(block_item)) -> rlist(declaration_specifier_no_type) . typedef_name list(declaration_specifier_no_type) [ STAR SEMICOLON PRE_NAME LPAREN ]
 ## declaration_specifiers(declaration(block_item)) -> rlist(declaration_specifier_no_type) . type_specifier_no_typedef_name list(declaration_specifier_no_typedef_name) [ STAR SEMICOLON PRE_NAME LPAREN ]
@@ -4454,7 +4659,7 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME RPAREN VOL
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 225, spurious reduction of production rlist(declaration_specifier_no_type) -> type_qualifier_noattr
+## In state 226, spurious reduction of production rlist(declaration_specifier_no_type) -> type_qualifier_noattr
 ##
 
 Ill-formed K&R parameter declaration.
@@ -4467,11 +4672,11 @@ At this point, one of the following is expected:
 
 translation_unit_file: VOID PRE_NAME TYPEDEF_NAME PACKED LPAREN CONSTANT RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 626.
+## Ends in an error in state: 647.
 ##
 ## attribute_specifier_list -> attribute_specifier . attribute_specifier_list [ SEMICOLON LBRACE EQ COMMA ]
-## rlist(declaration_specifier_no_type) -> attribute_specifier . [ VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT SIGNED SHORT PRE_NAME LONG INT FLOAT ENUM DOUBLE CHAR ]
-## rlist(declaration_specifier_no_type) -> attribute_specifier . rlist(declaration_specifier_no_type) [ VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT SIGNED SHORT PRE_NAME LONG INT FLOAT ENUM DOUBLE CHAR ]
+## rlist(declaration_specifier_no_type) -> attribute_specifier . [ VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT SIGNED SHORT PRE_NAME LONG INT FLOAT16 FLOAT ENUM DOUBLE CHAR ]
+## rlist(declaration_specifier_no_type) -> attribute_specifier . rlist(declaration_specifier_no_type) [ VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT SIGNED SHORT PRE_NAME LONG INT FLOAT16 FLOAT ENUM DOUBLE CHAR ]
 ##
 ## The known suffix of the stack is as follows:
 ## attribute_specifier
@@ -4500,7 +4705,7 @@ If this is the parameter declaration of a K&R function definition,
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 241.
+## Ends in an error in state: 242.
 ##
 ## parameter_list -> parameter_list COMMA . parameter_declaration [ RPAREN COMMA ]
 ## parameter_type_list -> parameter_list COMMA . ELLIPSIS [ RPAREN ]
@@ -4517,7 +4722,7 @@ At this point, one of the following is expected:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME SEMICOLON
 ##
-## Ends in an error in state: 240.
+## Ends in an error in state: 241.
 ##
 ## parameter_list -> parameter_list . COMMA parameter_declaration [ RPAREN COMMA ]
 ## parameter_type_list -> parameter_list . [ RPAREN ]
@@ -4530,12 +4735,12 @@ translation_unit_file: INT PRE_NAME VAR_NAME LPAREN INT PRE_NAME VAR_NAME SEMICO
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 266, spurious reduction of production declarator_noattrend -> direct_declarator
-## In state 271, spurious reduction of production attribute_specifier_list ->
-## In state 272, spurious reduction of production declarator -> declarator_noattrend attribute_specifier_list
-## In state 288, spurious reduction of production declare_varname(declarator) -> declarator
-## In state 287, spurious reduction of production parameter_declaration -> declaration_specifiers(parameter_declaration) declare_varname(declarator)
-## In state 248, spurious reduction of production parameter_list -> parameter_declaration
+## In state 277, spurious reduction of production declarator_noattrend -> direct_declarator
+## In state 292, spurious reduction of production attribute_specifier_list ->
+## In state 293, spurious reduction of production declarator -> declarator_noattrend attribute_specifier_list
+## In state 309, spurious reduction of production declare_varname(declarator) -> declarator
+## In state 308, spurious reduction of production parameter_declaration -> declaration_specifiers(parameter_declaration) declare_varname(declarator)
+## In state 249, spurious reduction of production parameter_list -> parameter_declaration
 ##
 
 # We omit the possibility of an ellipsis.
@@ -4571,9 +4776,9 @@ The following identifier is used as a type, but has not been defined as such:
 
 translation_unit_file: INT PRE_NAME VAR_NAME LPAREN PRE_NAME VAR_NAME RPAREN INT SEMICOLON XOR_ASSIGN
 ##
-## Ends in an error in state: 622.
+## Ends in an error in state: 643.
 ##
-## declaration_list -> declaration_list . kr_param_declaration [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG LBRACE INT INLINE FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
+## declaration_list -> declaration_list . kr_param_declaration [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT RESTRICT REGISTER PRE_NAME PACKED NORETURN LONG LBRACE INT INLINE FLOAT16 FLOAT EXTERN ENUM DOUBLE CONST CHAR AUTO ATTRIBUTE ALIGNAS ]
 ## function_definition1 -> declaration_specifiers(declaration(external_declaration)) declare_varname(declarator_noattrend) save_context declaration_list . [ LBRACE ]
 ##
 ## The known suffix of the stack is as follows:
@@ -4622,7 +4827,7 @@ At this point, a struct or union name is expected.
 
 translation_unit_file: PACKED LPAREN BUILTIN_OFFSETOF LPAREN VOID XOR_ASSIGN
 ##
-## Ends in an error in state: 356.
+## Ends in an error in state: 377.
 ##
 ## postfix_expression -> BUILTIN_OFFSETOF LPAREN type_name . COMMA general_identifier RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ## postfix_expression -> BUILTIN_OFFSETOF LPAREN type_name . COMMA general_identifier designator_list RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -4634,9 +4839,9 @@ translation_unit_file: PACKED LPAREN BUILTIN_OFFSETOF LPAREN VOID XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 159, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
-## In state 317, spurious reduction of production option(abstract_declarator(type_name)) ->
-## In state 323, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
+## In state 160, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
+## In state 338, spurious reduction of production option(abstract_declarator(type_name)) ->
+## In state 344, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
 ##
 
 Ill-formed __builtin_offsetof.
@@ -4646,7 +4851,7 @@ At this point, a colon ',' is expected
 
 translation_unit_file: PACKED LPAREN BUILTIN_OFFSETOF LPAREN VOID COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 357.
+## Ends in an error in state: 378.
 ##
 ## postfix_expression -> BUILTIN_OFFSETOF LPAREN type_name COMMA . general_identifier RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ## postfix_expression -> BUILTIN_OFFSETOF LPAREN type_name COMMA . general_identifier designator_list RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -4662,7 +4867,7 @@ At this point, a member-designator is expected.
 
 translation_unit_file: PACKED LPAREN BUILTIN_OFFSETOF LPAREN VOID COMMA PRE_NAME TYPEDEF_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 358.
+## Ends in an error in state: 379.
 ##
 ## postfix_expression -> BUILTIN_OFFSETOF LPAREN type_name COMMA general_identifier . RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ## postfix_expression -> BUILTIN_OFFSETOF LPAREN type_name COMMA general_identifier . designator_list RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -4678,7 +4883,7 @@ At this point, a member-designator is expected.
 
 translation_unit_file: PACKED LPAREN BUILTIN_OFFSETOF LPAREN VOID COMMA PRE_NAME TYPEDEF_NAME LBRACK STRING_LITERAL RBRACK XOR_ASSIGN
 ##
-## Ends in an error in state: 367.
+## Ends in an error in state: 388.
 ##
 ## option(designator_list) -> designator_list . [ LBRACK DOT ]
 ## postfix_expression -> BUILTIN_OFFSETOF LPAREN type_name COMMA general_identifier designator_list . RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -4694,9 +4899,9 @@ At this point, a member-designator is expected.
 
 translation_unit_file: STATIC_ASSERT XOR_ASSIGN
 ##
-## Ends in an error in state: 168.
+## Ends in an error in state: 169.
 ##
-## static_assert_declaration -> STATIC_ASSERT . LPAREN conditional_expression COMMA string_literals_list RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## static_assert_declaration -> STATIC_ASSERT . LPAREN conditional_expression COMMA string_literals_list RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## STATIC_ASSERT
@@ -4709,9 +4914,9 @@ At this point, an opening parenthesis '(' is expected.
 
 translation_unit_file: STATIC_ASSERT LPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 169.
+## Ends in an error in state: 170.
 ##
-## static_assert_declaration -> STATIC_ASSERT LPAREN . conditional_expression COMMA string_literals_list RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## static_assert_declaration -> STATIC_ASSERT LPAREN . conditional_expression COMMA string_literals_list RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## STATIC_ASSERT LPAREN
@@ -4724,9 +4929,9 @@ At this point, a constant expression is expected.
 
 translation_unit_file: STATIC_ASSERT LPAREN STRING_LITERAL XOR_ASSIGN
 ##
-## Ends in an error in state: 170.
+## Ends in an error in state: 171.
 ##
-## static_assert_declaration -> STATIC_ASSERT LPAREN conditional_expression . COMMA string_literals_list RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## static_assert_declaration -> STATIC_ASSERT LPAREN conditional_expression . COMMA string_literals_list RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## STATIC_ASSERT LPAREN conditional_expression
@@ -4735,21 +4940,21 @@ translation_unit_file: STATIC_ASSERT LPAREN STRING_LITERAL XOR_ASSIGN
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 70, spurious reduction of production primary_expression -> string_literals_list
-## In state 72, spurious reduction of production postfix_expression -> primary_expression
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 69, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 71, spurious reduction of production primary_expression -> string_literals_list
+## In state 73, spurious reduction of production postfix_expression -> primary_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 70, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
 ##
 
 Ill-formed _Static_assert.
@@ -4759,9 +4964,9 @@ At this point, a comma ',' is expected.
 
 translation_unit_file: STATIC_ASSERT LPAREN STRING_LITERAL COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 171.
+## Ends in an error in state: 172.
 ##
-## static_assert_declaration -> STATIC_ASSERT LPAREN conditional_expression COMMA . string_literals_list RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## static_assert_declaration -> STATIC_ASSERT LPAREN conditional_expression COMMA . string_literals_list RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## STATIC_ASSERT LPAREN conditional_expression COMMA
@@ -4774,9 +4979,9 @@ At this point, a string literal is expected.
 
 translation_unit_file: STATIC_ASSERT LPAREN STRING_LITERAL COMMA STRING_LITERAL XOR_ASSIGN
 ##
-## Ends in an error in state: 172.
+## Ends in an error in state: 173.
 ##
-## static_assert_declaration -> STATIC_ASSERT LPAREN conditional_expression COMMA string_literals_list . RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## static_assert_declaration -> STATIC_ASSERT LPAREN conditional_expression COMMA string_literals_list . RPAREN SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ## string_literals_list -> string_literals_list . STRING_LITERAL [ STRING_LITERAL RPAREN ]
 ##
 ## The known suffix of the stack is as follows:
@@ -4790,9 +4995,9 @@ At this point, a closing parenthesis ')' is expected.
 
 translation_unit_file: STATIC_ASSERT LPAREN STRING_LITERAL COMMA STRING_LITERAL RPAREN XOR_ASSIGN
 ##
-## Ends in an error in state: 173.
+## Ends in an error in state: 174.
 ##
-## static_assert_declaration -> STATIC_ASSERT LPAREN conditional_expression COMMA string_literals_list RPAREN . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
+## static_assert_declaration -> STATIC_ASSERT LPAREN conditional_expression COMMA string_literals_list RPAREN . SEMICOLON [ WHILE VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF TILDE SWITCH STRUCT STRING_LITERAL STATIC_ASSERT STATIC STAR SIZEOF SIGNED SHORT SEMICOLON RETURN RESTRICT REGISTER RBRACE PRE_NAME PRAGMA PLUS PACKED NORETURN MINUS LPAREN LONG LBRACE INT INLINE INC IF GOTO GENERIC FOR FLOAT16 FLOAT EXTERN EOF ENUM DOUBLE DO DEFAULT DEC CONTINUE CONSTANT CONST CHAR CASE BUILTIN_VA_ARG BUILTIN_OFFSETOF BREAK BANG AUTO ATTRIBUTE ASM AND ALIGNOF ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## STATIC_ASSERT LPAREN conditional_expression COMMA string_literals_list RPAREN
@@ -4835,7 +5040,7 @@ At this point, an expression is expected.
 
 translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL WHILE
 ##
-## Ends in an error in state: 374.
+## Ends in an error in state: 395.
 ##
 ## generic_selection -> GENERIC LPAREN assignment_expression . COMMA generic_assoc_list RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -4846,22 +5051,22 @@ translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL WHILE
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 70, spurious reduction of production primary_expression -> string_literals_list
-## In state 72, spurious reduction of production postfix_expression -> primary_expression
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
+## In state 71, spurious reduction of production primary_expression -> string_literals_list
+## In state 73, spurious reduction of production postfix_expression -> primary_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
 ##
 
 Ill-formed _Generic expression.
@@ -4874,7 +5079,7 @@ then at this point, a comma ',' is expected.
 
 translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 375.
+## Ends in an error in state: 396.
 ##
 ## generic_selection -> GENERIC LPAREN assignment_expression COMMA . generic_assoc_list RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
 ##
@@ -4889,7 +5094,7 @@ At this point, either a type name or 'default' are expected.
 
 translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL COMMA DEFAULT XOR_ASSIGN
 ##
-## Ends in an error in state: 376.
+## Ends in an error in state: 397.
 ##
 ## generic_association -> DEFAULT . COLON assignment_expression [ RPAREN COMMA ]
 ##
@@ -4904,7 +5109,7 @@ At this point, a colon ':' is expected.
 
 translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL COMMA DEFAULT COLON XOR_ASSIGN
 ##
-## Ends in an error in state: 377.
+## Ends in an error in state: 398.
 ##
 ## generic_association -> DEFAULT COLON . assignment_expression [ RPAREN COMMA ]
 ##
@@ -4919,7 +5124,7 @@ At this point, an expression is expected.
 
 translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL COMMA CHAR XOR_ASSIGN
 ##
-## Ends in an error in state: 379.
+## Ends in an error in state: 400.
 ##
 ## generic_association -> type_name . COLON assignment_expression [ RPAREN COMMA ]
 ##
@@ -4930,9 +5135,9 @@ translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL COMMA CHAR X
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 159, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
-## In state 317, spurious reduction of production option(abstract_declarator(type_name)) ->
-## In state 323, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
+## In state 160, spurious reduction of production specifier_qualifier_list(type_name) -> type_specifier_no_typedef_name list(specifier_qualifier_no_typedef_name)
+## In state 338, spurious reduction of production option(abstract_declarator(type_name)) ->
+## In state 344, spurious reduction of production type_name -> specifier_qualifier_list(type_name) option(abstract_declarator(type_name))
 ##
 
 Ill-formed _Generic expression.
@@ -4944,7 +5149,7 @@ At this point, a colon ':' is expected.
 
 translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL COMMA CHAR COLON XOR_ASSIGN
 ##
-## Ends in an error in state: 380.
+## Ends in an error in state: 401.
 ##
 ## generic_association -> type_name COLON . assignment_expression [ RPAREN COMMA ]
 ##
@@ -4961,7 +5166,7 @@ At this point, an expression is expected.
 
 translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL COMMA CHAR COLON STRING_LITERAL WHILE
 ##
-## Ends in an error in state: 383.
+## Ends in an error in state: 404.
 ##
 ## generic_assoc_list -> generic_assoc_list . COMMA generic_association [ RPAREN COMMA ]
 ## generic_selection -> GENERIC LPAREN assignment_expression COMMA generic_assoc_list . RPAREN [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RBRACK RBRACE QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA COLON BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -4973,24 +5178,24 @@ translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL COMMA CHAR C
 ## This implies that, although the LR(1) items shown above provide an
 ## accurate view of the past (what has been recognized so far), they
 ## may provide an INCOMPLETE view of the future (what was expected next).
-## In state 70, spurious reduction of production primary_expression -> string_literals_list
-## In state 72, spurious reduction of production postfix_expression -> primary_expression
-## In state 73, spurious reduction of production unary_expression -> postfix_expression
-## In state 77, spurious reduction of production cast_expression -> unary_expression
-## In state 101, spurious reduction of production multiplicative_expression -> cast_expression
-## In state 94, spurious reduction of production additive_expression -> multiplicative_expression
-## In state 114, spurious reduction of production shift_expression -> additive_expression
-## In state 90, spurious reduction of production relational_expression -> shift_expression
-## In state 107, spurious reduction of production equality_expression -> relational_expression
-## In state 123, spurious reduction of production and_expression -> equality_expression
-## In state 131, spurious reduction of production exclusive_or_expression -> and_expression
-## In state 132, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
-## In state 133, spurious reduction of production logical_and_expression -> inclusive_or_expression
-## In state 117, spurious reduction of production logical_or_expression -> logical_and_expression
-## In state 115, spurious reduction of production conditional_expression -> logical_or_expression
-## In state 136, spurious reduction of production assignment_expression -> conditional_expression
-## In state 381, spurious reduction of production generic_association -> type_name COLON assignment_expression
-## In state 382, spurious reduction of production generic_assoc_list -> generic_association
+## In state 71, spurious reduction of production primary_expression -> string_literals_list
+## In state 73, spurious reduction of production postfix_expression -> primary_expression
+## In state 74, spurious reduction of production unary_expression -> postfix_expression
+## In state 78, spurious reduction of production cast_expression -> unary_expression
+## In state 102, spurious reduction of production multiplicative_expression -> cast_expression
+## In state 95, spurious reduction of production additive_expression -> multiplicative_expression
+## In state 115, spurious reduction of production shift_expression -> additive_expression
+## In state 91, spurious reduction of production relational_expression -> shift_expression
+## In state 108, spurious reduction of production equality_expression -> relational_expression
+## In state 124, spurious reduction of production and_expression -> equality_expression
+## In state 132, spurious reduction of production exclusive_or_expression -> and_expression
+## In state 133, spurious reduction of production inclusive_or_expression -> exclusive_or_expression
+## In state 134, spurious reduction of production logical_and_expression -> inclusive_or_expression
+## In state 118, spurious reduction of production logical_or_expression -> logical_and_expression
+## In state 116, spurious reduction of production conditional_expression -> logical_or_expression
+## In state 137, spurious reduction of production assignment_expression -> conditional_expression
+## In state 402, spurious reduction of production generic_association -> type_name COLON assignment_expression
+## In state 403, spurious reduction of production generic_assoc_list -> generic_association
 ##
 
 Ill-formed _Generic expression.
@@ -5004,7 +5209,7 @@ Use a comma to add another generic association.
 
 translation_unit_file: ALIGNAS LPAREN GENERIC LPAREN STRING_LITERAL COMMA CHAR COLON STRING_LITERAL COMMA XOR_ASSIGN
 ##
-## Ends in an error in state: 385.
+## Ends in an error in state: 406.
 ##
 ## generic_assoc_list -> generic_assoc_list COMMA . generic_association [ RPAREN COMMA ]
 ##
@@ -5033,7 +5238,7 @@ translation_unit_file: ALIGNAS LPAREN PRE_NAME XOR_ASSIGN
 ##
 translation_unit_file: ALIGNAS LPAREN VOID LPAREN VOID LPAREN PRE_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 247.
+## Ends in an error in state: 248.
 ##
 ## declarator_identifier -> PRE_NAME . low_prec TYPEDEF_NAME [ RPAREN PACKED LPAREN LBRACK ATTRIBUTE ALIGNAS ]
 ## declarator_identifier -> PRE_NAME . VAR_NAME [ RPAREN PACKED LPAREN LBRACK ATTRIBUTE ALIGNAS ]
@@ -5044,17 +5249,17 @@ translation_unit_file: ALIGNAS LPAREN VOID LPAREN VOID LPAREN PRE_NAME XOR_ASSIG
 ##
 translation_unit_file: UNION PRE_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 48.
+## Ends in an error in state: 49.
 ##
-## general_identifier -> PRE_NAME . VAR_NAME [ XOR_ASSIGN VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF SUB_ASSIGN STRUCT STATIC STAR SLASH SIGNED SHORT SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RESTRICT REGISTER RBRACK RBRACE QUESTION PTR PRE_NAME PLUS PERCENT PACKED OR_ASSIGN NORETURN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LONG LEQ LEFT_ASSIGN LEFT LBRACK LBRACE INT INLINE INC HAT GT GEQ FLOAT EXTERN EQEQ EQ ENUM DOUBLE DOT DIV_ASSIGN DEC CONST COMMA COLON CHAR BARBAR BAR AUTO ATTRIBUTE AND_ASSIGN ANDAND AND ALIGNAS ADD_ASSIGN ]
-## typedef_name -> PRE_NAME . TYPEDEF_NAME [ XOR_ASSIGN VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF SUB_ASSIGN STRUCT STATIC STAR SLASH SIGNED SHORT SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RESTRICT REGISTER RBRACK RBRACE QUESTION PTR PRE_NAME PLUS PERCENT PACKED OR_ASSIGN NORETURN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LONG LEQ LEFT_ASSIGN LEFT LBRACK LBRACE INT INLINE INC HAT GT GEQ FLOAT EXTERN EQEQ EQ ENUM DOUBLE DOT DIV_ASSIGN DEC CONST COMMA COLON CHAR BARBAR BAR AUTO ATTRIBUTE AND_ASSIGN ANDAND AND ALIGNAS ADD_ASSIGN ]
+## general_identifier -> PRE_NAME . VAR_NAME [ XOR_ASSIGN VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF SUB_ASSIGN STRUCT STATIC STAR SLASH SIGNED SHORT SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RESTRICT REGISTER RBRACK RBRACE QUESTION PTR PRE_NAME PLUS PERCENT PACKED OR_ASSIGN NORETURN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LONG LEQ LEFT_ASSIGN LEFT LBRACK LBRACE INT INLINE INC HAT GT GEQ FLOAT16 FLOAT EXTERN EQEQ EQ ENUM DOUBLE DOT DIV_ASSIGN DEC CONST COMMA COLON CHAR BARBAR BAR AUTO ATTRIBUTE AND_ASSIGN ANDAND AND ALIGNAS ADD_ASSIGN ]
+## typedef_name -> PRE_NAME . TYPEDEF_NAME [ XOR_ASSIGN VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL TYPEDEF SUB_ASSIGN STRUCT STATIC STAR SLASH SIGNED SHORT SEMICOLON RPAREN RIGHT_ASSIGN RIGHT RESTRICT REGISTER RBRACK RBRACE QUESTION PTR PRE_NAME PLUS PERCENT PACKED OR_ASSIGN NORETURN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LONG LEQ LEFT_ASSIGN LEFT LBRACK LBRACE INT INLINE INC HAT GT GEQ FLOAT16 FLOAT EXTERN EQEQ EQ ENUM DOUBLE DOT DIV_ASSIGN DEC CONST COMMA COLON CHAR BARBAR BAR AUTO ATTRIBUTE AND_ASSIGN ANDAND AND ALIGNAS ADD_ASSIGN ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRE_NAME
 ##
 translation_unit_file: VOID PRE_NAME TYPEDEF_NAME LBRACE PRE_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 458.
+## Ends in an error in state: 479.
 ##
 ## general_identifier -> PRE_NAME . VAR_NAME [ COLON ]
 ## primary_expression -> PRE_NAME . VAR_NAME [ XOR_ASSIGN SUB_ASSIGN STAR SLASH SEMICOLON RIGHT_ASSIGN RIGHT QUESTION PTR PLUS PERCENT OR_ASSIGN NEQ MUL_ASSIGN MOD_ASSIGN MINUS LT LPAREN LEQ LEFT_ASSIGN LEFT LBRACK INC HAT GT GEQ EQEQ EQ DOT DIV_ASSIGN DEC COMMA BARBAR BAR AND_ASSIGN ANDAND AND ADD_ASSIGN ]
@@ -5065,7 +5270,7 @@ translation_unit_file: VOID PRE_NAME TYPEDEF_NAME LBRACE PRE_NAME XOR_ASSIGN
 ##
 translation_unit_file: VOID PRE_NAME TYPEDEF_NAME LPAREN PRE_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 205.
+## Ends in an error in state: 206.
 ##
 ## identifier_list -> PRE_NAME . VAR_NAME [ RPAREN COMMA ]
 ## typedef_name -> PRE_NAME . TYPEDEF_NAME [ VOLATILE STATIC STAR RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LBRACK INLINE EXTERN CONST COMMA AUTO ATTRIBUTE ALIGNAS ]
@@ -5075,10 +5280,10 @@ translation_unit_file: VOID PRE_NAME TYPEDEF_NAME LPAREN PRE_NAME XOR_ASSIGN
 ##
 translation_unit_file: VOID PRE_NAME XOR_ASSIGN
 ##
-## Ends in an error in state: 193.
+## Ends in an error in state: 194.
 ##
-## declarator_identifier -> PRE_NAME . low_prec TYPEDEF_NAME [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
-## declarator_identifier -> PRE_NAME . VAR_NAME [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## declarator_identifier -> PRE_NAME . low_prec TYPEDEF_NAME [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
+## declarator_identifier -> PRE_NAME . VAR_NAME [ VOLATILE VOID UNSIGNED UNION UNDERSCORE_BOOL STRUCT STATIC SIGNED SHORT SEMICOLON RPAREN RESTRICT REGISTER PRE_NAME PACKED NORETURN LPAREN LONG LBRACK LBRACE INT INLINE FLOAT16 FLOAT EXTERN EQ ENUM DOUBLE CONST COMMA COLON CHAR AUTO ATTRIBUTE ALIGNAS ]
 ##
 ## The known suffix of the stack is as follows:
 ## PRE_NAME

--- a/cparser/pre_parser.mly
+++ b/cparser/pre_parser.mly
@@ -696,6 +696,18 @@ direct_declarator:
     { match snd x with
       | Decl_ident -> (fst x, Decl_other)
       | _ -> x }
+| x = direct_declarator LBRACK STATIC type_qualifier_list? assignment_expression RBRACK
+    { match snd x with
+      | Decl_ident -> (fst x, Decl_other)
+      | _ -> x }
+| x = direct_declarator LBRACK type_qualifier_list STATIC assignment_expression RBRACK
+    { match snd x with
+      | Decl_ident -> (fst x, Decl_other)
+      | _ -> x }
+| x = direct_declarator LBRACK type_qualifier_list? STAR RBRACK
+    { match snd x with
+      | Decl_ident -> (fst x, Decl_other)
+      | _ -> x }
 | x = direct_declarator LPAREN ctx = context_parameter_type_list RPAREN
     { match snd x with
       | Decl_ident -> (fst x, Decl_fun ctx)
@@ -766,6 +778,9 @@ abstract_declarator(phantom):
 direct_abstract_declarator:
 | LPAREN save_context abstract_declarator(type_name) RPAREN
 | direct_abstract_declarator? LBRACK type_qualifier_list? optional(assignment_expression, RBRACK)
+| direct_abstract_declarator? LBRACK STATIC type_qualifier_list? assignment_expression RBRACK
+| direct_abstract_declarator? LBRACK type_qualifier_list STATIC assignment_expression RBRACK
+| direct_abstract_declarator? LBRACK type_qualifier_list? STAR RBRACK
 | ioption(direct_abstract_declarator) LPAREN context_parameter_type_list? RPAREN
     {}
 


### PR DESCRIPTION
E.g. `int x[static 10]` or `int x [*]`.  Currently, treated like `int x[10]` and `int x[]` respectively.

Ref: https://en.cppreference.com/w/c/language/array ; C99 6.7.5.2, C11 6.7.6.2.

Fixes: #531
