### PR TITLE
Makefile: use an explicit path for extraction/extraction.v

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,7 +282,7 @@ extraction: extraction/STAMP
 
 extraction/STAMP: $(FILES:.v=.vo) extraction/extraction.v $(ARCH)/extractionMachdep.v
 	rm -f extraction/*.ml extraction/*.mli
-	$(COQEXEC) extraction/extraction.v
+	$(COQEXEC) ./extraction/extraction.v
 	@if grep 'AXIOM TO BE REALIZED' extraction/*.ml; then \
             echo "An error occured during extraction to OCaml code."; \
             echo "Check the versions of Flocq and MenhirLib used."; \


### PR DESCRIPTION
`make extraction` passes `extraction/extraction.v` to `-load-vernac-source`. That path is implicit, so Rocq resolves it against the load path instead of treating it as a filename, and any installed package with an `extraction` subdirectory shadows CompCert's own file. CertiCoq installs `user-contrib/CertiRocq/extraction/extraction.v`, so when it is present the build fails with `Cannot find a physical path bound to logical path Glue.glue`. Prefixing `./` makes the path explicit.