### PR TITLE
Reject `aligned` attribute on bit fields in struct types

### DIFF
--- a/cparser/Cutil.ml
+++ b/cparser/Cutil.ml
@@ -609,6 +609,8 @@ let sizeof_layout_struct env members ma =
                          (record_field m.fld_name pos :: accu)
                          rem
           | Some width ->
+              (* bit fields must be naturally aligned *)
+              assert (alignas_attribute (attributes_of_type env m.fld_typ) = 0);
               (* curr = beginning of storage unit, in bits
                  next = one past end of storage unit, in bits *)
               let curr = pos / (a * 8) * (a * 8) in

--- a/cparser/Elab.ml
+++ b/cparser/Elab.ml
@@ -1086,7 +1086,7 @@ and elab_field_group env = function
             error loc
               "the type of bit-field '%a' must be an integer type no bigger than 'int'" pp_field id;
             None,env
-          end else if has_std_alignas env' ty then begin
+          end else if alignas_attribute (attributes_of_type env' ty) > 0 then begin
             error loc "alignment specified for bit-field '%a'" pp_field id;
             None, env
           end else begin

--- a/cparser/PackedStructs.ml
+++ b/cparser/PackedStructs.ml
@@ -74,11 +74,13 @@ let transf_field_decl mfa swapped loc env struct_id f =
   end;
   (* Reduce alignment if requested *)
   if mfa = 0 then f else begin
-    if f.fld_bitfield <> None then
+    if f.fld_bitfield <> None then begin
       error loc "bit fields in packed structs are not supported";
-    let al = safe_alignof loc env f.fld_typ in
-    { f with fld_typ =
-         change_attributes_type env (set_alignas_attr (min mfa al)) f.fld_typ }
+      f
+    end else
+      let al = safe_alignof loc env f.fld_typ in
+      { f with fld_typ =
+          change_attributes_type env (set_alignas_attr (min mfa al)) f.fld_typ }
   end
 
 (* Rewriting struct declarations *)


### PR DESCRIPTION
Currently, we reject `_Alignas(N)` on bit fields, as per ISO C, but tolerate `attribute((aligned(N)))`.  However:

- The verified part of CompCert (Ctypes.v) explicitly ignores alignment specifiers on the types of bit fields.

- The unverified part (Cutils.ml) implicitly honors alignment specifiers on the types of bit fields in one place (function `Cutil.sizeof_layout_struct`).  This can cause `__builtin_offsetof` and some rare uses of `sizeof` to return results that are inconsistent with the actual layout done in Ctypes.v.

- There is no specification of struct member layout that includes bit-fields with alignment specifiers.  The ELF ABI says nothing about this.  GCC and Clang do something, but it's unclear what they do.

It seems safer to just report an error for  `attribute((aligned(N)))` on bit-fields.

Issue reported by Christos Papakonstantinou (Cantina Security).