### PR TITLE
Coq 8.20.1 is supported

### DIFF
--- a/configure
+++ b/configure
@@ -502,14 +502,14 @@ missingtools=false
 echo "Testing Coq... " | tr -d '\n'
 coq_ver=$(${COQBIN}coqc --print-version 2>/dev/null | tr -d '\r' | cut -d' ' -f1)
 case "$coq_ver" in
-  8.13.0|8.13.1|8.13.2|8.14.0|8.14.1|8.15.0|8.15.1|8.15.2|8.16.0|8.16.1|8.17.0|8.17.1|8.18.0|8.19.0|8.19.1|8.19.2|8.20.0)
+  8.13.0|8.13.1|8.13.2|8.14.0|8.14.1|8.15.0|8.15.1|8.15.2|8.16.0|8.16.1|8.17.0|8.17.1|8.18.0|8.19.0|8.19.1|8.19.2|8.20.0|8.20.1)
         echo "version $coq_ver -- good!";;
   ?*)
         echo "version $coq_ver -- UNSUPPORTED"
         if $ignore_coq_version; then
             echo "Warning: this version of Coq is unsupported, proceed at your own risks."
         else
-            echo "Error: CompCert requires a version of Coq between 8.13.0 and 8.20.0"
+            echo "Error: CompCert requires a version of Coq between 8.13.0 and 8.20.1"
             missingtools=true
         fi;;
   "")


### PR DESCRIPTION
Coq 8.20.1 is out!
https://coq.inria.fr/doc/v8.20/refman/changes.html#changes-in-8-20-1

…and CompCert 3.15 builds fine with it.