### PR TITLE
String literals in asm files: use asm quoting conventions, not OCaml's

### DIFF
--- a/aarch64/TargetPrinter.ml
+++ b/aarch64/TargetPrinter.ml
@@ -612,7 +612,7 @@ module Target(System: SYSTEM): TARGET =
           | EF_annot(kind,txt, targs) ->
             begin match (P.to_int kind) with
               | 1 -> let annot = annot_text preg_annot "sp" txt args  in
-                fprintf oc "%s annotation: %S\n" comment annot
+                fprintf oc "%s annotation: %s\n" comment (quote_string annot)
               | 2 -> let lbl = new_label () in
                 fprintf oc "%a:\n" label lbl;
                 add_ais_annot lbl preg_annot "sp" txt args

--- a/arm/TargetPrinter.ml
+++ b/arm/TargetPrinter.ml
@@ -477,7 +477,7 @@ struct
         | EF_annot(kind,txt, targs) ->
             begin match (P.to_int kind) with
               | 1 -> let annot = annot_text preg_annot "sp" txt args in
-                fprintf oc "%s annotation: %S\n" comment annot
+                fprintf oc "%s annotation: %s\n" comment (quote_string annot)
               | 2 -> let lbl = new_label () in
                 fprintf oc "%a:\n" label lbl;
                 AisAnnot.add_ais_annot lbl preg_annot "r13" txt args

--- a/backend/Fileinfo.ml
+++ b/backend/Fileinfo.ml
@@ -12,6 +12,7 @@
 (* *********************************************************************)
 
 open Printf
+open PrintAsmaux
 
 (* Printing annotations in asm syntax *)
 
@@ -47,7 +48,7 @@ let print_file oc file =
     Hashtbl.find filename_info file
   with Not_found ->
     let (filenum, filebuf as res) = enter_filename file in
-    fprintf oc "	.file	%d %S\n" filenum file;
+    fprintf oc "	.file	%d %s\n" filenum (quote_string file);
     res
 
 let print_file_line oc pref file line =
@@ -70,7 +71,7 @@ let print_file_line_d2 oc pref file line =
       with Not_found ->
         enter_filename file in
     if file <> !last_file then begin
-      fprintf oc "	.d2file	%S\n" file;
+      fprintf oc "	.d2file	%s\n" (quote_string file);
       last_file := file
     end;
     fprintf oc "	.d2line	%d\n" line;

--- a/backend/PrintAsm.ml
+++ b/backend/PrintAsm.ml
@@ -180,7 +180,7 @@ module Printer(Target:TARGET) =
             print_addr oc Target.label lbl
           | AisAnnot.Symbol symb ->
             print_addr oc Target.symbol symb
-          | AisAnnot.String a -> fprintf oc "	.ascii %S\n" a in
+          | AisAnnot.String a -> fprintf oc "	.ascii %s\n" (quote_string a) in
         let annot oc str =
           List.iter (annot_part oc) str
         in

--- a/backend/PrintAsmaux.ml
+++ b/backend/PrintAsmaux.ml
@@ -300,6 +300,24 @@ let string_exists predicate s =
     exists (i + 1)
   in exists 0
 
+(** Quote the given string, using C string literal syntax.
+    The resulting string is enclosed in double quotes.
+    Double quotes and backslash are backslash-quoted.
+    Control characters (incl. newline and tabs) are octal-encoded. *)
+
+let quote_string s =
+  let b = Buffer.create (String.length s + 10) in
+  Buffer.add_char b '"';
+  String.iter
+    (fun c ->
+      match c with
+      | '"' | '\\' -> Buffer.add_char b '\\'; Buffer.add_char b c
+      | '\x00' .. '\x1F' -> Printf.bprintf b "\\%03o" (Char.code c)
+      | _ -> Buffer.add_char b c)
+    s;
+  Buffer.add_char b '"';
+  Buffer.contents b
+
 (** Print command-line argument, with quoting if needed.
     We quote using double quotes if the argument contains whitespace,
     control characters (incl. newline and tabs), or double quotes. *)
@@ -308,7 +326,7 @@ let quote_argument s =
   if string_exists
     (function '\x00'..'\x1F' | ' ' | '"' -> true | _ -> false)
     s
-  then "\"" ^ String.escaped s ^ "\""
+  then quote_string s
   else s
 
 (** Print CompCert version and command-line as asm comment *)

--- a/backend/PrintAsmaux.ml
+++ b/backend/PrintAsmaux.ml
@@ -289,6 +289,27 @@ let print_inline_asm print_preg oc txt sg args res =
   List.iter print_fragment (Str.full_split re_asm_param_1 txt);
   fprintf oc "\n"
 
+(** Quote the given string, using C string literal syntax.
+    The resulting string is enclosed in double quotes.
+    Double quotes and backslash are backslash-escaped.
+    Newline and tabs are written as [\n] and [\t].
+    Other control characters are octal-encoded. *)
+
+let quote_string s =
+  let b = Buffer.create (String.length s + 10) in
+  Buffer.add_char b '"';
+  String.iter
+    (fun c ->
+      match c with
+      | '"' | '\\'       -> Buffer.add_char b '\\'; Buffer.add_char b c
+      | '\n'             -> Buffer.add_string b "\\n"
+      | '\t'             -> Buffer.add_string b "\\t"
+      | '\x00' .. '\x1F' -> Printf.bprintf b "\\%03o" (Char.code c)
+      | _                -> Buffer.add_char b c)
+    s;
+  Buffer.add_char b '"';
+  Buffer.contents b
+
 (** This is [String.exists] in OCaml 4.13 and up.  Temporarily included here
     to support older OCaml versions. *)
 
@@ -299,24 +320,6 @@ let string_exists predicate s =
     if predicate s.[i] then true else
     exists (i + 1)
   in exists 0
-
-(** Quote the given string, using C string literal syntax.
-    The resulting string is enclosed in double quotes.
-    Double quotes and backslash are backslash-quoted.
-    Control characters (incl. newline and tabs) are octal-encoded. *)
-
-let quote_string s =
-  let b = Buffer.create (String.length s + 10) in
-  Buffer.add_char b '"';
-  String.iter
-    (fun c ->
-      match c with
-      | '"' | '\\' -> Buffer.add_char b '\\'; Buffer.add_char b c
-      | '\x00' .. '\x1F' -> Printf.bprintf b "\\%03o" (Char.code c)
-      | _ -> Buffer.add_char b c)
-    s;
-  Buffer.add_char b '"';
-  Buffer.contents b
 
 (** Print command-line argument, with quoting if needed.
     We quote using double quotes if the argument contains whitespace,

--- a/debug/DwarfPrinter.ml
+++ b/debug/DwarfPrinter.ml
@@ -322,10 +322,10 @@ module DwarfPrinter(Target: DWARF_TARGET):
 
     let print_string oc c = function
       | Simple_string s ->
-          fprintf oc "	.asciz		%S%a\n" s print_comment c
+          fprintf oc "	.asciz		%s%a\n" (quote_string s) print_comment c
       | Offset_string (o,s) ->
-        let c = sprintf "%s %s" c s in
-        print_loc_ref oc c o
+          let c = sprintf "%s %s" c (quote_string s) in
+          print_loc_ref oc c o
 
     let print_uleb128 oc c d =
       fprintf oc "	.uleb128	%d%a\n" d print_comment c
@@ -693,7 +693,7 @@ module DwarfPrinter(Target: DWARF_TARGET):
         let s = List.sort (fun (a,_) (b,_) -> compare a b) entries.string_table in
         List.iter (fun (id,s) ->
           print_label oc (loc_to_label id);
-          fprintf oc "	.asciz		%S\n" s) s)
+          fprintf oc "	.asciz		%s\n" (quote_string s)) s)
 
 
     (* Print the debug info and abbrev section *)

--- a/powerpc/TargetPrinter.ml
+++ b/powerpc/TargetPrinter.ml
@@ -812,7 +812,7 @@ module Target (System : SYSTEM):TARGET =
           | EF_annot(kind,txt, targs) ->
             begin match (P.to_int kind) with
               | 1 -> let annot = annot_text preg_annot "sp" txt args in
-                fprintf oc "%s annotation: %S\n" comment annot
+                fprintf oc "%s annotation: %s\n" comment (quote_string annot)
 
               | 2 -> let lbl = new_label () in
                 fprintf oc "%a:\n" label lbl;

--- a/riscV/TargetPrinter.ml
+++ b/riscV/TargetPrinter.ml
@@ -543,7 +543,7 @@ module Target : TARGET =
            | EF_annot(kind,txt, targs) ->
              begin match (P.to_int kind) with
                | 1 -> let annot = annot_text preg_annot "x2" txt args  in
-                 fprintf oc "%s annotation: %S\n" comment annot
+                 fprintf oc "%s annotation: %s\n" comment (quote_string annot)
                | 2 -> let lbl = new_label () in
                  fprintf oc "%a:\n" label lbl;
                  add_ais_annot lbl preg_annot "x2" txt args

--- a/x86/TargetPrinter.ml
+++ b/x86/TargetPrinter.ml
@@ -864,7 +864,7 @@ module Target(System: SYSTEM):TARGET =
             | EF_annot(kind,txt, targs) ->
                 begin match (P.to_int kind) with
                   | 1 ->  let annot = annot_text preg_annot "esp" txt args in
-                    fprintf oc "%s annotation: %S\n" comment annot
+                    fprintf oc "%s annotation: %s\n" comment (quote_string annot)
                   | 2 -> let lbl = new_label () in
                     fprintf oc "%a:\n" label lbl;
                     let sp = if Archi.ptr64 then "rsp" else "esp" in


### PR DESCRIPTION
Currently, we use the `%S` format of `Printf.printf` to emit some string literals in assembly files: filenames in `.file` directives, and `.asciz` directives for DWARF debug information.

(String literals coming from C source files follow a different path that doesn't use `%S`.  They are not affected by the problem fixed in this commit.)

The `%S` format produces an OCaml string literal, which can be misinterpreted by the GNU and Diab assemblers.  In particular, OCaml uses decimal escapes `\ddd` (three decimal digits) while assemblers, like C, use octal escapes `\ooo` (three octal digits).  Consequently, a "vertical tab" character (ASCII 0x0B) is printed as `\011`, which is interpreted as "horizontal tab" (ASCII 0x09) by the assembler.

This commits introduces `PrintAsmaux.quote_string` to produce a string literal in asm / C syntax, with octal escape sequences, and uses it in assembler printers in place of `%S`.